### PR TITLE
Add CLI e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,8 @@ tidy:
 
 .PHONY: test-porch
 test-porch:
-	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; E2E=1 go test -race --count=1 ./...) || exit 1; done
+	#@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; E2E=1 go test -v -race --count=1 ./...) || exit 1; done
+	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; go test -v -race --count=1 ./...) || exit 1; done
 
 .PHONY: configure-git
 configure-git:

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -1,0 +1,257 @@
+// Copyright 2022 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	updateGoldenFiles = "UPDATE_GOLDEN_FILES"
+	testGitNamespace  = "test-git-namespace"
+)
+
+func TestPorch(t *testing.T) {
+	e2e := os.Getenv("E2E")
+	if e2e == "" {
+		t.Skip("set E2E to run this test")
+	}
+
+	abs, err := filepath.Abs(filepath.Join(".", "testdata"))
+	if err != nil {
+		t.Fatalf("Failed to get absolute path to testdata directory: %v", err)
+	}
+	runTests(t, abs)
+}
+
+func runUtilityCommand(t *testing.T, command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	t.Logf("running utility command %s %s", command, strings.Join(args, " "))
+	return cmd.Run()
+}
+
+func runTests(t *testing.T, path string) {
+	gitServerURL := startGitServer(t, path)
+	testCases := scanTestCases(t, path)
+
+	// remove any tmp files from previous test runs
+	err := runUtilityCommand(t, "rm", "-rf", "/tmp/porch-e2e")
+	if err != nil {
+		t.Fatalf("Failed to clean up older run: %v", err)
+	}
+	err = runUtilityCommand(t, "mkdir", "/tmp/porch-e2e")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.TestCase, func(t *testing.T) {
+			if tc.Skip != "" {
+				t.Skipf("Skipping test: %s", tc.Skip)
+			}
+			repoURL := gitServerURL + "/" + strings.ReplaceAll(tc.TestCase, "/", "-")
+			runTestCase(t, repoURL, tc)
+		})
+	}
+}
+
+func runTestCase(t *testing.T, repoURL string, tc TestCaseConfig) {
+	KubectlCreateNamespace(t, tc.TestCase)
+	t.Cleanup(func() {
+		KubectlDeleteNamespace(t, tc.TestCase)
+	})
+
+	if tc.Repository != "" {
+		RegisterRepository(t, repoURL, tc.TestCase, tc.Repository)
+	}
+
+	for i := range tc.Commands {
+		time.Sleep(1 * time.Second)
+		command := &tc.Commands[i]
+		cmd := exec.Command(command.Args[0], command.Args[1:]...)
+
+		var stdout, stderr bytes.Buffer
+		if command.Stdin != "" {
+			cmd.Stdin = strings.NewReader(command.Stdin)
+		}
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		t.Logf("running command %v", strings.Join(cmd.Args, " "))
+		err := cmd.Run()
+
+		if command.Yaml {
+			reorderYamlStdout(t, &stdout)
+		}
+
+		cleanupStderr(t, &stderr)
+
+		if os.Getenv(updateGoldenFiles) != "" {
+			updateCommand(command, err, stdout.String(), stderr.String())
+		}
+
+		if got, want := exitCode(err), command.ExitCode; got != want {
+			t.Errorf("unexpected exit code from '%s'; got %d, want %d", strings.Join(command.Args, " "), got, want)
+		}
+		if got, want := stdout.String(), command.Stdout; got != want {
+			t.Errorf("unexpected stdout content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+		}
+		if got, want := stderr.String(), command.Stderr; got != want {
+			t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+		}
+
+		// hack here; but if the command registered a repo, give a few extra seconds for the repo to reach readiness
+		for _, arg := range command.Args {
+			if arg == "register" {
+				time.Sleep(5 * time.Second)
+			}
+		}
+	}
+
+	if os.Getenv(updateGoldenFiles) != "" {
+		WriteTestCaseConfig(t, &tc)
+	}
+}
+
+// remove PASS lines from kpt fn eval, which includes a duration and will vary
+func cleanupStderr(t *testing.T, buf *bytes.Buffer) {
+	scanner := bufio.NewScanner(buf)
+	var newBuf bytes.Buffer
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "[PASS]") {
+			newBuf.Write([]byte(line))
+			newBuf.Write([]byte("\n"))
+		}
+	}
+
+	buf.Reset()
+	if _, err := buf.Write(newBuf.Bytes()); err != nil {
+		t.Fatalf("Failed to update cleaned up stderr: %v", err)
+	}
+}
+
+func reorderYamlStdout(t *testing.T, buf *bytes.Buffer) {
+	if buf.Len() == 0 {
+		return
+	}
+
+	// strip out the resourceVersion:, creationTimestamp:
+	// because that will change with every run
+	scanner := bufio.NewScanner(buf)
+	var newBuf bytes.Buffer
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "resourceVersion:") &&
+			!strings.Contains(line, "creationTimestamp:") {
+			newBuf.Write([]byte(line))
+			newBuf.Write([]byte("\n"))
+		}
+	}
+
+	var data interface{}
+	if err := yaml.Unmarshal(newBuf.Bytes(), &data); err != nil {
+		// not yaml.
+		return
+	}
+
+	var stable bytes.Buffer
+	encoder := yaml.NewEncoder(&stable)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(data); err != nil {
+		t.Fatalf("Failed to re-encode yaml output: %v", err)
+	}
+	buf.Reset()
+	if _, err := buf.Write(stable.Bytes()); err != nil {
+		t.Fatalf("Failed to update reordered yaml output: %v", err)
+	}
+}
+
+func startGitServer(t *testing.T, path string) string {
+	gitServerURL := "http://git-server." + testGitNamespace + ".svc.cluster.local:8080"
+
+	gitServerImage := GetGitServerImageName(t)
+	t.Logf("Git Image: %s", gitServerImage)
+
+	configFile := filepath.Join(path, "git-server.yaml")
+	configBytes, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to read git server config file %q: %v", configFile, err)
+	}
+	config := string(configBytes)
+	config = strings.ReplaceAll(config, "GIT_SERVER_IMAGE", gitServerImage)
+
+	t.Cleanup(func() {
+		KubectlDeleteNamespace(t, testGitNamespace)
+	})
+
+	KubectlApply(t, config)
+	KubectlWaitForDeployment(t, testGitNamespace, "git-server")
+	KubectlWaitForService(t, testGitNamespace, "git-server")
+	KubectlWaitForGitDNS(t, gitServerURL)
+
+	return gitServerURL
+}
+
+func scanTestCases(t *testing.T, root string) []TestCaseConfig {
+	testCases := []TestCaseConfig{}
+
+	if err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+
+		tc := ReadTestCaseConfig(t, info.Name(), path)
+		testCases = append(testCases, tc)
+
+		return nil
+	}); err != nil {
+		t.Fatalf("Failed to scan test cases: %v", err)
+	}
+
+	return testCases
+}
+
+func updateCommand(command *Command, exit error, stdout, stderr string) {
+	command.ExitCode = exitCode(exit)
+	command.Stdout = stdout
+	command.Stderr = stderr
+}
+
+func exitCode(exit error) int {
+	var ee *exec.ExitError
+	if errors.As(exit, &ee) {
+		return ee.ExitCode()
+	}
+	return 0
+}

