### PR TITLE
Ignore ARM architecture warning on e2e test results

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -158,10 +158,11 @@ func runTestCase(t *testing.T, repoURL string, tc TestCaseConfig, searchAndRepla
 		if got, want := stdoutStr, command.Stdout; got != want {
 			t.Errorf("unexpected stdout content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
 		}
-		if got, want := stderrStr, command.Stderr; got != want {
-			if !ignoreArmPlatformWarning(got) {
-				t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
-			}
+		got, want := stderrStr, command.Stderr
+		got = removeArmPlatformWarning(got)
+
+		if got != want {
+			t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
 		}
 
 		// hack here; but if the command registered a repo, give a few extra seconds for the repo to reach readiness
@@ -177,10 +178,20 @@ func runTestCase(t *testing.T, repoURL string, tc TestCaseConfig, searchAndRepla
 	}
 }
 
-func ignoreArmPlatformWarning(got string) bool {
-	return strings.HasSuffix(
+func removeArmPlatformWarning(got string) string {
+	got = strings.Replace(
 		got,
-		"  Stderr:\n    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\"\n")
+		"    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\"\n",
+		"",
+		1)
+
+	if strings.HasSuffix(got, "  Stderr:\n") {
+		// The warning message was the only message on stderr
+		return strings.Replace(got, "  Stderr:\n", "", 1)
+	} else {
+		// There are other messages on stderr, so leave the "Stderr:"" tag in place
+		return got
+	}
 }
 
 // remove PASS lines from kpt fn eval, which includes a duration and will vary

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -159,7 +159,9 @@ func runTestCase(t *testing.T, repoURL string, tc TestCaseConfig, searchAndRepla
 			t.Errorf("unexpected stdout content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
 		}
 		if got, want := stderrStr, command.Stderr; got != want {
-			t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+			if !ignoreArmPlatformWarning(got) {
+				t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+			}
 		}
 
 		// hack here; but if the command registered a repo, give a few extra seconds for the repo to reach readiness
@@ -173,6 +175,12 @@ func runTestCase(t *testing.T, repoURL string, tc TestCaseConfig, searchAndRepla
 	if os.Getenv(updateGoldenFiles) != "" {
 		WriteTestCaseConfig(t, &tc)
 	}
+}
+
+func ignoreArmPlatformWarning(got string) bool {
+	return strings.HasSuffix(
+		got,
+		"  Stderr:\n    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\"\n")
 }
 
 // remove PASS lines from kpt fn eval, which includes a duration and will vary


### PR DESCRIPTION
When running the Porch end to end tests on ARM architecture, kpt issues the warning below when it's images don't match the host machine's architecture:

`WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`

However, regardless of the warning above, the kpt command does work.

Currently, the test code checks if there is anything on stderr in the test and fails if there is. This PR adds code that if the only output on standard output is the warning message above, then the warning is ignored. If there is anything else on the standard error, then the test will fail.