### PR TITLE
Improve error message emitted when metadata is missing

### DIFF
--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -136,7 +136,8 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 
 	rv, err := util.GetResourceVersion(&pkgResources)
 	if err != nil {
-		return errors.E(op, err)
+		errString := err.Error() + "\nuse \"porchctl rpkg pull\" to download the remote package metadata before pushing"
+		return errors.E(op, err, errString)
 	}
 	pkgResources.ResourceVersion = rv
 	if err = util.RemoveRevisionMetadata(&pkgResources); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment only one  /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>  /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it:**
See https://github.com/nephio-project/nephio/issues/471

The push fails due to the hidden .KptRevisionMetadata file being missing, the reason is that the "porchctl rpkg pull" command must be used to pull down the package to the local file system prior to pushing local contents.

porchctl -n porch-demo rpkg init zooby --repository=management --workspace=v1                                   
porchctl rpkg push management-f329f708454bb52906e17266ac6cf689c325f6fa -n porch-demo aaa/bbb
Error: ".KptRevisionMetadata" not found in PackageRevisionResources 'porch-demo/management-f329f708454bb52906e17266ac6cf689c325f6fa'

This PR updates the error message issued by "porchctl rpjg push" to be more helpful:
~/git/github/nephio-project/porch/.build/porchctl rpkg push management-f329f708454bb52906e17266ac6cf689c325f6fa -n porch-demo aaa/bbb
Error: ".KptRevisionMetadata" not found in PackageRevisionResources 'porch-demo/management-f329f708454bb52906e17266ac6cf689c325f6fa'
use "porchctl rpkg pull" to download the remote package metadata before pushing 

**Which issue(s) this PR fixes:**
Addresses [Issue 471](https://github.com/nephio-project/nephio/issues/471) with a better error message.

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
yes, an improved error message
