### PR TITLE
 Retry 'Update' operations that are failing due to normal optimistic locking behavior in CLI commands

### DIFF
--- a/pkg/cli/commands/rpkg/propose/command_test.go
+++ b/pkg/cli/commands/rpkg/propose/command_test.go
@@ -63,7 +63,7 @@ func TestCmd(t *testing.T) {
 			lc:     porchapi.PackageRevisionLifecycleDraft,
 		},
 		"Cannot propose package": {
-			output:  "cannot propose Published package\n",
+			output:  pkgRevName + " failed (cannot propose Published package)\n",
 			lc:      porchapi.PackageRevisionLifecyclePublished,
 			wantErr: true,
 		},

--- a/pkg/cli/commands/rpkg/proposedelete/command.go
+++ b/pkg/cli/commands/rpkg/proposedelete/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/docs"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,39 +84,40 @@ func (r *runner) runE(_ *cobra.Command, args []string) error {
 	namespace := *r.cfg.Namespace
 
 	for _, name := range args {
-		pr := &v1alpha1.PackageRevision{}
-		if err := r.client.Get(r.ctx, client.ObjectKey{
+		key := client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
-		}, pr); err != nil {
-			return errors.E(op, err)
 		}
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var pr v1alpha1.PackageRevision
+			if err := r.client.Get(r.ctx, key, &pr); err != nil {
+				return err
+			}
 
-		switch pr.Spec.Lifecycle {
-		case v1alpha1.PackageRevisionLifecyclePublished:
-			// ok
-		case v1alpha1.PackageRevisionLifecycleDeletionProposed:
-			fmt.Fprintf(r.Command.OutOrStderr(), "%s is already proposed for deletion\n", name)
-			continue
-		default:
-			msg := fmt.Sprintf("can only propose published packages for deletion; package %s is not published", name)
-			messages = append(messages, msg)
-			fmt.Fprintln(r.Command.ErrOrStderr(), msg)
-			continue
-		}
+			switch pr.Spec.Lifecycle {
+			case v1alpha1.PackageRevisionLifecyclePublished:
+				pr.Spec.Lifecycle = v1alpha1.PackageRevisionLifecycleDeletionProposed
+				err := r.client.Update(r.ctx, &pr)
+				if err == nil {
+					fmt.Fprintf(r.Command.OutOrStdout(), "%s proposed for deletion\n", name)
+				}
+				return err
+			case v1alpha1.PackageRevisionLifecycleDeletionProposed:
+				fmt.Fprintf(r.Command.OutOrStderr(), "%s is already proposed for deletion\n", name)
+				return nil
+			default:
+				return fmt.Errorf("can only propose published packages for deletion; package %s is not published", name)
+			}
 
-		pr.Spec.Lifecycle = v1alpha1.PackageRevisionLifecycleDeletionProposed
-		if err := r.client.Update(r.ctx, pr); err != nil {
+		})
+		if err != nil {
 			messages = append(messages, err.Error())
 			fmt.Fprintf(r.Command.ErrOrStderr(), "%s failed (%s)\n", name, err)
-		} else {
-			fmt.Fprintf(r.Command.OutOrStdout(), "%s proposed for deletion\n", name)
 		}
 	}
 
 	if len(messages) > 0 {
 		return errors.E(op, fmt.Errorf("errors:\n  %s", strings.Join(messages, "\n  ")))
 	}
-
 	return nil
 }

