### PR TITLE
Porchctl command fixes:

### DIFF
--- a/pkg/cli/commands/repo/get/command.go
+++ b/pkg/cli/commands/repo/get/command.go
@@ -79,6 +79,13 @@ func (r *runner) preRunE(cmd *cobra.Command, _ []string) error {
 	} else {
 		r.requestTable = true
 	}
+
+	allNamespacesFlag := cmd.Flags().Lookup("all-namespaces").Value.String()
+	if strings.Contains(allNamespacesFlag, "true") {
+		r.printFlags.HumanReadableFlags.WithNamespace = true
+	} else {
+		r.printFlags.HumanReadableFlags.WithNamespace = false
+	}
 	return nil
 }
 

--- a/pkg/cli/commands/repo/reg/command.go
+++ b/pkg/cli/commands/repo/reg/command.go
@@ -88,6 +88,15 @@ type runner struct {
 
 func (r *runner) preRunE(_ *cobra.Command, _ []string) error {
 	const op errors.Op = command + ".preRunE"
+	if *r.cfg.Namespace == "" {
+		// Get the namespace from kubeconfig
+		namespace, _, err := r.cfg.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return fmt.Errorf("error getting namespace: %w", err)
+		}
+		r.cfg.Namespace = &namespace
+	}
+
 	client, err := porch.CreateClientWithFlags(r.cfg)
 	if err != nil {
 		return errors.E(op, err)

--- a/pkg/cli/commands/repo/unreg/command.go
+++ b/pkg/cli/commands/repo/unreg/command.go
@@ -71,6 +71,15 @@ type runner struct {
 
 func (r *runner) preRunE(_ *cobra.Command, _ []string) error {
 	const op errors.Op = command + ".preRunE"
+	if *r.cfg.Namespace == "" {
+		// Get the namespace from kubeconfig
+		namespace, _, err := r.cfg.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return fmt.Errorf("error getting namespace: %w", err)
+		}
+		r.cfg.Namespace = &namespace
+	}
+
 	client, err := porch.CreateClientWithFlags(r.cfg)
 	if err != nil {
 		return errors.E(op, err)


### PR DESCRIPTION
Fixes for porchctl repo commands described in https://github.com/nephio-project/nephio/issues/755 issue.

- repo get: Output n=Namespace column when `-A/--all` flag specified.
- repo reg: Use kubeconfig context namespace if `-n/--namespace` flag not provided.
- repo unreg: Use kubeconfig context namespace if `-n/--namespace` flag not provided.

I've resubmitted this PR under new GH account to be able to sign the corporate CDL.

I would need guidance on how to approach tests for the commands. I've noticed the `repo reg` command uses a fake porch server to handle the tests cases. Should I follow suit for commands affected by this PR?