### PR TITLE
Fix minor warnings in Dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /go/src
 

--- a/build/Dockerfile.apiserver
+++ b/build/Dockerfile.apiserver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /workspace/src
 RUN git clone https://github.com/kubernetes/kubernetes --branch v1.30.1 --depth=1

--- a/build/Dockerfile.etcd
+++ b/build/Dockerfile.etcd
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /workspace
 ARG ETCD_VER=v3.5.1

--- a/controllers/Dockerfile
+++ b/controllers/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /go/src
 

--- a/examples/apps/hello-server/Dockerfile
+++ b/examples/apps/hello-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/func/Dockerfile
+++ b/func/Dockerfile
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/kpt-fn/apply-setters:v0.2.0 as apply-setters
-FROM gcr.io/kpt-fn/apply-setters:v0.1.1 as apply-setters-v1
-FROM gcr.io/kpt-fn/ensure-name-substring:v0.1.1 as ensure-name-substring
-FROM gcr.io/kpt-fn/search-replace:v0.2.0 as search-replace
-FROM gcr.io/kpt-fn/set-annotations:v0.1.4 as set-annotations
-FROM gcr.io/kpt-fn/set-image:v0.1.0 as set-image
-FROM gcr.io/kpt-fn/set-labels:v0.1.5 as set-labels
-FROM gcr.io/kpt-fn/set-namespace:v0.2.0 as set-namespace
-FROM gcr.io/kpt-fn/set-namespace:v0.3.4 as set-namespace-v3
-FROM gcr.io/kpt-fn/set-project-id:v0.2.0 as set-project-id
-FROM gcr.io/kpt-fn/starlark:v0.3.0 as starlark
-FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 as upsert-resource
+FROM gcr.io/kpt-fn/apply-setters:v0.2.0 AS apply-setters
+FROM gcr.io/kpt-fn/apply-setters:v0.1.1 AS apply-setters-v1
+FROM gcr.io/kpt-fn/ensure-name-substring:v0.1.1 AS ensure-name-substring
+FROM gcr.io/kpt-fn/search-replace:v0.2.0 AS search-replace
+FROM gcr.io/kpt-fn/set-annotations:v0.1.4 AS set-annotations
+FROM gcr.io/kpt-fn/set-image:v0.1.0 AS set-image
+FROM gcr.io/kpt-fn/set-labels:v0.1.5 AS set-labels
+FROM gcr.io/kpt-fn/set-namespace:v0.2.0 AS set-namespace
+FROM gcr.io/kpt-fn/set-namespace:v0.3.4 AS set-namespace-v3
+FROM gcr.io/kpt-fn/set-project-id:v0.2.0 AS set-project-id
+FROM gcr.io/kpt-fn/starlark:v0.3.0 AS starlark
+FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 AS upsert-resource
 
-FROM golang:1.22.1-alpine3.18 as builder
+FROM golang:1.22.1-alpine3.18 AS builder
 WORKDIR /go/src
 
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11

--- a/func/Dockerfile-wrapperserver
+++ b/func/Dockerfile-wrapperserver
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-alpine3.18 as builder
+FROM golang:1.22.1-alpine3.18 AS builder
 
 WORKDIR /go/src
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.22.2-bookworm as builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /go/src
 


### PR DESCRIPTION
New versions of docker reports warnings like the following while building our Dockerfiles:
`=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 15)`

This trivial PR fixes those.