### PR TITLE
change trigger for porchctl release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ name: porchctl Release
 on:
   push:
     tags:
-      - "v[1-9].*.*"
+      - "v*[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:


### PR DESCRIPTION
It will only trigger on tag named in scheme vX.Y.Z  