--- a/test/e2e/cli/cluster.go
+++ b/test/e2e/cli/cluster.go
@@ -1,0 +1,185 @@
+// Copyright 2022 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	TestGitServerImage = "test-git-server"
+)
+
+func GetGitServerImageName(t *testing.T) string {
+	cmd := exec.Command("kubectl", "get", "pods", "--selector=app=porch-server", "--namespace=porch-system",
+		"--output=jsonpath={.items[*].spec.containers[*].image}")
+
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Error when getting Porch image version: %v: %s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	t.Logf("Porch image query output: %s", out)
+
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 {
+		t.Fatalf("kubectl get pods didn't return any images: %s", out)
+	}
+	image := strings.TrimSpace(lines[0])
+	if image == "" {
+		t.Fatalf("Cannot determine Porch server image: output was %q", out)
+	}
+	return InferGitServerImage(image)
+}
+
+func InferGitServerImage(porchImage string) string {
+	slash := strings.LastIndex(porchImage, "/")
+	repo := porchImage[:slash+1]
+	image := porchImage[slash+1:]
+	colon := strings.LastIndex(image, ":")
+	tag := image[colon+1:]
+
+	return repo + TestGitServerImage + ":" + tag
+}
+
+func KubectlApply(t *testing.T, config string) {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(config)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl apply failed: %v\ninput: %s\n\noutput:%s", err, config, string(out))
+	}
+	t.Logf("kubectl apply\n%s\noutput:\n%s", config, string(out))
+}
+
+func KubectlWaitForDeployment(t *testing.T, namespace, name string) {
+	args := []string{"rollout", "status", "deployment", "--namespace", namespace, name}
+	cmd := exec.Command("kubectl", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl %s failed: %v\noutput:\n%s", strings.Join(args, " "), err, string(out))
+	}
+	t.Logf("kubectl %s:\n%s", strings.Join(args, " "), string(out))
+}
+
+func KubectlWaitForService(t *testing.T, namespace, name string) {
+	args := []string{"get", "endpoints", "--namespace", namespace, name, "--output=jsonpath='{.subsets[*].addresses[*].ip}'"}
+
+	giveUp := time.Now().Add(1 * time.Minute)
+	for {
+		cmd := exec.Command("kubectl", args...)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		s := stdout.String()
+		if err == nil && len(s) > 0 { // Endpoint has an IP address assigned
+			t.Logf("Endpoints: %q", s)
+			break
+		}
+
+		if time.Now().After(giveUp) {
+			var msg string
+			if err != nil {
+				msg = err.Error()
+			}
+			t.Fatalf("Service endpoint %s/%s not ready on time. Giving up: %s", namespace, name, msg)
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// Kubernetes DNS needs time to propagate the updated address
+// Wait until we can register the repository and list its contents.
+func KubectlWaitForGitDNS(t *testing.T, gitServerURL string) {
+	const name = "test-git-dns-resolve"
+
+	KubectlCreateNamespace(t, name)
+	defer KubectlDeleteNamespace(t, name)
+
+	// We expect repos to automatically be created (albeit empty)
+	repoURL := gitServerURL + "/" + name
+
+	cmd := exec.Command("porchctl", "repo", "register", "--namespace", name, "--name", name, repoURL)
+	t.Logf("running command %v", strings.Join(cmd.Args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to register probe repository: %v\n%s", err, string(out))
+	}
+
+	// Based on experience, DNS seems to get updated inside the cluster within
+	// few seconds. We will wait about a minute.
+	// If this turns out to be an issue, we will sidestep DNS and use the Endpoints
+	// IP address directly.
+	giveUp := time.Now().Add(1 * time.Minute)
+	for {
+		cmd := exec.Command("porchctl", "rpkg", "get", "--namespace", name)
+		t.Logf("running command %v", strings.Join(cmd.Args, " "))
+		out, err := cmd.CombinedOutput()
+		t.Logf("output: %v", string(out))
+
+		if err == nil {
+			break
+		}
+
+		if time.Now().After(giveUp) {
+			t.Fatalf("Git service DNS resolution failed: %v", err)
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func KubectlCreateNamespace(t *testing.T, name string) {
+	cmd := exec.Command("kubectl", "create", "namespace", name)
+	t.Logf("running command %v", strings.Join(cmd.Args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to create namespace %q: %v\n%s", name, err, string(out))
+	}
+	t.Logf("output: %v", string(out))
+}
+
+func KubectlDeleteNamespace(t *testing.T, name string) {
+	cmd := exec.Command("kubectl", "delete", "namespace", name)
+	t.Logf("running command %v", strings.Join(cmd.Args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Failed to delete namespace %q: %v\n%s", name, err, string(out))
+	}
+	t.Logf("output: %v", string(out))
+}
+
+func RegisterRepository(t *testing.T, repoURL, namespace, name string) {
+	cmd := exec.Command("porchctl", "repo", "register", "--namespace", namespace, "--name", name, repoURL)
+	t.Logf("running command %v", strings.Join(cmd.Args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to register repository %q: %v\n%s", repoURL, err, string(out))
+	}
+	t.Logf("output: %v", string(out))
+}

--- a/test/e2e/cli/config.go
+++ b/test/e2e/cli/config.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Command struct {
+	// Args is a list of args for the kpt CLI.
+	Args []string `yaml:"args,omitempty"`
+	// StdIn contents will be passed as the command's standard input, if not empty.
+	Stdin string `yaml:"stdin,omitempty"`
+	// StdOut is the standard output expected from the command.
+	Stdout string `yaml:"stdout,omitempty"`
+	// StdErr is the standard error output expected from the command.
+	Stderr string `yaml:"stderr,omitempty"`
+	// ExitCode is the expected exit code frm the command.
+	ExitCode int `yaml:"exitCode,omitempty"`
+	// Yaml indicates that stdout is yaml and the test will reformat it for stable ordering
+	Yaml bool `yaml:"yaml,omitempty"`
+}
+
+type TestCaseConfig struct {
+	// TestCase is the name of the test case.
+	TestCase string `yaml:"-"`
+	// ConfigFile stores the name of the config file from which the config was loaded.
+	// Used when generating or updating golden files.
+	ConfigFile string `yaml:"-"`
+	// Repository is the name of the k8s Repository resource to register the default Git repo.
+	Repository string `yaml:"repository,omitempty"`
+	// Commands is a list of kpt commands to be executed by the test.
+	Commands []Command `yaml:"commands,omitempty"`
+	// Skip the test? If the value is not empty, it will be used as a message with which to skip the test.
+	Skip string `yaml:"skip,omitempty"`
+}
+
+func ReadTestCaseConfig(t *testing.T, name, path string) TestCaseConfig {
+	configPath := filepath.Join(path, "config.yaml")
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read test config file %q: %v", configPath, err)
+	}
+
+	var tc TestCaseConfig
+	if err := yaml.Unmarshal(b, &tc); err != nil {
+		t.Fatalf("Failed to unmarshal test config %q: %v", configPath, err)
+	}
+
+	tc.TestCase = name
+	tc.ConfigFile = configPath
+	return tc
+}
+
+func WriteTestCaseConfig(t *testing.T, tc *TestCaseConfig) {
+	var out bytes.Buffer
+	e := yaml.NewEncoder(&out)
+	e.SetIndent(2)
+	if err := e.Encode(tc); err != nil {
+		t.Fatalf("Failed to marshal test case config for %s: %v", tc.TestCase, err)
+	}
+	if err := os.WriteFile(tc.ConfigFile, out.Bytes(), 0644); err != nil {
+		t.Errorf("Failed to save test case config for %s into %q: %v", tc.TestCase, tc.ConfigFile, err)
+	}
+}

--- a/test/e2e/cli/testdata/git-server.yaml
+++ b/test/e2e/cli/testdata/git-server.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-git-namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: git-server
+  namespace: test-git-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: git-server
+  template:
+    metadata:
+      labels:
+        app: git-server
+    spec:
+      containers:
+        - name: git-server
+          image: GIT_SERVER_IMAGE
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: git-server
+  namespace: test-git-namespace
+spec:
+  selector:
+    app: git-server
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/test/e2e/cli/testdata/repo-register/config.yaml
+++ b/test/e2e/cli/testdata/repo-register/config.yaml
@@ -1,0 +1,46 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - https://github.com/platkrm/test-blueprints.git
+      - --namespace=repo-register
+      - --description
+      - Test Blueprints
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=repo-register
+      - --output=custom-columns=NAME:.metadata.name,ADDRESS:.spec.git.repo,BRANCH:.spec.git.branch,DIR:.spec.git.directory
+    stdout: |
+      NAME              ADDRESS                                          BRANCH   DIR
+      test-blueprints   https://github.com/platkrm/test-blueprints.git   main     /
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=repo-register
+      - --output=custom-columns=NAME:.metadata.name,CONTENT:.spec.content,DESC:.spec.description
+    stdout: |
+      NAME              CONTENT   DESC
+      test-blueprints   Package   Test Blueprints
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=repo-register
+    stdout: |
+      NAME              TYPE   CONTENT   DEPLOYMENT   READY   ADDRESS
+      test-blueprints   git    Package                True    https://github.com/platkrm/test-blueprints.git
+  - args:
+      - porchctl
+      - repo
+      - unregister
+      - --namespace=repo-register
+      - test-blueprints
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=repo-register

--- a/test/e2e/cli/testdata/rpkg-clone/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-clone/config.yaml
@@ -1,0 +1,158 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-clone
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-clone
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-clone
+      - https://github.com/platkrm/test-blueprints.git/basens@basens/v1
+      - --repository=git
+      - --workspace=clone-2
+      - basens-clone
+    stdout: "git-3465eed5831e5c372243d048631c8ef1666b47d6 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-clone
+      - https://github.com/platkrm/test-blueprints.git/basens@basens/v1
+      - --repository=git
+      - --workspace=clone-3
+      - basens-clone
+    stderr: "error: `clone` cannot create a new revision for package \"basens-clone\" that already exists in repo \"git\"; make subsequent revisions using `copy`\n"
+    exitCode: 1
+  - args:
+      - porchctl
+      - repo
+      - register
+      - https://github.com/platkrm/test-blueprints.git
+      - --namespace=rpkg-clone
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - --namespace=rpkg-clone
+      - --name=empty
+      - --revision=v1
+      - --output=jsonpath={.metadata.name}
+    stdout: test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-clone
+      - test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53
+      - --repository=git
+      - --workspace=clone-1
+      - empty-clone
+    stdout: "git-b67f9ce14d378317ba83c9504eab9cc024932dd3 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-clone
+      - git-3465eed5831e5c372243d048631c8ef1666b47d6
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-3465eed5831e5c372243d048631c8ef1666b47d6
+          namespace: rpkg-clone
+          uid: uid:basens-clone:clone-2
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+            internal.kpt.dev/upstream-identifier: kpt.dev|Kptfile|default|basens-clone
+          name: basens-clone
+        upstream:
+          git:
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+        upstreamLock:
+          git:
+            commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: namespace.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: namespace.yaml
+            internal.kpt.dev/upstream-identifier: '|Namespace|default|example'
+          name: example
+      kind: ResourceList
+    yaml: true
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-clone
+      - git-b67f9ce14d378317ba83c9504eab9cc024932dd3
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-b67f9ce14d378317ba83c9504eab9cc024932dd3
+          namespace: rpkg-clone
+          uid: uid:empty-clone:clone-1
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Empty Blueprint
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+            internal.kpt.dev/upstream-identifier: kpt.dev|Kptfile|default|empty-clone
+          name: empty-clone
+        upstream:
+          git:
+            directory: empty
+            ref: empty/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+        upstreamLock:
+          git:
+            commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
+            directory: empty
+            ref: empty/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+      kind: ResourceList
+    yaml: true

--- a/test/e2e/cli/testdata/rpkg-copy/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-copy/config.yaml
@@ -1,0 +1,99 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-copy
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-copy
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-copy
+      - https://github.com/platkrm/test-blueprints.git
+      - --directory=basens
+      - --ref=basens/v1
+      - --repository=git
+      - --workspace=copy-1
+      - basens-edit
+    stdout: "git-eb5afe755bedd142f142c6a9363649c667ef77a5 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - --namespace=rpkg-copy
+      - git-eb5afe755bedd142f142c6a9363649c667ef77a5
+    stderr: "git-eb5afe755bedd142f142c6a9363649c667ef77a5 proposed\n"
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - --namespace=rpkg-copy
+      - git-eb5afe755bedd142f142c6a9363649c667ef77a5
+    stderr: "git-eb5afe755bedd142f142c6a9363649c667ef77a5 approved\n"
+  - args:
+      - porchctl
+      - rpkg
+      - copy
+      - --namespace=rpkg-copy
+      - --workspace=copy-2
+      - git-eb5afe755bedd142f142c6a9363649c667ef77a5
+    stdout: "git-a29df72d1135fd010ea49f4d4877001dee423be6 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-copy
+      - git-a29df72d1135fd010ea49f4d4877001dee423be6
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-a29df72d1135fd010ea49f4d4877001dee423be6
+          namespace: rpkg-copy
+          uid: uid:basens-edit:copy-2
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+            internal.kpt.dev/upstream-identifier: kpt.dev|Kptfile|default|basens-edit
+          name: basens-edit
+        upstream:
+          git:
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+        upstreamLock:
+          git:
+            commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints.git
+          type: git
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: namespace.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: namespace.yaml
+            internal.kpt.dev/upstream-identifier: '|Namespace|default|example'
+          name: example
+      kind: ResourceList
+    yaml: true

--- a/test/e2e/cli/testdata/rpkg-get/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-get/config.yaml
@@ -1,0 +1,44 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - https://github.com/platkrm/test-blueprints.git
+      - --namespace=rpkg-get
+      - --description
+      - Test Blueprints
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - --namespace=rpkg-get
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.revision
+    stdout: |
+      NAME                                                       PKG      REPO              REV
+      test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens   test-blueprints   main
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
+      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens   test-blueprints   v2
+      test-blueprints-913ab85d2d49621636a0ffa514a2a008e6a7012e   basens   test-blueprints   v3
+      test-blueprints-58fffeb908ead18e2c05c873e61bff11a5292963   empty    test-blueprints   main
+      test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53   empty    test-blueprints   v1
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - --namespace=rpkg-get
+      - test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597
+    stdout: |
+      NAME                                                       PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1              v1         false    Published   test-blueprints
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - --namespace=rpkg-get
+      - --name=basens
+    stdout: |
+      NAME                                                       PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens    main            main       false    Published   test-blueprints
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1              v1         false    Published   test-blueprints
+      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens    v2              v2         false    Published   test-blueprints
+      test-blueprints-913ab85d2d49621636a0ffa514a2a008e6a7012e   basens    v3              v3         true     Published   test-blueprints

--- a/test/e2e/cli/testdata/rpkg-init-deploy/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-init-deploy/config.yaml
@@ -1,0 +1,90 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-init-deploy
+      - --name=git
+      - --deployment
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init-deploy
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=rpkg-init-deploy
+      - --output=custom-columns=NAME:.metadata.name,DEPLOYMENT:.spec.deployment
+    stdout: |
+      NAME   DEPLOYMENT
+      git    true
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - --namespace=rpkg-init-deploy
+      - --description
+      - Test Package Description
+      - --keywords=test,package
+      - --site
+      - http://kpt.dev/deploy-package
+      - --repository=git
+      - --workspace=deploy
+      - deploy-package
+    stdout: "git-628abd0a0903f5de6cb3604d917724f6fc1b5e08 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-init-deploy
+      - git-628abd0a0903f5de6cb3604d917724f6fc1b5e08
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-628abd0a0903f5de6cb3604d917724f6fc1b5e08
+          namespace: rpkg-init-deploy
+          uid: uid:deploy-package:deploy
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Test Package Description
+          keywords:
+          - test
+          - package
+          site: http://kpt.dev/deploy-package
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: deploy-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=rpkg-init-deploy
+    stdout: |
+      NAME   TYPE   CONTENT   DEPLOYMENT   READY   ADDRESS
+      git    git    Package   true         True    http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init-deploy

--- a/test/e2e/cli/testdata/rpkg-init/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-init/config.yaml
@@ -1,0 +1,91 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-init
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init
+  - args:
+      - porchctl
+      - repo
+      - get
+      - --namespace=rpkg-init
+      - --output=custom-columns=NAME:.metadata.name,ADDRESS:.spec.git.repo,BRANCH:.spec.git.branch,DIR:.spec.git.directory
+    stdout: |
+      NAME   ADDRESS                                                                 BRANCH   DIR
+      git    http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init   main     /
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - --namespace=rpkg-init
+      - --description
+      - Test Package Description
+      - --keywords=test,package
+      - --site
+      - http://kpt.dev/init-package
+      - --repository=git
+      - --workspace=init-1
+      - init-package
+    stdout: "git-95686470a1fd3a3ba726cce4c8f449f6bbe2b02a created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-init
+      - git-95686470a1fd3a3ba726cce4c8f449f6bbe2b02a
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-95686470a1fd3a3ba726cce4c8f449f6bbe2b02a
+          namespace: rpkg-init
+          uid: uid:init-package:init-1
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Test Package Description
+          keywords:
+          - test
+          - package
+          site: http://kpt.dev/init-package
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: init-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - --namespace=rpkg-init
+      - --repository=git
+      - --workspace=init-2
+      - init-package
+    stderr: "error: `init` cannot create a new revision for package \"init-package\" that already exists in repo \"git\"; make subsequent revisions using `copy`\n"
+    exitCode: 1

--- a/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
@@ -1,0 +1,205 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-lifecycle
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-lifecycle
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - --namespace=rpkg-lifecycle
+      - --repository=git
+      - --workspace=lifecycle
+      - lifecycle-package
+    stdout: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - --namespace=rpkg-lifecycle
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 proposed
+  - args:
+      - porchctl
+      - rpkg
+      - propose-delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    exitCode: 1
+    stderr: |
+      can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published
+      Error: errors:
+        can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published 
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REV:.spec.revision,LIFECYCLE:.spec.lifecycle
+    stdout: |
+      NAME                                           PKG                 REV      LIFECYCLE
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   <none>   Proposed
+  - args:
+      - porchctl
+      - rpkg
+      - reject
+      - --namespace=rpkg-lifecycle
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 rejected
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle                  false    Draft       git
+  - args:
+      - porchctl
+      - rpkg
+      - propose-delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    exitCode: 1
+    stderr: |
+      can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published
+      Error: errors:
+        can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published 
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - --namespace=rpkg-lifecycle
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 proposed
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle                  false    Proposed    git
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - --namespace=rpkg-lifecycle
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 approved
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle       v1         true     Published   git
+  - args:
+      - porchctl
+      - rpkg
+      - delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    exitCode: 1
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (admission webhook "packagerevdeletion.google.com" denied the request: failed to delete package revision "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion)
+      Error: errors:
+        admission webhook "packagerevdeletion.google.com" denied the request: failed to delete package revision "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion 
+  - args:
+      - porchctl
+      - rpkg
+      - propose-delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 proposed for deletion
+  - args:
+      - porchctl
+      - rpkg
+      - propose-delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is already proposed for deletion
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE          REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle       v1         true     DeletionProposed   git
+  - args:
+      - porchctl
+      - rpkg
+      - reject
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 no longer proposed for deletion
+  - args:
+      - porchctl
+      - rpkg
+      - reject
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published'
+      Error: errors:
+        cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published' 
+    exitCode: 1
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle       v1         true     Published   git
+  - args:
+      - porchctl
+      - rpkg
+      - propose-delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 proposed for deletion
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE          REPOSITORY
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034   lifecycle-package   lifecycle       v1         true     DeletionProposed   git
+  - args:
+      - porchctl
+      - rpkg
+      - delete
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 deleted
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
+      - --namespace=rpkg-lifecycle
+    stderr: "Error: the server could not find the requested resource (get packagerevisions.porch.kpt.dev git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034) \n"
+    exitCode: 1

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -1,0 +1,184 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-push
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-push
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - --namespace=rpkg-push
+      - --repository=git
+      - --workspace=push
+      - test-package
+    stdout: "git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+          namespace: rpkg-push
+          uid: uid:test-package:push
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+    stdin: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+          namespace: rpkg-push
+          uid: uid:test-package:push
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true
+    exitCode: 1
+    stderr: "Error: Internal error occurred: resourceVersion must be specified for an update \n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+      - /tmp/porch-e2e/rpkg-push-git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+  - args:
+      - kpt
+      - fn
+      - eval
+      - --image
+      - gcr.io/kpt-fn/search-replace:v0.2.0
+      - --match-kind
+      - Kptfile
+      - /tmp/porch-e2e/rpkg-push-git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+      - --
+      - by-path=info.description
+      - put-value=Updated Test Package Description
+    stderr: "[RUNNING] \"gcr.io/kpt-fn/search-replace:v0.2.0\" on 1 resource(s)\n  Results:\n    [info] info.description: Mutated field value to \"Updated Test Package Description\"\n"
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+      - /tmp/porch-e2e/rpkg-push-git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+    stdout: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+          namespace: rpkg-push
+          uid: uid:test-package:push
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Updated Test Package Description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true

--- a/test/e2e/cli/testdata/rpkg-update/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-update/config.yaml
@@ -1,0 +1,149 @@
+commands:
+  - args:
+      - porchctl
+      - repo
+      - register
+      - --namespace=rpkg-update
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-update
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-update
+      - https://github.com/platkrm/test-blueprints.git
+      - --directory=basens
+      - --ref=basens/v1
+      - --repository=git
+      - --workspace=update-1
+      - basens-edit
+    stdout: "git-3f036055f7ba68706372cbe0c4b14d553794f7c4 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - --namespace=rpkg-update
+      - git-3f036055f7ba68706372cbe0c4b14d553794f7c4
+      - --directory=basens
+      - --ref=basens/v1
+      - --repository=git
+      - --workspace=update-2
+      - basens-edit-clone
+    stdout: "git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - copy
+      - --namespace=rpkg-update
+      - --workspace=update-3
+      - --replay-strategy=true
+      - git-3f036055f7ba68706372cbe0c4b14d553794f7c4
+    stdout: "git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - --namespace=rpkg-update
+      - git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60
+    stderr: "git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60 proposed\n"
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - --namespace=rpkg-update
+      - git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60
+    stderr: "git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60 approved\n"
+  - args:
+      - porchctl
+      - rpkg
+      - get
+      - --namespace=rpkg-update
+    stdout: |
+      NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      git-3f036055f7ba68706372cbe0c4b14d553794f7c4   basens-edit         update-1                   false    Draft       git
+      git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60   basens-edit         update-3        v1         true     Published   git
+      git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   basens-edit-clone   update-2                   false    Draft       git
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=upstream
+      - git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+    stdout: |
+      PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
+      git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   v1
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=upstream
+    stdout: |
+      PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
+      git-3f036055f7ba68706372cbe0c4b14d553794f7c4                         No update available
+      git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60                         No update available
+      git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   v1
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=downstream
+    stdout: |
+      PACKAGE REVISION                               DOWNSTREAM PACKAGE                             DOWNSTREAM UPDATE
+      git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60   git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   (draft "update-1")->v1
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --revision=v1
+      - git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+    stdout: "git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0 updated\n"
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=upstream
+    stdout: |
+      PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
+      git-3f036055f7ba68706372cbe0c4b14d553794f7c4                         No update available
+      git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60                         No update available
+      git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   No update available
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-update
+      - git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+      - /tmp/porch-e2e/pkg-update-git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+  - args:
+      - kpt
+      - fn
+      - eval
+      - --image
+      - gcr.io/kpt-fn/search-replace:v0.2.0
+      - --match-kind
+      - Kptfile
+      - /tmp/porch-e2e/pkg-update-git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+      - --
+      - by-path=upstreamLock.git.ref
+      - put-value=invalid
+    stderr: "[RUNNING] \"gcr.io/kpt-fn/search-replace:v0.2.0\" on 1 resource(s)\n  Results:\n    [info] upstreamLock.git.ref: Mutated field value to \"invalid\"\n"
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - --namespace=rpkg-update
+      - git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+      - /tmp/porch-e2e/pkg-update-git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=upstream
+    stderr: "Error: could not parse upstreamLock in Kptfile of package \"git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0\": malformed upstreamLock.Git.Ref \"invalid\" \n"
+    exitCode: 1

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	porchtest "github.com/GoogleContainerTools/kpt/pkg/test/porch"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -40,6 +39,7 @@ import (
 	"github.com/nephio-project/porch/pkg/git"
 	kptfilev1 "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
+	porchtest "github.com/nephio-project/porch/test/e2e/cli"
 	appsv1 "k8s.io/api/apps/v1"
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This adds the CLI E2E tests. A couple notes:

- Like the other e2e tests, in order to run you need to create a cluster and deploy porch, and set E2E=1
- These require that porchctl is built and in the path.
- Currently they also require that kpt is built and in the path, because a few tests execute `kpt fn`. There is no need to have a version of kpt with `kpt alpha` commands, just `kpt fn`.

I manually ran the e2e tests in this PR.