### PR TITLE
Restore tutorial example configuration files

### DIFF
--- a/examples/config/tutorials/starting-with-porch/blueprints/initialized/.gitignore
+++ b/examples/config/tutorials/starting-with-porch/blueprints/initialized/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/Kptfile
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/Kptfile
@@ -1,0 +1,15 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+
+metadata:
+  name: network-function-auto-namespace
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+info:
+  description: Network Function with automatic namespace setting Blueprint
+
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configPath: package-context.yaml

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/README.md
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/README.md
@@ -1,0 +1,25 @@
+# Network Function
+
+## Description
+Network Function with automatic namespace Blueprint
+
+## Usage
+
+### Fetch the package
+```
+kpt pkg get $GIT_HOST/$GIT_USERNAME/$GIT_BLUEPRINTS_REPO[@VERSION] network-function-auto-namespace
+```
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+```
+kpt pkg tree network-function-auto-namespace
+```
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init network-function-auto-namespace
+kpt live apply network-function-auto-namespace --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/deployment.yaml
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-function-auto-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: network-function-auto-namespace
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: network-function-auto-namespace
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/package-context.yaml
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function-auto-namespace/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: default-namespace-name

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/Kptfile
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/Kptfile
@@ -1,0 +1,10 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+
+metadata:
+  name: network-function
+  annotations:
+    config.kubernetes.io/local-config: "true"
+
+info:
+  description: network function blueprint

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/README.md
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/README.md
@@ -1,0 +1,25 @@
+# Network Function
+
+## Description
+Network Function Blueprint
+
+## Usage
+
+### Fetch the package
+```
+kpt pkg get $GIT_HOST/$GIT_USERNAME/$GIT_BLUEPRINTS_REPO[@VERSION] network-function
+```
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+```
+kpt pkg tree network-function
+```
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init network-function
+kpt live apply network-function --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/deployment.yaml
+++ b/examples/config/tutorials/starting-with-porch/blueprints/local-changes/network-function/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-function
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: network-function
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: network-function
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/examples/config/tutorials/starting-with-porch/kind_edge1_cluster.yaml
+++ b/examples/config/tutorials/starting-with-porch/kind_edge1_cluster.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+
+name: edge1
+networking:
+  apiServerAddress: 127.0.0.1
+  apiServerPort: 31001
+  podSubnet: 10.98.0.0/16
+  serviceSubnet: 10.198.0.0/16
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30000
+    hostPort: 32001

--- a/examples/config/tutorials/starting-with-porch/kind_management_cluster.yaml
+++ b/examples/config/tutorials/starting-with-porch/kind_management_cluster.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+
+name: management
+networking:
+  apiServerAddress: 127.0.0.1
+  apiServerPort: 31000
+  podSubnet: 10.97.0.0/16
+  serviceSubnet: 10.197.0.0/16
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30000
+    hostPort: 32000
+  - containerPort: 3000 # Gitea NodePort
+    hostPort: 30600

--- a/examples/config/tutorials/starting-with-porch/kpt_packages/.gitignore
+++ b/examples/config/tutorials/starting-with-porch/kpt_packages/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/config/tutorials/starting-with-porch/metallb-conf.yaml
+++ b/examples/config/tutorials/starting-with-porch/metallb-conf.yaml
@@ -1,0 +1,15 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.255.200-172.18.255.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+  namespace: metallb-system
+

--- a/examples/config/tutorials/starting-with-porch/name-namespace-variant.yaml
+++ b/examples/config/tutorials/starting-with-porch/name-namespace-variant.yaml
@@ -1,0 +1,21 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+
+metadata:
+  name: network-function-auto-namespace
+  namespace: porch-demo
+
+spec:
+  upstream:
+    repo: management
+    package: network-function-auto-namespace
+    revision: v1
+  targets:
+  - repositories:
+    - name: edge1
+      packageNames:
+      - network-function-auto-namespace-x
+      - network-function-auto-namespace-y
+    template:
+      downstream:
+        packageExpr: "target.package + '-cumulonimbus'"

--- a/examples/config/tutorials/starting-with-porch/porch-repositories.yaml
+++ b/examples/config/tutorials/starting-with-porch/porch-repositories.yaml
@@ -1,0 +1,59 @@
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: Repository
+
+metadata:
+  name: edge1
+  namespace: porch-demo
+
+spec:
+  description: edge1
+  content: Package
+  deployment: true
+  type: git
+  git:
+    repo: http://172.18.255.200:3000/nephio/edge1.git
+    directory: /
+    branch: main
+    createBranch: true
+    secretRef:
+      name: gitea
+
+---
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: Repository
+
+metadata:
+  name: management
+  namespace: porch-demo
+
+spec:
+  description: management
+  content: Package
+  deployment: false
+  type: git
+  git:
+    repo: http://172.18.255.200:3000/nephio/management.git
+    directory: /
+    branch: main
+    secretRef:
+      name: gitea
+
+---
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: Repository
+
+metadata:
+  name: external-blueprints
+  namespace: porch-demo
+
+spec:
+  description: External blueprints
+  content: Package
+  deployment: false
+  type: git
+  git:
+    repo: https://github.com/nephio-project/free5gc-packages.git
+    directory: /
+    branch: main

--- a/examples/config/tutorials/starting-with-porch/repos/.gitignore
+++ b/examples/config/tutorials/starting-with-porch/repos/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/config/tutorials/starting-with-porch/simple-variant.yaml
+++ b/examples/config/tutorials/starting-with-porch/simple-variant.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+
+metadata:
+  name: network-function
+  namespace: porch-demo
+
+spec:
+  upstream:
+    repo: management
+    package: network-function
+    revision: v1
+  targets:
+  -  repositories:
+      - name: edge1
+        packageNames:
+        - network-function-b
+        - network-function-c

--- a/examples/config/tutorials/starting-with-porch/tmp_packages_for_deployment/.gitignore
+++ b/examples/config/tutorials/starting-with-porch/tmp_packages_for_deployment/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
When the tutorial documentation was moved to the "docs"repo, we did not move the example config into the examples directory in the Porch repo. This PR does that.