### PR TITLE
Make the default value of Repository's spec.git.branch field explicit

### DIFF
--- a/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -77,9 +77,11 @@ spec:
                   Ignored if `type` is not `git`.
                 properties:
                   branch:
+                    default: main
                     description: Name of the branch containing the packages. Finalized
                       packages will be committed to this branch (if the repository
                       allows write access). If unspecified, defaults to "main".
+                    minLength: 1
                     type: string
                   createBranch:
                     description: CreateBranch specifies if Porch should create the
@@ -176,9 +178,11 @@ spec:
                       Must be unspecified if `type` is not `git`.
                     properties:
                       branch:
+                        default: main
                         description: Name of the branch containing the packages. Finalized
                           packages will be committed to this branch (if the repository
                           allows write access). If unspecified, defaults to "main".
+                        minLength: 1
                         type: string
                       createBranch:
                         description: CreateBranch specifies if Porch should create

--- a/api/porchconfig/v1alpha1/types.go
+++ b/api/porchconfig/v1alpha1/types.go
@@ -92,6 +92,8 @@ type GitRepository struct {
 	// Address of the Git repository, for example:
 	//   `https://github.com/GoogleCloudPlatform/blueprints.git`
 	Repo string `json:"repo"`
+	// +kubebuilder:default=main
+	// +kubebuilder:validation:MinLength=1
 	// Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
 	Branch string `json:"branch,omitempty"`
 	// CreateBranch specifies if Porch should create the package branch if it doesn't exist.

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -121,7 +121,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 		return nil, fmt.Errorf("error cloning git repository %q, cannot create remote: %v", spec.Repo, err)
 	}
 
-	// NOTE: the spec.git.branch field in the Repository CRD (OpenAPI schema) defined with
+	// NOTE: the spec.git.branch field in the Repository CRD (OpenAPI schema) is defined with
 	//		 MinLength=1 validation and its default value is set to "main". This means that
 	// 		 it should never be empty at this point. The following code is left here as a last resort failsafe.
 	branch := MainBranch


### PR DESCRIPTION
Set the default value for the "main" branch in the OpenAPI schema part of the Repository CRD, and reject empty values for this field.

This PR doesn't really change the behavior of Repository: the branch field remains optional, and the default value of "main" will be applied if omitted. 
The two differences that the PR introduces are:
- the value "main" will be visible in the Repository object when queried (e.g. by the Get/List operation), even if it wasn't set explicitly upon creation
- setting the branch name explicitly to the empty string is not allowed anymore, and will cause the object creation to be rejected

The last point in more detail:
- omitting the `spec.git.branch` field is accepted and assigns the default value ("main") to the branch field:
- this is accepted and assigns the default value ("main") to the branch field:
```YAML
apiVersion: config.porch.kpt.dev/v1alpha1
kind: Repository
[...]
spec:
  git:
    branch: 
```

- setting the field explicitly to the empty string is NOT accepted and the creation of the Repository object will be rejected. E.g.: 
```YAML
apiVersion: config.porch.kpt.dev/v1alpha1
kind: Repository
[...]
spec:
  git:
    branch: ""
```

Fixes https://github.com/nephio-project/nephio/issues/787