### PR TITLE
Refactor of the Developer Environment setup script

### DIFF
--- a/docs/tutorials/porch-development-environment/bin/replace-gitea-service-ports.yaml
+++ b/docs/tutorials/porch-development-environment/bin/replace-gitea-service-ports.yaml
@@ -1,0 +1,21 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: ApplyReplacements
+metadata:
+  name: replace-gitea-service
+replacements:
+- source:
+    group: kind.x-k8s.io
+    kind: Cluster
+    fieldPath: nodes.0.extraPortMappings.0.containerPort
+  targets:
+  - select: 
+      kind: Service
+      name: gitea
+      namespace: gitea
+    fieldPaths:
+    - spec.ports.[name=http].nodePort
+    options:
+      create: true
+    
+
+    

--- a/docs/tutorials/porch-development-environment/bin/setup.sh
+++ b/docs/tutorials/porch-development-environment/bin/setup.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 # Copyright 2024 The kpt and Nephio Authors
 #
@@ -14,23 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-os_type=$(uname)
-if [ "$os_type" = "Darwin" ]
-then
-  SED="gsed"
+porch_cluster_name=porch-test
+git_repo_name="$porch_cluster_name"
+gitea_ip=172.18.255.200  # should be from the address range specified here: https://github.com/nephio-project/porch/blob/main/docs/tutorials/starting-with-porch/metallb-conf.yaml
+self_dir="$(dirname "$(readlink -f "$0")")"
+
+function h1() {
+  echo
+  echo "** $*"
+  echo 
+}
+
+##############################################
+h1 "Install kind cluster: $porch_cluster_name"
+if ! kind get clusters | grep -q "^$porch_cluster_name\$" ; then
+  curl -s https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/kind_management_cluster.yaml | \
+    kind create cluster --config=- --name "$porch_cluster_name" || true
+
+  mkdir -p ~/.kube
+  kind get kubeconfig --name="$porch_cluster_name" > ~/.kube/"kind-$porch_cluster_name"
 else
-  SED="sed"
+  echo "Cluster already exists."
 fi
+kind export kubeconfig --name="$porch_cluster_name"
 
-# Create mgmt cluster in kind
-curl -s https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/kind_management_cluster.yaml | \
-  kind create cluster --config=-
-
-kind get kubeconfig --name=management > ~/.kube/kind-management-config
-
-export KUBECONFIG=~/.kube/kind-management-config
-
-# Instal MetalLB
+##############################################
+h1 Instal MetalLB
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
 kubectl wait --namespace metallb-system \
                 --for=condition=ready pod \
@@ -39,47 +48,51 @@ kubectl wait --namespace metallb-system \
 
 kubectl apply -f https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/metallb-conf.yaml
 
+############################################
+h1 Prepare tmp dir
 TMP_DIR=$(mktemp -d)
+echo "$TMP_DIR"
 
-pushd "$TMP_DIR" || exit
 
-mkdir kpt_packages
-pushd kpt_packages || exit
-
-# Install Gitea
+############################################
+h1 Install Gitea
+mkdir "$TMP_DIR/kpt_packages"
+cd "$TMP_DIR/kpt_packages"
 kpt pkg get https://github.com/nephio-project/catalog/tree/main/distros/sandbox/gitea
-$SED -i 's/ metallb.universe.tf/ #metallb.universe.tf/' gitea/service-gitea.yaml
+kpt fn eval gitea \
+  --image gcr.io/kpt-fn/set-annotations:v0.1.4 \
+  --match-kind Service \
+  --match-name gitea \
+  --match-namespace gitea \
+  -- "metallb.universe.tf/loadBalancerIPs=${gitea_ip}"
 kpt fn render gitea
 kpt live init gitea
 kpt live apply gitea
 
-popd || exit
+############################################
+h1 Create git repo in gitea
+curl -k -H "content-type: application/json" "http://nephio:secret@${gitea_ip}:3000/api/v1/user/repos" --data "{\"name\":\"$git_repo_name\"}"
 
-# Create management repo in gitea
-curl -k -H "content-type: application/json" "http://nephio:secret@172.18.255.200:3000/api/v1/user/repos" --data '{"name":"management"}'
+mkdir "$TMP_DIR/repos"
+cd "$TMP_DIR/repos"
 
-mkdir repos
-pushd repos || exit
+git clone "http://nephio:secret@${gitea_ip}:3000/nephio/$git_repo_name"
+cd "$git_repo_name"
 
-# Initialize management repo in Gitea
-git clone http://172.18.255.200:3000/nephio/management
-pushd management || exit
+if ! git rev-parse -q --verify refs/remotes/origin/main >/dev/null; then
+  git switch -c  main
+  touch README.md
+  git add README.md
+  git config user.name nephio
+  git commit -m "first commit"
+  git push -u origin main
+else
+  echo "main branch already exists in git repo."
+fi
 
