### PR TITLE
#735 - Fix porchctl version by injecting release version into run.go module

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
       - darwin
     goarch:
       - amd64
-    ldflags: -s -w
+    ldflags: -s -w -X github.com/nephio-project/porch/cmd/porchctl/run.version={{.Version}}
     main: ./cmd/porchctl
 
   - id: darwin-arm64
@@ -42,7 +42,7 @@ builds:
       - darwin
     goarch:
       - arm64
-    ldflags: -s -w
+    ldflags: -s -w -X github.com/nephio-project/porch/cmd/porchctl/run.version={{.Version}}
     main: ./cmd/porchctl
 
   - id: linux-amd64
@@ -53,7 +53,7 @@ builds:
       - linux
     goarch:
       - amd64
-    ldflags: -s -w -extldflags "-z noexecstack"
+    ldflags: -s -w -X github.com/nephio-project/porch/cmd/porchctl/run.version={{.Version}} -extldflags "-z noexecstack"
     main: ./cmd/porchctl
 
   - id: linux-arm64
@@ -64,7 +64,7 @@ builds:
       - linux
     goarch:
       - arm64
-    ldflags: -s -w -extldflags "-z noexecstack"
+    ldflags: -s -w -X github.com/nephio-project/porch/cmd/porchctl/run.version={{.Version}} -extldflags "-z noexecstack"
     main: ./cmd/porchctl
 
 


### PR DESCRIPTION
This change injects the release version into the run.go module during build time using goreleaser. 
This updates the version from "unknown" to the current version set by goreleaser. 