### PR TITLE
Porchctl dev release workflow

### DIFF
--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: porchctl dev release
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: porchctl-dev-release
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.2'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: make porchctl
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .build/porchctl
+          asset_name: porchctl
+          tag: ${{ github.ref }}
+          overwrite: true
+          prerelease: true
+          release_name: Porchctl build from main
+          body: "This is dev porchctl binary built from main each merge"
+


### PR DESCRIPTION
This workflow will build porchctl binary from 'main' branch with just 'make porchctl' each successful merge. This binary whill then be used for e2e tests running 'main'.
Workflow will create release called 'Porchctl build from main' and replace it each build so it's always latest.