### PR TITLE
GitHub Actions exclude -pre tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ name: porchctl Release
 on:
   push:
     tags:
-      - "v*[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]"
 
 jobs:
   build:


### PR DESCRIPTION
This will exclude -pre tags from triggers in release GitHub Actions 