### PR TITLE
Allow configuration of an external webhook & associated certs

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -289,7 +289,11 @@ func (s *PorchServer) Run(ctx context.Context) error {
 
 	certStorageDir, found := os.LookupEnv("CERT_STORAGE_DIR")
 	if found && strings.TrimSpace(certStorageDir) != "" {
-		if err := setupWebhooks(ctx, webhookNs, certStorageDir); err != nil {
+		useCertMan := false
+		if _, found := os.LookupEnv("USE_CERT_MAN_FOR_WEBHOOK"); found {
+			useCertMan = true
+		}
+		if err := setupWebhooks(ctx, webhookNs, certStorageDir, useCertMan); err != nil {
 			klog.Errorf("%v\n", err)
 			return err
 		}

--- a/pkg/apiserver/webhooks_test.go
+++ b/pkg/apiserver/webhooks_test.go
@@ -17,6 +17,7 @@ package apiserver
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -56,6 +58,130 @@ func TestCreateCerts(t *testing.T) {
 	keyStr := strings.TrimSpace(string(key))
 	require.True(t, strings.HasPrefix(keyStr, "-----BEGIN RSA PRIVATE KEY-----\n"))
 	require.True(t, strings.HasSuffix(keyStr, "\n-----END RSA PRIVATE KEY-----"))
+}
+
+func TestLoadCertificate(t *testing.T) {
+
+	//what do i need to test.
+	// first create dummy certs for testing
+	dir := t.TempDir()
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+	_, err := createCerts("", dir)
+	require.NoError(t, err)
+
+	//1. test file that cannot be os.stated or causes that function to fail
+	_, err1 := loadCertificate(filepath.Join(dir, "nonexistingcrtfile.key"), filepath.Join(dir, "nonexistingkeyfile.key"))
+	require.Error(t, err1)
+	// reseting back to 0
+	certModTime = time.Time{}
+	//2. test happy path of os.stat and continue to next error
+	//3. test loading good cert happy path
+	keypath := filepath.Join(dir, "tls.key")
+	crtpath := filepath.Join(dir, "tls.crt")
+
+	_, err2 := loadCertificate(crtpath, keypath)
+	require.NoError(t, err2)
+	certModTime = time.Time{}
+
+	//4. test loading faulty cert error
+	data := []byte("Hello, World!")
+
+	writeErr := os.WriteFile(keypath, data, 0644)
+	require.NoError(t, writeErr)
+	writeErr2 := os.WriteFile(crtpath, data, 0644)
+	require.NoError(t, writeErr2)
+
+	_, err3 := loadCertificate(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	require.Error(t, err3)
+	certModTime = time.Time{}
+}
+// method for capturing klog error's 
+func captureStderr(f func()) string {
+	read, write, _ := os.Pipe()
+	stderr := os.Stderr
+	os.Stderr = write
+	outputChannel := make(chan string)
+
+	// Copy the output in a separate goroutine so printing can't block indefinitely.
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, read)
+		outputChannel <- buf.String()
+	}()
+
+	// Run the provided function and capture the stderr output
+	f()
+
+	// Restore the original stderr and close the write-end of the pipe so the goroutine will exit
+	os.Stderr = stderr
+	write.Close()
+	out := <-outputChannel
+
+	return out
+}
+
+func TestWatchCertificates(t *testing.T) {
+	// method for processing klog output
+	assertLogMessages := func(log string) error {
+		if len(log) > 0 {
+			if log[0] == 'E' || log[0] == 'W' || log[0] == 'F' {
+				return errors.New("Error Occured in Watcher")
+			}
+		}
+		return nil
+	}
+	// Set up the temp directory with dummy certificate files
+	dir := t.TempDir()
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+	_, err := createCerts("", dir)
+	require.NoError(t, err)
+
+	keyFile := filepath.Join(dir, "tls.key")
+	certFile := filepath.Join(dir, "tls.crt")
+
+	// firstly test error occuring from invalid entity for watcher to watch. aka invalid dir
+	// we expect an error
+	go watchCertificates("Dummy Directory that does not exist", certFile, keyFile)
+
+	invalid_watch_entity_logs := captureStderr(func() {
+		time.Sleep(100 * time.Millisecond) // Give some time for the logs to be flushed
+	})
+	t.Log(invalid_watch_entity_logs)
+	err = assertLogMessages(invalid_watch_entity_logs)
+	require.Error(t, err)
+
+	go watchCertificates(dir, certFile, keyFile)
+	time.Sleep(1 * time.Second)
+
+	//create file to trigger change but not alter the certificate contents
+	//should trigger reload and certificate reloaded successfully
+	newFilePath := filepath.Join(dir, "new_temp_file.txt")
+	_, err = os.Create(newFilePath)
+	require.NoError(t, err)
+
+	valid_reload_logs := captureStderr(func() {
+		time.Sleep(100 * time.Millisecond) // Give some time for the logs to be flushed
+	})
+	t.Log(valid_reload_logs)
+	err = assertLogMessages(valid_reload_logs)
+	require.NoError(t, err)
+
+	// Modify the certificate file to trigger a file system event
+	// should cause an error log since cert contents are not valid anymore
+	certModTime = time.Time{}
+	err = os.WriteFile(certFile, []byte("dummy text"), 0660)
+	require.NoError(t, err)
+
+	invalid_reload_logs := captureStderr(func() {
+		time.Sleep(100 * time.Millisecond) // Give some time for the logs to be flushed
+	})
+	t.Log(invalid_reload_logs)
+	err = assertLogMessages(invalid_reload_logs)
+	require.Error(t, err)
 }
 
 func TestValidateDeletion(t *testing.T) {


### PR DESCRIPTION
This change is related to https://github.com/nephio-project/nephio/issues/554
This change introduces a new environment variable, when present in the porch server and set to true porch will no longer create its own tls certificates for webhooks from the code but expects those to be created by a cert manager issuer and certificate yaml configuration along with the validationwebhookconfiguration.

1. Since the ValidationWebhookConfiguration is now a yaml file config which will be in its own separate porch package points 1 and 3 in issue 554 are handled.
2. if were running with cert manager certificates the certificate gets mounted as a secret to the porch-server pod and when updated by cert manager it is detected and the new one is used by the porch server. point 2 in issue 554.
3. the cert manager certificate and issuer resources are configurable in their own yaml file.

It is important to note that this is is only half of the request. another pull request will be requested for the catalogue repo where an optional porch package would be added containing both the cert manager resources required for creating and maintaining the certificates (Issuer & Certificate) & the external validationwebhookconfiguration.