--- a/pkg/cli/commands/rpkg/proposedelete/command_test.go
+++ b/pkg/cli/commands/rpkg/proposedelete/command_test.go
@@ -55,11 +55,12 @@ func TestCmd(t *testing.T) {
 		ns      string
 	}{
 		"Package not found in ns": {
+			output:  pkgRevName + " failed (packagerevisions.porch.kpt.dev \"" + pkgRevName + "\" not found)\n",
 			ns:      "doesnotexist",
 			wantErr: true,
 		},
 		"Package not published": {
-			output:  "can only propose published packages for deletion; package " + pkgRevName + " is not published\n",
+			output:  pkgRevName + " failed (can only propose published packages for deletion; package " + pkgRevName + " is not published)\n",
 			ns:      "ns",
 			wantErr: true,
 		},

--- a/pkg/cli/commands/rpkg/reject/command.go
+++ b/pkg/cli/commands/rpkg/reject/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/docs"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -85,41 +86,37 @@ func (r *runner) runE(_ *cobra.Command, args []string) error {
 	var messages []string
 
 	namespace := *r.cfg.Namespace
-
+	var proposedFor string
 	for _, name := range args {
-		pr := &v1alpha1.PackageRevision{}
-		if err := r.client.Get(r.ctx, client.ObjectKey{
+		key := client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
-		}, pr); err != nil {
-			return errors.E(op, err)
 		}
-		switch pr.Spec.Lifecycle {
-		case v1alpha1.PackageRevisionLifecycleProposed:
-			if err := porch.UpdatePackageRevisionApproval(r.ctx, r.client, client.ObjectKey{
-				Namespace: namespace,
-				Name:      name,
-			}, v1alpha1.PackageRevisionLifecycleDraft); err != nil {
-				messages = append(messages, err.Error())
-				fmt.Fprintf(r.Command.ErrOrStderr(), "%s failed (%s)\n", name, err)
-			} else {
-				fmt.Fprintf(r.Command.OutOrStdout(), "%s rejected\n", name)
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var pr v1alpha1.PackageRevision
+			if err := r.client.Get(r.ctx, key, &pr); err != nil {
+				return err
 			}
-		case v1alpha1.PackageRevisionLifecycleDeletionProposed:
-			pr.Spec.Lifecycle = v1alpha1.PackageRevisionLifecyclePublished
-			if err := r.client.Update(r.ctx, pr); err != nil {
-				messages = append(messages, err.Error())
-				fmt.Fprintf(r.Command.ErrOrStderr(), "%s failed (%s)\n", name, err)
-			} else {
-				fmt.Fprintf(r.Command.OutOrStdout(), "%s no longer proposed for deletion\n", name)
+			switch pr.Spec.Lifecycle {
+			case v1alpha1.PackageRevisionLifecycleProposed:
+				proposedFor = "approval"
+				return porch.UpdatePackageRevisionApproval(r.ctx, r.client, &pr, v1alpha1.PackageRevisionLifecycleDraft)
+			case v1alpha1.PackageRevisionLifecycleDeletionProposed:
+				proposedFor = "deletion"
+				// NOTE(kispaljr): should we use UpdatePackageRevisionApproval() here?
+				pr.Spec.Lifecycle = v1alpha1.PackageRevisionLifecyclePublished
+				return r.client.Update(r.ctx, &pr)
+			default:
+				return fmt.Errorf("cannot reject %s with lifecycle '%s'", name, pr.Spec.Lifecycle)
 			}
-		default:
-			msg := fmt.Sprintf("cannot reject %s with lifecycle '%s'", name, pr.Spec.Lifecycle)
-			messages = append(messages, msg)
-			fmt.Fprintln(r.Command.ErrOrStderr(), msg)
+		})
+		if err != nil {
+			messages = append(messages, err.Error())
+			fmt.Fprintf(r.Command.ErrOrStderr(), "%s failed (%s)\n", name, err)
+		} else {
+			fmt.Fprintf(r.Command.OutOrStdout(), "%s no longer proposed for %s\n", name, proposedFor)
 		}
 	}
-
 	if len(messages) > 0 {
 		return errors.E(op, fmt.Errorf("errors:\n  %s", strings.Join(messages, "\n  ")))
 	}

--- a/pkg/cli/commands/rpkg/reject/command_test.go
+++ b/pkg/cli/commands/rpkg/reject/command_test.go
@@ -58,6 +58,7 @@ func TestCmd(t *testing.T) {
 		fakeclient client.WithWatch
 	}{
 		"Package not found in ns": {
+			output:  pkgRevName + " failed (packagerevisions.porch.kpt.dev \"" + pkgRevName + "\" not found)\n",
 			wantErr: true,
 			fakeclient: fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(&porchapi.PackageRevision{
@@ -93,7 +94,7 @@ func TestCmd(t *testing.T) {
 		},
 		"Reject draft package": {
 			wantErr: true,
-			output:  "cannot reject " + pkgRevName + " with lifecycle 'Draft'\n",
+			output:  pkgRevName + " failed (cannot reject " + pkgRevName + " with lifecycle 'Draft')\n",
 			fakeclient: fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(&porchapi.PackageRevision{
 					TypeMeta: metav1.TypeMeta{
@@ -111,7 +112,7 @@ func TestCmd(t *testing.T) {
 		},
 		"Reject published package": {
 			wantErr: true,
-			output:  "cannot reject " + pkgRevName + " with lifecycle 'Published'\n",
+			output:  pkgRevName + " failed (cannot reject " + pkgRevName + " with lifecycle 'Published')\n",
 			fakeclient: fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(&porchapi.PackageRevision{
 					TypeMeta: metav1.TypeMeta{
@@ -128,7 +129,7 @@ func TestCmd(t *testing.T) {
 					}}).Build(),
 		},
 		"Reject proposed package": {
-			output: pkgRevName + " rejected\n",
+			output: pkgRevName + " no longer proposed for approval\n",
 			fakeclient: fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
 				//fake subresourceupdate
 				SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {

--- a/scripts/cleanup-after-tests.sh
+++ b/scripts/cleanup-after-tests.sh
@@ -9,4 +9,4 @@ rm -rf "$self_dir/../.cache"
 
 kubectl get packagerev -A --no-headers | awk '{ print "-n", $1, $2 }' | xargs -L 1 --no-run-if-empty kubectl patch packagerev --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
 
-kubectl get ns -o name --no-headers | grep test | xargs -L 1 --no-run-if-empty kubectl delete
+kubectl get ns -o name --no-headers | egrep '(test|rpkg-|repo-)' | xargs -L 1 --no-run-if-empty kubectl delete

--- a/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
@@ -14,7 +14,8 @@ commands:
       - --repository=git
       - --workspace=lifecycle
       - lifecycle-package
-    stdout: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 created\n"
+    stdout: |
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 created
   - args:
       - porchctl
       - rpkg
@@ -29,11 +30,8 @@ commands:
       - propose-delete
       - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
       - --namespace=rpkg-lifecycle
+    stderr: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published)\nError: errors:\n  can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published \n"
     exitCode: 1
-    stderr: |
-      can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published
-      Error: errors:
-        can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published 
   - args:
       - porchctl
       - rpkg
@@ -51,7 +49,7 @@ commands:
       - --namespace=rpkg-lifecycle
       - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
     stdout: |
-      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 rejected
+      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 no longer proposed for approval
   - args:
       - porchctl
       - rpkg
@@ -67,11 +65,8 @@ commands:
       - propose-delete
       - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
       - --namespace=rpkg-lifecycle
+    stderr: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published)\nError: errors:\n  can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published \n"
     exitCode: 1
-    stderr: |
-      can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published
-      Error: errors:
-        can only propose published packages for deletion; package git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 is not published 
   - args:
       - porchctl
       - rpkg
@@ -112,11 +107,8 @@ commands:
       - delete
       - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
       - --namespace=rpkg-lifecycle
+    stderr: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (admission webhook \"packagerevdeletion.google.com\" denied the request: failed to delete package revision \"git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034\": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion)\nError: errors:\n  admission webhook \"packagerevdeletion.google.com\" denied the request: failed to delete package revision \"git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034\": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion \n"
     exitCode: 1
-    stderr: |
-      git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (admission webhook "packagerevdeletion.google.com" denied the request: failed to delete package revision "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion)
-      Error: errors:
-        admission webhook "packagerevdeletion.google.com" denied the request: failed to delete package revision "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion 
   - args:
       - porchctl
       - rpkg
@@ -156,10 +148,7 @@ commands:
       - reject
       - git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034
       - --namespace=rpkg-lifecycle
-    stderr: |
-      cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published'
-      Error: errors:
-        cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published' 
+    stderr: "git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 failed (cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published')\nError: errors:\n  cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published' \n"
     exitCode: 1
   - args:
       - porchctl


### PR DESCRIPTION
We are using the Update API operation in the porchctl CLI commands for multiple purposes. Those can fail due to normal optimistic locking behavior if another process tries to manipulate the same object (typically PackageRevision) in parallel. In a reconciliation loop these naturally occurring errors correctly cause a retry, but in the CLI these errors cause the command to fail. 
This PR adds a retry loop around those Update calls, thus implementing default optimistic locking behavior.
This should fix some flaky errors that we experienced in our Nephio end-to-end tests, e.g.: https://github.com/nephio-project/nephio/issues/803. 

NOTE: using server-side apply instead of Update doesn't work when we try to change the lifecycle state of PackageRevisions, because of at least these two reasons:
- the porch API server doesn't support it
- we have to be sure what the current Lifecycle state of the PackageRevision is before applying the new state. Server-side apply doesn't provide this guarantee, but optimistic locking does.

Fixes https://github.com/nephio-project/nephio/issues/803