### PR TITLE
Yet another improvement to development process

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ postsubmits:
     - org: nephio-project
       repo: porch
       base_ref: main
-      path_alias: "porch_build/porch"
+      path_alias: "porch_build"
     spec:
       containers:
       - name: kaniko
@@ -34,7 +34,7 @@ postsubmits:
         - "/bin/sh"
         - "-c"
         - |
-          executor --context=/home/prow/go/src/porch_build/ --dockerfile=porch/build/Dockerfile --destination=nephio/porch-server:${PULL_BASE_REF} --destination=nephio/porch-server:latest
+          executor --context=/home/prow/go/src/porch_build/ --dockerfile=build/Dockerfile --destination=nephio/porch-server:${PULL_BASE_REF} --destination=nephio/porch-server:latest
         volumeMounts:
           - name: kaniko-secret
             mountPath: /kaniko/.docker/
@@ -66,7 +66,7 @@ postsubmits:
     - org: nephio-project
       repo: porch
       base_ref: main
-      path_alias: "porch_build/porch"
+      path_alias: "porch_build"
     spec:
       containers:
       - name: kaniko
@@ -75,7 +75,7 @@ postsubmits:
         - "/bin/sh"
         - "-c"
         - |
-          executor --context=/home/prow/go/src/porch_build/ --dockerfile=porch/controllers/Dockerfile --destination=nephio/porch-controllers:${PULL_BASE_REF} --destination=nephio/porch-controllers:latest
+          executor --context=/home/prow/go/src/porch_build/ --dockerfile=controllers/Dockerfile --destination=nephio/porch-controllers:${PULL_BASE_REF} --destination=nephio/porch-controllers:latest
         volumeMounts:
           - name: kaniko-secret
             mountPath: /kaniko/.docker/
@@ -107,7 +107,7 @@ postsubmits:
     - org: nephio-project
       repo: porch
       base_ref: main
-      path_alias: "porch_build/porch"
+      path_alias: "porch_build"
     spec:
       containers:
       - name: kaniko
@@ -116,7 +116,7 @@ postsubmits:
         - "/bin/sh"
         - "-c"
         - |
-          executor --context=/home/prow/go/src/porch_build/ --dockerfile=porch/func/Dockerfile --destination=nephio/porch-function-runner:${PULL_BASE_REF} --destination=nephio/porch-function-runner:latest
+          executor --context=/home/prow/go/src/porch_build/ --dockerfile=func/Dockerfile --destination=nephio/porch-function-runner:${PULL_BASE_REF} --destination=nephio/porch-function-runner:latest
         volumeMounts:
           - name: kaniko-secret
             mountPath: /kaniko/.docker/
@@ -148,7 +148,7 @@ postsubmits:
     - org: nephio-project
       repo: porch
       base_ref: main
-      path_alias: "porch_build/porch"
+      path_alias: "porch_build"
     spec:
       containers:
       - name: kaniko
@@ -157,7 +157,7 @@ postsubmits:
         - "/bin/sh"
         - "-c"
         - |
