### PR TITLE
More sensible defaults for webhook environment variables

### DIFF
--- a/deployments/porch/5-rbac.yaml
+++ b/deployments/porch/5-rbac.yaml
@@ -38,7 +38,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["apiregistration.k8s.io"]
     resources: ["apiservices"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["get"]
   # Needed for priority and fairness
   - apiGroups: ["flowcontrol.apiserver.k8s.io"]
     resources: ["flowschemas", "prioritylevelconfigurations"]

--- a/deployments/porch/5-rbac.yaml
+++ b/deployments/porch/5-rbac.yaml
@@ -36,6 +36,9 @@ rules:
   - apiGroups: ["config.porch.kpt.dev"]
     resources: ["packagerevs", "packagerevs/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "watch", "list"]
   # Needed for priority and fairness
   - apiGroups: ["flowcontrol.apiserver.k8s.io"]
     resources: ["flowschemas", "prioritylevelconfigurations"]

--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -75,8 +75,8 @@ type WebhookConfig struct {
 	CertManWebhook   bool
 }
 
-// NewWebhookConfig creates a new WebhookConfig object filled with values read from environment variables
-func NewWebhookConfig(ctx context.Context) *WebhookConfig {
+// newWebhookConfig creates a new WebhookConfig object filled with values read from environment variables
+func newWebhookConfig(ctx context.Context) *WebhookConfig {
 	var cfg WebhookConfig
 	// NOTE: CERT_NAMESPACE is supported for backward compatibility.
 	// TODO: We may consider using only WEBHOOK_SERVICE_NAMESPACE instead.
@@ -86,7 +86,7 @@ func NewWebhookConfig(ctx context.Context) *WebhookConfig {
 		!hasEnv("WEBHOOK_HOST") {
 
 		cfg.Type = WebhookTypeService
-		cfg.ServiceName, cfg.ServiceNamespace = WebhookServiceName(ctx)
+		cfg.ServiceName, cfg.ServiceNamespace = webhookServiceName(ctx)
 		cfg.Host = fmt.Sprintf("%s.%s.svc", cfg.ServiceName, cfg.ServiceNamespace)
 	} else {
 		cfg.Type = WebhookTypeUrl
@@ -99,8 +99,8 @@ func NewWebhookConfig(ctx context.Context) *WebhookConfig {
 	return &cfg
 }
 
-// WebhookServiceName returns the name and namespace of Kubernetes service belonging to the webhook
-func WebhookServiceName(ctx context.Context) (serviceName, serviceNamespace string) {
+// webhookServiceName returns the name and namespace of Kubernetes service belonging to the webhook
+func webhookServiceName(ctx context.Context) (serviceName, serviceNamespace string) {
 	var apiSvcNs string
 
 	// the webhook service namespace gets it value from the following sources in order of precedence:
@@ -151,7 +151,7 @@ func WebhookServiceName(ctx context.Context) (serviceName, serviceNamespace stri
 }
 
 func setupWebhooks(ctx context.Context) error {
-	cfg := NewWebhookConfig(ctx)
+	cfg := newWebhookConfig(ctx)
 	if !cfg.CertManWebhook {
 		caBytes, err := createCerts(cfg)
 		if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"os"
 
+	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	registrationapi "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -76,15 +79,24 @@ func GetPorchApiServiceKey(ctx context.Context) (client.ObjectKey, error) {
 	}
 
 	apiSvc := registrationapi.APIService{}
+	apiSvcName := porchapi.SchemeGroupVersion.Version + "." + porchapi.SchemeGroupVersion.Group
 	err = c.Get(ctx, client.ObjectKey{
-		Name: "v1alpha1.porch.kpt.dev",
+		Name: apiSvcName,
 	}, &apiSvc)
 	if err != nil {
-		return client.ObjectKey{}, fmt.Errorf("failed to get APIService 'v1alpha1.porch.kpt.dev': %w", err)
+		return client.ObjectKey{}, fmt.Errorf("failed to get APIService %q: %w", apiSvcName, err)
 	}
 
 	return client.ObjectKey{
 		Namespace: apiSvc.Spec.Service.Namespace,
 		Name:      apiSvc.Spec.Service.Name,
 	}, nil
+}
+
+func SchemaToMetaGVR(gvr schema.GroupVersionResource) metav1.GroupVersionResource {
+	return metav1.GroupVersionResource{
+		Group:    gvr.Group,
+		Version:  gvr.Version,
+		Resource: gvr.Resource,
+	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,10 +15,16 @@
 package util
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
 	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	registrationapi "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // KubernetesName returns the passed id if it less than maxLen, otherwise
@@ -45,7 +51,40 @@ func KubernetesName(id string, hashLen, maxLen int) string {
 func GetInClusterNamespace() (string, error) {
 	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
-		return "", fmt.Errorf("failed to read namespace: %w", err)
+		return "", fmt.Errorf("failed to read in-cluster namespace: %w", err)
 	}
 	return string(ns), nil
+}
+
+func GetPorchApiServiceKey(ctx context.Context) (client.ObjectKey, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return client.ObjectKey{}, fmt.Errorf("failed to get K8s config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	err = registrationapi.AddToScheme(scheme)
+	if err != nil {
+		return client.ObjectKey{}, fmt.Errorf("failed to add apiregistration API to scheme: %w", err)
+	}
+
+	c, err := client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return client.ObjectKey{}, fmt.Errorf("failed to create K8s client: %w", err)
+	}
+
+	apiSvc := registrationapi.APIService{}
+	err = c.Get(ctx, client.ObjectKey{
+		Name: "v1alpha1.porch.kpt.dev",
+	}, &apiSvc)
+	if err != nil {
+		return client.ObjectKey{}, fmt.Errorf("failed to get APIService 'v1alpha1.porch.kpt.dev': %w", err)
+	}
+
+	return client.ObjectKey{
+		Namespace: apiSvc.Spec.Service.Namespace,
+		Name:      apiSvc.Spec.Service.Name,
+	}, nil
 }

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -158,7 +158,7 @@ func (t *TestSuite) IsPorchServerInCluster() bool {
 	porch := aggregatorv1.APIService{}
 	ctx := context.TODO()
 	t.GetF(ctx, client.ObjectKey{
-		Name: "v1alpha1.porch.kpt.dev",
+		Name: porchapi.SchemeGroupVersion.Version + "." + porchapi.SchemeGroupVersion.Group,
 	}, &porch)
 	service := coreapi.Service{}
 	t.GetF(ctx, client.ObjectKey{
@@ -173,7 +173,7 @@ func (t *TestSuite) IsTestRunnerInCluster() bool {
 	porch := aggregatorv1.APIService{}
 	ctx := context.TODO()
 	t.GetF(ctx, client.ObjectKey{
-		Name: "v1alpha1.porch.kpt.dev",
+		Name: porchapi.SchemeGroupVersion.Version + "." + porchapi.SchemeGroupVersion.Group,
 	}, &porch)
 	service := coreapi.Service{}
 	err := t.client.Get(ctx, client.ObjectKey{


### PR DESCRIPTION
Remove hardwired string literals as the default values of WEBHOOK_SERVICE_NAME and WEBHOOK_SERVICE_NAMESPACE environment variables.

This PR introduces the following changes in behavior:

The value of WEBHOOK_SERVICE_NAME is determined by one of the followings (in precedence order):
- the WEBHOOK_SERVICE_NAME environment variable
- the name of the service specified in the `APIService` object named `v1alpha1.porch.kpt.dev`

The value of WEBHOOK_SERVICE_NAMESPACE is determined by one of the followings (in precedence order):
- the WEBHOOK_SERVICE_NAMESPACE environment variable
- the CERT_NAMESPACE environment variable (deprecated, please don't use this!!!)
- the namespace of the service specified in the `APIService` object named `v1alpha1.porch.kpt.dev`
- namespace of the current process (if running in a pod)