-touch README.md
-git init
-git checkout -b main
-git config user.name nephio
-git add README.md
-
-git commit -m "first commit"
-git remote remove origin
-git remote add origin http://nephio:secret@172.18.255.200:3000/nephio/management.git
-git remote -v
-git push -u origin main
-popd || exit
-
-popd || exit
-
+h1 "Clean up"
+cd "$self_dir"
 rm -fr "$TMP_DIR"
 
-kubectl config use-context kind-management
+echo
+echo Done.

--- a/docs/tutorials/porch-development-environment/bin/setup.sh
+++ b/docs/tutorials/porch-development-environment/bin/setup.sh
@@ -41,9 +41,10 @@ kind export kubeconfig --name="$porch_cluster_name"
 ##############################################
 h1 Instal MetalLB
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
-kubectl wait --namespace metallb-system \
-                --for=condition=ready pod \
-                --selector=component=controller \
+sleep 1
+echo "Waiting for controller to become ready..."
+kubectl wait --namespace metallb-system deploy controller \
+                --for=condition=available \
                 --timeout=90s
 
 kubectl apply -f https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/metallb-conf.yaml

--- a/docs/tutorials/porch-development-environment/bin/setup.sh
+++ b/docs/tutorials/porch-development-environment/bin/setup.sh
@@ -65,6 +65,18 @@ kpt fn eval gitea \
   --match-name gitea \
   --match-namespace gitea \
   -- "metallb.universe.tf/loadBalancerIPs=${gitea_ip}"
+curl -o gitea/cluster-config.yaml https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/kind_management_cluster.yaml
+echo "metadata: { name: "porch-test" }" >> gitea/cluster-config.yaml
+kpt fn eval gitea \
+  --image gcr.io/kpt-fn/set-annotations:v0.1.4 \
+  --match-kind Cluster \
+  --match-api-version kind.x-k8s.io/v1alpha4 \
+  -- "config.kubernetes.io/local-config=true"
+
+kpt fn eval gitea \
+  --image gcr.io/kpt-fn/apply-replacements:v0.1.1 \
+  --fn-config "${self_dir}/replace-gitea-service-ports.yaml"
+
 kpt fn render gitea
 kpt live init gitea
 kpt live apply gitea

--- a/docs/tutorials/porch-development-environment/bin/setup.sh
+++ b/docs/tutorials/porch-development-environment/bin/setup.sh
@@ -22,15 +22,11 @@ else
   SED="sed"
 fi
 
-# Create mgmt and edge1 clusters in kind
+# Create mgmt cluster in kind
 curl -s https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/kind_management_cluster.yaml | \
   kind create cluster --config=-
 
-curl -s https://raw.githubusercontent.com/nephio-project/porch/main/docs/tutorials/starting-with-porch/kind_edge1_cluster.yaml | \
-  kind create cluster --config=-
-
 kind get kubeconfig --name=management > ~/.kube/kind-management-config
-kind get kubeconfig --name=edge1 > ~/.kube/kind-edge1-config
 
 export KUBECONFIG=~/.kube/kind-management-config
 
@@ -59,14 +55,13 @@ kpt live apply gitea
 
 popd || exit
 
-# Create management and edge1 repos in gitea
+# Create management repo in gitea
 curl -k -H "content-type: application/json" "http://nephio:secret@172.18.255.200:3000/api/v1/user/repos" --data '{"name":"management"}'
-curl -k -H "content-type: application/json" "http://nephio:secret@172.18.255.200:3000/api/v1/user/repos" --data '{"name":"edge1"}'
 
 mkdir repos
 pushd repos || exit
 
-# Initialize management and edge1 repos in Gitea
+# Initialize management repo in Gitea
 git clone http://172.18.255.200:3000/nephio/management
 pushd management || exit
 
@@ -79,22 +74,6 @@ git add README.md
 git commit -m "first commit"
 git remote remove origin
 git remote add origin http://nephio:secret@172.18.255.200:3000/nephio/management.git
-git remote -v
-git push -u origin main
-popd || exit
-
-git clone http://172.18.255.200:3000/nephio/edge1
-pushd edge1 || exit
-
-touch README.md
-git init
-git checkout -b main
-git config user.name nephio
-git add README.md
-
-git commit -m "first commit"
-git remote remove origin
-git remote add origin http://nephio:secret@172.18.255.200:3000/nephio/edge1.git
 git remote -v
 git push -u origin main
 popd || exit


### PR DESCRIPTION
Includes the following changes:
- remove edge1 cluster
- ensure that Gitea's nodePort matches with the port that is forwarded to the host in the kind cluster's config
- the following values are turned into parameters: 
  - name of kind cluster, 
  - name of git repo, 
  - Gitea external IP
- script made idempotent (you can rerun it without any cleanup)
- script exits on error
- Gitea install package is manipulated by KRM functions instead of sed
- check if git user.name config is set
- bugfix: wait for Deployment availability instead of Pod readiness