-          executor --context=/home/prow/go/src/porch_build/ --dockerfile=porch/func/Dockerfile-wrapperserver --destination=nephio/porch-wrapper-server:${PULL_BASE_REF} --destination=nephio/porch-wrapper-server:latest
+          executor --context=/home/prow/go/src/porch_build/ --dockerfile=func/Dockerfile-wrapperserver --destination=nephio/porch-wrapper-server:${PULL_BASE_REF} --destination=nephio/porch-wrapper-server:latest
         volumeMounts:
           - name: kaniko-secret
             mountPath: /kaniko/.docker/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
             "mode": "auto",
             "program": "${workspaceFolder}/func/client/main.go",
             "args": [
-                "--address=192.168.8.202:9445",
+                "--address=172.18.255.201:9445",
                 "--package=${workspaceFolder}/func/config/",
                 "--image=gcr.io/kpt-fn/set-namespace:v0.2.0",
                 "--",

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ PORCH_CONTROLLERS_IMAGE ?= porch-controllers
 PORCH_WRAPPER_SERVER_IMAGE ?= porch-wrapper-server
 TEST_GIT_SERVER_IMAGE ?= test-git-server
 SKIP_IMG_BUILD ?= false
+SKIP_PORCHSERVER_BUILD ?= false
+SKIP_CONTROLLER_BUILD ?= false
 
 # Only enable a subset of reconcilers in porch controllers by default. Use the RECONCILERS
 # env variable to specify a specific list of reconcilers or use
@@ -262,30 +264,45 @@ load-images-to-kind: ## Build porch images and load them into a kind cluster
   ifeq ($(SKIP_IMG_BUILD), false)
   # only build test-git-server & function-runner if they are not already loaded into kind
 	@if ! docker exec "${KIND_CONTEXT_NAME}-control-plane" crictl images | grep -q "$(IMAGE_REPO)/$(TEST_GIT_SERVER_IMAGE)  *${IMAGE_TAG} " ; then \
+		echo "Building $(IMAGE_REPO)/$(TEST_GIT_SERVER_IMAGE):${IMAGE_TAG}" ; \
 		IMAGE_NAME="$(TEST_GIT_SERVER_IMAGE)" make -C test/ build-image ; \
 		kind load docker-image $(IMAGE_REPO)/$(TEST_GIT_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
 	else \
 		echo "Skipping building $(IMAGE_REPO)/$(TEST_GIT_SERVER_IMAGE):${IMAGE_TAG} as it is already loaded into kind" ; \
 	fi
 	@if ! docker exec "${KIND_CONTEXT_NAME}-control-plane" crictl images | grep -q "$(IMAGE_REPO)/$(PORCH_FUNCTION_RUNNER_IMAGE)  *${IMAGE_TAG} " ; then \
+		echo "Building $(IMAGE_REPO)/$(PORCH_FUNCTION_RUNNER_IMAGE):${IMAGE_TAG}" ; \
 		IMAGE_NAME="$(PORCH_FUNCTION_RUNNER_IMAGE)" WRAPPER_SERVER_IMAGE_NAME="$(PORCH_WRAPPER_SERVER_IMAGE)" make -C func/ build-image ; \
 		kind load docker-image $(IMAGE_REPO)/$(PORCH_FUNCTION_RUNNER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
 		kind load docker-image $(IMAGE_REPO)/$(PORCH_WRAPPER_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
 	else \
 		echo "Skipping building $(IMAGE_REPO)/$(PORCH_FUNCTION_RUNNER_IMAGE):${IMAGE_TAG} as it is already loaded into kind" ; \
 	fi
-  # always rebuild porch-server and controllers
-	docker buildx build --load --tag $(IMAGE_REPO)/$(PORCH_SERVER_IMAGE):$(IMAGE_TAG) -f ./build/Dockerfile "$(PORCHDIR)"
-	IMAGE_NAME="$(PORCH_CONTROLLERS_IMAGE)" make -C controllers/ build-image
-  endif
+    # NOTE: SKIP_PORCHSERVER_BUILD must be evaluated at runtime, hence the shell conditional (if) here
+	@if [ "$(SKIP_PORCHSERVER_BUILD)" = "false"	]; then \
+		echo "Building $(IMAGE_REPO)/$(PORCH_SERVER_IMAGE):${IMAGE_TAG}" ; \
+		docker buildx build --load --tag $(IMAGE_REPO)/$(PORCH_SERVER_IMAGE):$(IMAGE_TAG) -f ./build/Dockerfile "$(PORCHDIR)" ; \
+		kind load docker-image $(IMAGE_REPO)/$(PORCH_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
+	fi
+	@if [ "$(SKIP_CONTROLLER_BUILD)" = "false"	]; then \
+		echo "Building $(IMAGE_REPO)/$(PORCH_CONTROLLERS_IMAGE):${IMAGE_TAG}" ; \
+		IMAGE_NAME="$(PORCH_CONTROLLERS_IMAGE)" make -C controllers/ build-image ; \
+		kind load docker-image $(IMAGE_REPO)/$(PORCH_CONTROLLERS_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
+	fi
+
+  else
+	kind load docker-image $(IMAGE_REPO)/$(TEST_GIT_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
+	kind load docker-image $(IMAGE_REPO)/$(PORCH_FUNCTION_RUNNER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
+	kind load docker-image $(IMAGE_REPO)/$(PORCH_WRAPPER_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME} ; \
 	kind load docker-image $(IMAGE_REPO)/$(PORCH_SERVER_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME}
 	kind load docker-image $(IMAGE_REPO)/$(PORCH_CONTROLLERS_IMAGE):${IMAGE_TAG} -n ${KIND_CONTEXT_NAME}
+  endif
 
 .PHONY: deploy-current-config
 deploy-current-config: ## Deploy the configuration that is currently in $(DEPLOYPORCHCONFIGDIR)
 	kpt fn render $(DEPLOYPORCHCONFIGDIR)
 	kpt live init $(DEPLOYPORCHCONFIGDIR) --name porch --namespace porch-system --inventory-id porch-test || true
-	kpt live apply --inventory-policy=adopt --server-side $(DEPLOYPORCHCONFIGDIR)
+	kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
 	@kubectl rollout status deployment function-runner --namespace porch-system 2>/dev/null || true
 	@kubectl rollout status deployment porch-controllers --namespace porch-system 2>/dev/null || true
 	@kubectl rollout status deployment porch-server --namespace porch-system 2>/dev/null || true
@@ -299,11 +316,13 @@ run-in-kind: load-images-to-kind deployment-config deploy-current-config ## Buil
 .PHONY: run-in-kind-no-server
 run-in-kind-no-server: IMAGE_REPO=porch-kind
 run-in-kind-no-server: IMAGE_TAG=test
+run-in-kind-no-server: SKIP_PORCHSERVER_BUILD=true
 run-in-kind-no-server: load-images-to-kind deployment-config-no-server deploy-current-config ## Build and deploy porch without the porch-server into a kind cluster
 
 .PHONY: run-in-kind-no-controller
 run-in-kind-no-controller: IMAGE_REPO=porch-kind
 run-in-kind-no-controller: IMAGE_TAG=test
+run-in-kind-no-controller: SKIP_CONTROLLER_BUILD=true
 run-in-kind-no-controller: load-images-to-kind deployment-config-no-controller deploy-current-config ## Build and deploy porch without the controllers into a kind cluster
 
 .PHONY: destroy


### PR DESCRIPTION
This PR contains:
* FIX for a prow issue introduced by #72 
* new make target called `destroy` that deletes the current porch deployment
* better strategy to keep (kpt) state between porch deployments (instead of trying to preserve the `resourcegroup.yaml` file)
* use server-side apply for porch deployments
* do not build container images of locally running processes
* fix function-runner IP address in `.vscode/launch.json`

WARNING: unfortunately the new porch deploy method conflicts with the old one, so you have to delete and recreate your kind cluster after this change is merged into your local setup. 