### PR TITLE
#678: Blueprint isn't immediately available after creation

### DIFF
--- a/pkg/cache/repository.go
+++ b/pkg/cache/repository.go
@@ -87,6 +87,13 @@ func newRepository(id string, repoSpec *configapi.Repository, repo repository.Re
 	return r
 }
 
+func (r *cachedRepository) RefreshCache(ctx context.Context) error {
+
+	_, _, err := r.refreshAllCachedPackages(ctx)
+
+	return err
+}
+
 func (r *cachedRepository) Version(ctx context.Context) (string, error) {
 	return r.repo.Version(ctx)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -706,6 +706,15 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 
 	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
 	klog.Infof("engine: sent %d for updated PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
+
+	// Refresh Cache after package is approved so that 'main' package rev is available instantly after creation
+	if repoPkgRev.Lifecycle() == api.PackageRevisionLifecyclePublished {
+		err := repo.RefreshCache(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 }
 


### PR DESCRIPTION
This change refreshes the cache every time an approve is called so that the main twin of the package is immediately available. 