### PR TITLE
fix porchсtl push method for windows

### DIFF
--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -254,7 +254,12 @@ func readFromDir(dir string) (map[string]string, error) {
 	}); err != nil {
 		return nil, err
 	}
-	return resources, nil
+	newRes := make(map[string]string)
+	for key, value := range resources {
+		newKey := strings.ReplaceAll(key, "\\", "/")
+		newRes[newKey] = value
+	}
+	return newRes, nil
 }
 
 func readFromReader(in io.Reader) (map[string]string, error) {

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -256,7 +256,7 @@ func readFromDir(dir string) (map[string]string, error) {
 	}
 	newRes := make(map[string]string)
 	for key, value := range resources {
-		newKey := strings.ReplaceAll(key, "\\", "/")
+		newKey := filepath.ToSlash(key)
 		newRes[newKey] = value
 	}
 	return newRes, nil

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -249,17 +249,12 @@ func readFromDir(dir string) (map[string]string, error) {
 			// Return an early error here to prevent pushing corrupt content.
 			return fmt.Errorf("file %s is not a valid UTF-8 text file: current porch API doesn't support binary files", path)
 		}
-		resources[rel] = string(contents)
+		resources[filepath.ToSlash(rel)] = string(contents)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	newRes := make(map[string]string)
-	for key, value := range resources {
-		newKey := filepath.ToSlash(key)
-		newRes[newKey] = value
-	}
-	return newRes, nil
+	return resources, nil
 }
 
 func readFromReader(in io.Reader) (map[string]string, error) {


### PR DESCRIPTION
we are compiling the porchctl to use it on Windows. the proposed fix is changing the Windows path representation to the Unix-based one.