### PR TITLE
Excluding changes in Prow files from triggering e2e runs

### DIFF
--- a/.github/workflows/porch-e2e.yaml
+++ b/.github/workflows/porch-e2e.yaml
@@ -19,12 +19,15 @@ on:
       - "docs/**"
       - "release/**"
       - "deployments/**"
+      - ".prow.yaml"
+      - "OWNERS"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "release/**"
       - "deployments/**"
-
+      - ".prow.yaml"
+      - "OWNERS"
 jobs:
   tests:
     name: Porch End-to-End Tests

--- a/.github/workflows/porchctl-cli-e2e.yaml
+++ b/.github/workflows/porchctl-cli-e2e.yaml
@@ -19,12 +19,15 @@ on:
       - "docs/**"
       - "release/**"
       - "deployments/**"
+      - ".prow.yaml"
+      - "OWNERS"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "release/**"
       - "deployments/**"
-
+      - ".prow.yaml"
+      - "OWNERS"
 jobs:
   tests:
     name: Porch CLI End-to-End Tests


### PR DESCRIPTION
There's no need to run E2E tests when Prow configuration files change. Also they have their own checks defined in test-infra's Prow configuration. 