### PR TITLE
Fix the porchctl build to run on Ubuntu 20.04

### DIFF
--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: porchctl-dev-release
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
This PR fixes the `porchctl` command so that it runs on Ubuntu 20.04. The `porchctl` command must be built on the same or an earlier Ubuntu version as the e2e tests or it won't run in the e2e tests and will break the tests.