### PR TITLE
Upgrade Porch to Go 1.22

### DIFF
--- a/.github/workflows/porch-e2e.yaml
+++ b/.github/workflows/porch-e2e.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.5'
+          go-version: '>=1.22.2'
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3
       - name: Install kpt

--- a/.github/workflows/porchctl-cli-e2e.yaml
+++ b/.github/workflows/porchctl-cli-e2e.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.5'
+          go-version: '>=1.22.2'
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3
       - name: Install kpt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.5'
+          go-version: '>=1.22.2'
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/porch/api
 
-go 1.21
+go 1.22
 
 require (
 	k8s.io/apimachinery v0.29.2

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.21.4-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /go/src
 

--- a/build/Dockerfile.apiserver
+++ b/build/Dockerfile.apiserver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.4-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /workspace/src
 RUN git clone https://github.com/kubernetes/kubernetes --branch v1.23.2 --depth=1

--- a/build/Dockerfile.etcd
+++ b/build/Dockerfile.etcd
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.3-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /workspace
 ARG ETCD_VER=v3.5.1

--- a/controllers/Dockerfile
+++ b/controllers/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.4-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /go/src
 COPY porch/ .

--- a/controllers/go.mod
+++ b/controllers/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/porch/controllers
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/go-git/go-git/v5 v5.4.3-0.20220408232334-4f916225cb2f => github.com/platkrm/go-git/v5 v5.4.3-0.20220410165046-c76b262044ce

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/render.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/render.go
@@ -319,7 +319,7 @@ func evalExpr(expr string, inputs map[string]interface{}) (string, error) {
 		return "", err
 	}
 
-	result, err := val.ConvertToNative(reflect.TypeOf(""))
+	result, err := val.ConvertToNative(reflect.TypeFor[string]())
 	if err != nil {
 		return "", err
 	}

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-GOLANG_CI_VER ?= v1.52
+GOLANG_CI_VER ?= v1.57
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 

--- a/default-go-test.mk
+++ b/default-go-test.mk
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-GO_VERSION ?= 1.20.2
+GO_VERSION ?= 1.22.2
 TEST_COVERAGE_FILE=lcov.info
 TEST_COVERAGE_HTML_FILE=coverage_unit.html
 TEST_COVERAGE_FUNC_FILE=func_coverage.out

--- a/default-gosec.mk
+++ b/default-gosec.mk
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-GOSEC_VER ?= 2.15.0
+GOSEC_VER ?= 2.19.0
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 

--- a/examples/apps/hello-server/Dockerfile
+++ b/examples/apps/hello-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.4-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/examples/apps/hello-server/go.mod
+++ b/examples/apps/hello-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/nephio-project/porch/config/samples/apps/hello
 
-go 1.21
+go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/porch
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/go-git/go-git/v5 v5.4.3-0.20220408232334-4f916225cb2f => github.com/platkrm/go-git/v5 v5.4.3-0.20220410165046-c76b262044ce

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.21.4-bookworm as builder
+FROM golang:1.22.2-bookworm as builder
 
 WORKDIR /go/src
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment only one  /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>  /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it:**

- Updated go version in go.mod files
- Updated go version in github workflows
- Updated base image to 1.22.2-bookworm in Dockerfiles
- Updated Go/Golang-CI/GoSec versions in makefiles

**Which issue(s) this PR fixes:**
Fixes [Issue 510](https://github.com/nephio-project/nephio/issues/510).

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
no
