### PR TITLE
Add session-conflict resolution for concurrent CUD operations on package revisions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,14 +14,16 @@
                 "--secure-port=4443",
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
-                "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
+                "--function-runner=172.18.255.201:9445",
                 "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
             "env": { 
                 "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp", 
                 "WEBHOOK_HOST": "localhost",
-                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
+                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true",
+                "OTEL_SERVICE_NAME": "porch-server",
+                "OTEL": "otel://localhost:4317"
             }
         },
         {
@@ -37,17 +39,6 @@
             }
         },
         {
-            "name": "Run Porchctl command",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${workspaceFolder}/cmd/porchctl/main.go",
-            "args": [
-                "-n", "porch", "rpkg", "approve", "blueprints-835222fccff6e9e042e3b01b8c554f394d6e55d1"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
             "name": "Launch E2E tests",
             "type": "go",
             "request": "launch",
@@ -56,7 +47,7 @@
             "args": [
                 "-test.v",
                 "-test.run",
-                "TestE2E/PorchSuite/TestConcurrentDeletes"
+                "TestE2E/PorchSuite/TestGitRepositoryWithReleaseTagsAndDirectory"
             ],
             "env": { "E2E": "1"}
         },
@@ -74,12 +65,5 @@
                 "namespace=foo"
             ]
         }
-    ],
-    "compounds": [
-      {
-        "name": "Launch Server and Controllers",
-        "configurations": ["Launch Server", "Launch Controllers"],
-        "stopAll": true
-      }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,16 +14,14 @@
                 "--secure-port=4443",
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
-                "--function-runner=172.18.255.201:9445",
+                "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
                 "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
             "env": { 
                 "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp", 
                 "WEBHOOK_HOST": "localhost",
-                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true",
-                "OTEL_SERVICE_NAME": "porch-server",
-                "OTEL": "otel://localhost:4317"
+                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
             }
         },
         {
@@ -39,7 +37,7 @@
             }
         },
         {
-            "name": "Launch E2E tests",
+            "name": "Launch test function",
             "type": "go",
             "request": "launch",
             "mode": "test",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,18 @@
             }
         },
         {
-            "name": "Launch test function",
+            "name": "Run Porchctl command",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/porchctl/main.go",
+            "args": [
+                "-n", "porch", "rpkg", "approve", "blueprints-835222fccff6e9e042e3b01b8c554f394d6e55d1"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Launch E2E tests",
             "type": "go",
             "request": "launch",
             "mode": "test",
@@ -45,7 +56,7 @@
             "args": [
                 "-test.v",
                 "-test.run",
-                "TestE2E/PorchSuite/TestGitRepositoryWithReleaseTagsAndDirectory"
+                "TestE2E/PorchSuite/TestConcurrentInits"
             ],
             "env": { "E2E": "1"}
         },
@@ -63,5 +74,12 @@
                 "namespace=foo"
             ]
         }
+    ],
+    "compounds": [
+      {
+        "name": "Launch Server and Controllers",
+        "configurations": ["Launch Server", "Launch Controllers"],
+        "stopAll": true
+      }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
             "args": [
                 "-test.v",
                 "-test.run",
-                "TestE2E/PorchSuite/TestConcurrentInits"
+                "TestE2E/PorchSuite/TestConcurrentDeletes"
             ],
             "env": { "E2E": "1"}
         },

--- a/pkg/cache/repository.go
+++ b/pkg/cache/repository.go
@@ -319,6 +319,7 @@ func (r *cachedRepository) DeletePackage(ctx context.Context, old repository.Pac
 }
 
 func (r *cachedRepository) Close() error {
+	r.pollOnce(context.TODO())
 	r.cancel()
 
 	// Make sure that watch events are sent for packagerevisions that are
@@ -338,12 +339,13 @@ func (r *cachedRepository) Close() error {
 			// There isn't much use in returning an error here, so we just log it
 			// and create a PackageRevisionMeta with just name and namespace. This
 			// makes sure that the Delete event is sent.
-			klog.Warningf("Error looking up PackageRev CR for %s: %v", nn.Name, err)
+			klog.Warningf("Error deleting PackageRev CR for %s: %v", nn.Name, err)
 			pkgRevMeta = meta.PackageRevisionMeta{
 				Name:      nn.Name,
 				Namespace: nn.Namespace,
 			}
 		}
+		klog.Infof("repo %s: successfully deleted packagerev %s/%s", r.id, nn.Namespace, nn.Name)
 		sent += r.objectNotifier.NotifyPackageRevisionChange(watch.Deleted, pr, pkgRevMeta)
 	}
 	klog.Infof("repo %s: sent %d notifications for %d package revisions during close", r.id, sent, len(r.cachedPackageRevisions))

--- a/pkg/cache/repository.go
+++ b/pkg/cache/repository.go
@@ -319,7 +319,6 @@ func (r *cachedRepository) DeletePackage(ctx context.Context, old repository.Pac
 }
 
 func (r *cachedRepository) Close() error {
-	r.pollOnce(context.TODO())
 	r.cancel()
 
 	// Make sure that watch events are sent for packagerevisions that are
@@ -339,7 +338,7 @@ func (r *cachedRepository) Close() error {
 			// There isn't much use in returning an error here, so we just log it
 			// and create a PackageRevisionMeta with just name and namespace. This
 			// makes sure that the Delete event is sent.
-			klog.Warningf("Error deleting PackageRev CR for %s: %v", nn.Name, err)
+			klog.Warningf("repo %s: error deleting packagerev for %s: %v", r.id, nn.Name, err)
 			pkgRevMeta = meta.PackageRevisionMeta{
 				Name:      nn.Name,
 				Namespace: nn.Namespace,

--- a/pkg/meta/store.go
+++ b/pkg/meta/store.go
@@ -209,10 +209,13 @@ func (c *crdMetadataStore) Delete(ctx context.Context, namespacedName types.Name
 		}
 		return nil
 	})
+	if retriedErr != nil {
+		return PackageRevisionMeta{}, retriedErr
+	}
 
 	klog.Infof("Deleting packagerev %s/%s", internalPkgRev.Namespace, internalPkgRev.Name)
-	if retriedErr = c.coreClient.Delete(ctx, &internalPkgRev); retriedErr != nil {
-		return PackageRevisionMeta{}, retriedErr
+	if err := c.coreClient.Delete(ctx, &internalPkgRev); err != nil {
+		return PackageRevisionMeta{}, err
 	}
 	return toPackageRevisionMeta(&internalPkgRev), nil
 }

--- a/pkg/meta/store.go
+++ b/pkg/meta/store.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -194,21 +195,24 @@ func (c *crdMetadataStore) Delete(ctx context.Context, namespacedName types.Name
 	defer span.End()
 
 	var internalPkgRev internalapi.PackageRev
-	err := c.coreClient.Get(ctx, namespacedName, &internalPkgRev)
-	if err != nil {
-		return PackageRevisionMeta{}, err
-	}
-
-	if clearFinalizers {
-		internalPkgRev.Finalizers = []string{}
-		if err = c.coreClient.Update(ctx, &internalPkgRev); err != nil {
-			return PackageRevisionMeta{}, err
+	retriedErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := c.coreClient.Get(ctx, namespacedName, &internalPkgRev)
+		if err != nil {
+			return err
 		}
-	}
+
+		if clearFinalizers {
+			internalPkgRev.Finalizers = []string{}
+			if err = c.coreClient.Update(ctx, &internalPkgRev); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 
 	klog.Infof("Deleting packagerev %s/%s", internalPkgRev.Namespace, internalPkgRev.Name)
-	if err := c.coreClient.Delete(ctx, &internalPkgRev); err != nil {
-		return PackageRevisionMeta{}, err
+	if retriedErr = c.coreClient.Delete(ctx, &internalPkgRev); retriedErr != nil {
+		return PackageRevisionMeta{}, retriedErr
 	}
 	return toPackageRevisionMeta(&internalPkgRev), nil
 }

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -210,22 +210,21 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 		return nil, false, apierrors.NewBadRequest("namespace must be specified")
 	}
 
-	packageMutexKey := fmt.Sprintf("%s/%s", ns, name)
-	packageMutex := getMutexForPackage(packageMutexKey)
+	pkgMutexKey := fmt.Sprintf("%s/%s", ns, name)
+	pkgMutex := getMutexForPackage(pkgMutexKey)
 
-	lockAcquired := packageMutex.TryLock()
-	if !lockAcquired {
+	locked := pkgMutex.TryLock()
+	if !locked {
 		return nil, false,
 			apierrors.NewConflict(
 				api.Resource("packagerevisions"),
 				name,
-				fmt.Errorf(GenericConflictErrorMsg, "package revision", packageMutexKey))
+				fmt.Errorf(GenericConflictErrorMsg, "package revision", pkgMutexKey))
 	}
-	defer packageMutex.Unlock()
+	defer pkgMutex.Unlock()
 
 	// isCreate tracks whether this is an update that creates an object (this happens in server-side apply)
 	isCreate := false
-
 	oldRepoPkgRev, err := r.getRepoPkgRev(ctx, name)
 	if err != nil {
 		if forceAllowCreate && apierrors.IsNotFound(err) {

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -218,7 +218,7 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 		return nil, false, apierrors.NewBadRequest("namespace must be specified")
 	}
 
-	pkgMutexKey := fmt.Sprintf("%s/%s", ns, name)
+	pkgMutexKey := getPackageMutexKey(ns, name)
 	pkgMutex := getMutexForPackage(pkgMutexKey)
 
 	locked := pkgMutex.TryLock()
@@ -488,6 +488,10 @@ func (r *packageCommon) validateUpdate(ctx context.Context, newRuntimeObj runtim
 
 	r.updateStrategy.Canonicalize(newRuntimeObj)
 	return nil
+}
+
+func getPackageMutexKey(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 func getMutexForPackage(pkgMutexKey string) *sync.Mutex {

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -39,7 +39,7 @@ var mutexMapMutex sync.Mutex
 var pkgRevOperationMutexes = map[string]*sync.Mutex{}
 
 const (
-	CreateConflictErrorMsg  = "another request is already in progress to create %s with details %s"
+	CreateConflictErrorMsg  = "another request is already in progress to create package revision with details namespace=%q, repository=%q, package=%q,workspace=%q"
 	GenericConflictErrorMsg = "another request is already in progress on %s \"%s\""
 )
 
@@ -186,13 +186,12 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		return nil,
 			apierrors.NewConflict(
 				api.Resource("packagerevisions"),
-				fmt.Sprintf("(new creation)"),
-				fmt.Errorf(CreateConflictErrorMsg, "package revision", fmt.Sprintf(
-					"namespace=%s, repository=%s, package=%s,workspace=%s",
+				"(new creation)",
+				fmt.Errorf(CreateConflictErrorMsg,
 					newApiPkgRev.Namespace,
 					newApiPkgRev.Spec.RepositoryName,
 					newApiPkgRev.Spec.PackageName,
-					newApiPkgRev.Spec.WorkspaceName)))
+					newApiPkgRev.Spec.WorkspaceName))
 	}
 	defer packageMutex.Unlock()
 

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -17,7 +17,6 @@ package porch
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/engine"
@@ -34,14 +33,6 @@ import (
 )
 
 var tracer = otel.Tracer("apiserver")
-
-var mutexMapMutex sync.Mutex
-var pkgRevOperationMutexes = map[string]*sync.Mutex{}
-
-const (
-	CreateConflictErrorMsg  = "another request is already in progress to create package revision with details namespace=%q, repository=%q, package=%q,workspace=%q"
-	GenericConflictErrorMsg = "another request is already in progress on %s \"%s\""
-)
 
 type packageRevisions struct {
 	packageCommon
@@ -183,15 +174,18 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 
 	locked := pkgMutex.TryLock()
 	if !locked {
+
+		conflictError := fmt.Errorf(
+			fmt.Sprintf(ConflictErrorMsgBase, "to create package revision with details namespace=%q, repository=%q, package=%q,workspace=%q"),
+			newApiPkgRev.Namespace,
+			newApiPkgRev.Spec.RepositoryName,
+			newApiPkgRev.Spec.PackageName,
+			newApiPkgRev.Spec.WorkspaceName)
 		return nil,
 			apierrors.NewConflict(
 				api.Resource("packagerevisions"),
 				"(new creation)",
-				fmt.Errorf(CreateConflictErrorMsg,
-					newApiPkgRev.Namespace,
-					newApiPkgRev.Spec.RepositoryName,
-					newApiPkgRev.Spec.PackageName,
-					newApiPkgRev.Spec.WorkspaceName))
+				conflictError)
 	}
 	defer pkgMutex.Unlock()
 
@@ -275,15 +269,4 @@ func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValida
 
 	// TODO: Should we do an async delete?
 	return apiPkgRev, true, nil
-}
-
-func getMutexForPackage(pkgMutexKey string) *sync.Mutex {
-	mutexMapMutex.Lock()
-	defer mutexMapMutex.Unlock()
-	pkgMutex, alreadyPresent := pkgRevOperationMutexes[pkgMutexKey]
-	if !alreadyPresent {
-		pkgMutex = &sync.Mutex{}
-		pkgRevOperationMutexes[pkgMutexKey] = pkgMutex
-	}
-	return pkgMutex
 }

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -46,12 +46,10 @@ var _ rest.Scoper = &packageRevisionResources{}
 var _ rest.Updater = &packageRevisionResources{}
 var _ rest.SingularNameProvider = &packageRevisionResources{}
 
-
 // GetSingularName implements the SingularNameProvider interface
-func (r *packageRevisionResources) GetSingularName() (string) {
+func (r *packageRevisionResources) GetSingularName() string {
 	return "packagerevisionresources"
 }
-
 
 func (r *packageRevisionResources) New() runtime.Object {
 	return &api.PackageRevisionResources{}
@@ -126,6 +124,18 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 	if !namespaced {
 		return nil, false, apierrors.NewBadRequest("namespace must be specified")
 	}
+
+	packageMutexKey := fmt.Sprintf("%s/%s", ns, name)
+	packageMutex := getMutexForPackage(packageMutexKey)
+	lockAcquired := packageMutex.TryLock()
+	if !lockAcquired {
+		return nil, false,
+			apierrors.NewConflict(
+				api.Resource("packagerevisionresources"),
+				name,
+				fmt.Errorf(GenericConflictErrorMsg, "package revision resources", packageMutexKey))
+	}
+	defer packageMutex.Unlock()
 
 	oldRepoPkgRev, err := r.packageCommon.getRepoPkgRev(ctx, name)
 	if err != nil {

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -125,7 +125,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		return nil, false, apierrors.NewBadRequest("namespace must be specified")
 	}
 
-	pkgMutexKey := fmt.Sprintf("%s/%s", ns, name)
+	pkgMutexKey := getPackageMutexKey(ns, name)
 	pkgMutex := getMutexForPackage(pkgMutexKey)
 	locked := pkgMutex.TryLock()
 	if !locked {

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -125,17 +125,17 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		return nil, false, apierrors.NewBadRequest("namespace must be specified")
 	}
 
-	packageMutexKey := fmt.Sprintf("%s/%s", ns, name)
-	packageMutex := getMutexForPackage(packageMutexKey)
-	lockAcquired := packageMutex.TryLock()
-	if !lockAcquired {
+	pkgMutexKey := fmt.Sprintf("%s/%s", ns, name)
+	pkgMutex := getMutexForPackage(pkgMutexKey)
+	locked := pkgMutex.TryLock()
+	if !locked {
 		return nil, false,
 			apierrors.NewConflict(
 				api.Resource("packagerevisionresources"),
 				name,
-				fmt.Errorf(GenericConflictErrorMsg, "package revision resources", packageMutexKey))
+				fmt.Errorf(GenericConflictErrorMsg, "package revision resources", pkgMutexKey))
 	}
-	defer packageMutex.Unlock()
+	defer pkgMutex.Unlock()
 
 	oldRepoPkgRev, err := r.packageCommon.getRepoPkgRev(ctx, name)
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -340,7 +340,7 @@ func (t *PorchSuite) TestInitEmptyPackage(ctx context.Context) {
 func (t *PorchSuite) TestConcurrentInits(ctx context.Context) {
 	// Create a new package via init, no task specified
 	const (
-		repository  = "git"
+		repository  = "git-concurrent"
 		packageName = "empty-package-concurrent"
 		revision    = "v1"
 		workspace   = "test-workspace"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1011,7 +1011,7 @@ func (t *PorchSuite) TestProposeApprove(ctx context.Context) {
 func (t *PorchSuite) TestConcurrentProposeApprove(ctx context.Context) {
 	const (
 		repository  = "lifecycle"
-		packageName = "test-package"
+		packageName = "test-package-concurrent"
 		workspace   = "workspace"
 	)
 
@@ -1231,7 +1231,7 @@ func (t *PorchSuite) TestDeleteFinal(ctx context.Context) {
 func (t *PorchSuite) TestConcurrentProposeDeletes(ctx context.Context) {
 	const (
 		repository  = "delete-final"
-		packageName = "test-delete-final"
+		packageName = "test-delete-final-concurrent"
 		workspace   = "workspace"
 	)
 
@@ -1644,7 +1644,7 @@ func (t *PorchSuite) TestPackageUpdate(ctx context.Context) {
 func (t *PorchSuite) TestConcurrentPackageUpdates(ctx context.Context) {
 	const (
 		gitRepository = "package-update"
-		packageName   = "testns"
+		packageName   = "testns-concurrent"
 		workspace     = "test-workspace"
 	)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -688,12 +688,12 @@ func (t *PorchSuite) TestConcurrentEdits(ctx context.Context) {
 	}
 
 	// Two clients try to create the new package at the same time
-	editOperation := func() any {
+	editFunction := func() any {
 		return t.Client.Create(ctx, editPR)
 	}
 	results := RunInParallel(
-		editOperation,
-		editOperation)
+		editFunction,
+		editFunction)
 
 	assert.Contains(t, results, nil, "expected one request to succeed, but did not happen - results: %v", results)
 
@@ -1150,7 +1150,7 @@ func (t *PorchSuite) TestConcurrentDeletes(ctx context.Context) {
 	t.MustExist(ctx, client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &draft)
 
 	// Delete the same package with two clients at the same time
-	deleteOperation := func() any {
+	deleteFunction := func() any {
 		return t.Client.Delete(ctx, &porchapi.PackageRevision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: t.Namespace,
@@ -1159,8 +1159,8 @@ func (t *PorchSuite) TestConcurrentDeletes(ctx context.Context) {
 		})
 	}
 	results := RunInParallel(
-		deleteOperation,
-		deleteOperation)
+		deleteFunction,
+		deleteFunction)
 
 	expectedResultCount := 2
 	actualResultCount := len(results)

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -127,6 +127,27 @@ func RunSuite(suite interface{}, t *testing.T) {
 	})
 }
 
+func RunInParallel(functions ...func() any) []any {
+	var group sync.WaitGroup
+	var results []any
+	for _, eachFunction := range functions {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			if reflect.TypeOf(eachFunction).NumOut() == 0 {
+				results = append(results, nil)
+				eachFunction()
+			} else {
+				eachResult := eachFunction()
+
+				results = append(results, eachResult)
+			}
+		}()
+	}
+	group.Wait()
+	return results
+}
+
 func (t *TestSuite) SetT(tt *testing.T) {
 	t.T = tt
 }

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -213,7 +213,7 @@ func (t *TestSuite) registerGitRepositoryFromConfigF(ctx context.Context, name s
 	t.Cleanup(func() {
 		t.DeleteE(ctx, repository)
 		t.WaitUntilRepositoryDeleted(ctx, name, t.Namespace)
-		t.WaitUntilAllPackagesDeleted(ctx, name)
+		t.WaitUntilAllPackagesDeleted(ctx, name, t.Namespace)
 	})
 
 	// Make sure the repository is ready before we test to (hopefully)
@@ -365,7 +365,31 @@ func (t *TestSuite) WaitUntilRepositoryDeleted(ctx context.Context, name, namesp
 	}
 }
 
+<<<<<<< HEAD:test/e2e/suite_utils.go
 func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+<<<<<<< HEAD:test/e2e/e2e_utils_test.go
+func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+<<<<<<< HEAD:test/e2e/suite_utils.go
+func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+<<<<<<< HEAD:test/e2e/e2e_utils_test.go
+func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+<<<<<<< HEAD:test/e2e/suite_utils.go
+func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+<<<<<<< HEAD:test/e2e/e2e_utils_test.go
+func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
+=======
+func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
+>>>>>>> 2ed49bf (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+>>>>>>> 02825a0 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+>>>>>>> 9835dc1 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+>>>>>>> 021ed5a (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+>>>>>>> aadf3eb (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+>>>>>>> 6983ea7 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		t.Helper()
@@ -375,7 +399,7 @@ func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName st
 			return false, nil
 		}
 		for _, pkgRev := range pkgRevList.Items {
-			if strings.HasPrefix(fmt.Sprintf("%s-", pkgRev.Name), repoName) {
+			if pkgRev.Namespace == namespace && strings.HasPrefix(fmt.Sprintf("%s-", pkgRev.Name), repoName) {
 				t.Logf("Found package %s from repo %s", pkgRev.Name, repoName)
 				return false, nil
 			}
@@ -387,8 +411,8 @@ func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName st
 			return false, nil
 		}
 		for _, internalPkgRev := range internalPkgRevList.Items {
-			if strings.HasPrefix(fmt.Sprintf("%s-", internalPkgRev.Name), repoName) {
-				t.Logf("Found internalPkg %s from repo %s", internalPkgRev.Name, repoName)
+			if internalPkgRev.Namespace == namespace && strings.HasPrefix(fmt.Sprintf("%s-", internalPkgRev.Name), repoName) {
+				t.Logf("Found internalPkg %s/%s from repo %s", internalPkgRev.Namespace, internalPkgRev.Name, repoName)
 				return false, nil
 			}
 		}

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -371,47 +371,7 @@ func (t *TestSuite) WaitUntilRepositoryDeleted(ctx context.Context, name, namesp
 	}
 }
 
-<<<<<<< HEAD:test/e2e/suite_utils.go
-func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
-<<<<<<< HEAD:test/e2e/e2e_utils_test.go
-func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
-<<<<<<< HEAD:test/e2e/suite_utils.go
-func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
-<<<<<<< HEAD:test/e2e/e2e_utils_test.go
-func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
-<<<<<<< HEAD:test/e2e/suite_utils.go
-<<<<<<< HEAD:test/e2e/suite_utils.go
-func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
-<<<<<<< HEAD:test/e2e/e2e_utils_test.go
-func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
-=======
 func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
->>>>>>> 2ed49bf (Issue #657 - session conflict handling):test/e2e/suite_utils.go
->>>>>>> 02825a0 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
-<<<<<<< HEAD:test/e2e/e2e_utils_test.go
->>>>>>> 9835dc1 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
-<<<<<<< HEAD:test/e2e/suite_utils.go
->>>>>>> 021ed5a (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
-<<<<<<< HEAD:test/e2e/e2e_utils_test.go
->>>>>>> aadf3eb (Issue #657 - session conflict handling):test/e2e/suite_utils.go
-<<<<<<< HEAD:test/e2e/suite_utils.go
->>>>>>> 6983ea7 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
-=======
-=======
-=======
-=======
-=======
-func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
->>>>>>> 90101d4 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
->>>>>>> 5286ef6 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
->>>>>>> 7ed9d28 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
->>>>>>> a9e3581 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
->>>>>>> 2bf829c (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		t.Helper()

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -262,7 +262,7 @@ func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, package
 	return pr
 }
 
-func (t *TestSuite) CreatePackageSkeleton(repository, packageName, workspace string) *porchapi.PackageRevision {
+func (t *TestSuite) CreatePackageSkeleton(repoName, packageName, workspace string) *porchapi.PackageRevision {
 	return &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
@@ -274,7 +274,7 @@ func (t *TestSuite) CreatePackageSkeleton(repository, packageName, workspace str
 		Spec: porchapi.PackageRevisionSpec{
 			PackageName:    packageName,
 			WorkspaceName:  porchapi.WorkspaceName(workspace),
-			RepositoryName: repository,
+			RepositoryName: repoName,
 			// empty tasks list - set them as needed in the particular usage
 			Tasks: []porchapi.Task{},
 		},

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -249,9 +249,21 @@ func InNamespace(ns string) RepositoryOption {
 }
 
 // Creates an empty package draft by initializing an empty package
-func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, name, workspace string) *porchapi.PackageRevision {
+func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, packageName, workspace string) *porchapi.PackageRevision {
 	t.Helper()
-	pr := &porchapi.PackageRevision{
+	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
+	pr.Spec.Tasks = []porchapi.Task{
+		{
+			Type: porchapi.TaskTypeInit,
+			Init: &porchapi.PackageInitTaskSpec{},
+		},
+	}
+	t.CreateF(ctx, pr)
+	return pr
+}
+
+func (t *TestSuite) CreatePackageSkeleton(repository, packageName, workspace string) *porchapi.PackageRevision {
+	return &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
 			APIVersion: porchapi.SchemeGroupVersion.String(),
@@ -260,19 +272,13 @@ func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, name, w
 			Namespace: t.Namespace,
 		},
 		Spec: porchapi.PackageRevisionSpec{
-			PackageName:    name,
+			PackageName:    packageName,
 			WorkspaceName:  porchapi.WorkspaceName(workspace),
 			RepositoryName: repository,
-			Tasks: []porchapi.Task{
-				{
-					Type: porchapi.TaskTypeInit,
-					Init: &porchapi.PackageInitTaskSpec{},
-				},
-			},
+			// empty tasks list - set them as needed in the particular usage
+			Tasks: []porchapi.Task{},
 		},
 	}
-	t.CreateF(ctx, pr)
-	return pr
 }
 
 func (t *TestSuite) MustExist(ctx context.Context, key client.ObjectKey, obj client.Object) {
@@ -378,6 +384,7 @@ func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName st
 func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
 =======
 <<<<<<< HEAD:test/e2e/suite_utils.go
+<<<<<<< HEAD:test/e2e/suite_utils.go
 func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string) {
 =======
 <<<<<<< HEAD:test/e2e/e2e_utils_test.go
@@ -386,10 +393,25 @@ func (t *TestSuite) waitUntilAllPackagesDeleted(ctx context.Context, repoName st
 func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
 >>>>>>> 2ed49bf (Issue #657 - session conflict handling):test/e2e/suite_utils.go
 >>>>>>> 02825a0 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+<<<<<<< HEAD:test/e2e/e2e_utils_test.go
 >>>>>>> 9835dc1 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+<<<<<<< HEAD:test/e2e/suite_utils.go
 >>>>>>> 021ed5a (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+<<<<<<< HEAD:test/e2e/e2e_utils_test.go
 >>>>>>> aadf3eb (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+<<<<<<< HEAD:test/e2e/suite_utils.go
 >>>>>>> 6983ea7 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+=======
+=======
+=======
+=======
+=======
+func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
+>>>>>>> 90101d4 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+>>>>>>> 5286ef6 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+>>>>>>> 7ed9d28 (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
+>>>>>>> a9e3581 (Issue #657 - session conflict handling):test/e2e/suite_utils.go
+>>>>>>> 2bf829c (Issue #657 - session conflict handling):test/e2e/e2e_utils_test.go
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		t.Helper()


### PR DESCRIPTION
Implements [#657](https://github.com/nephio-project/nephio/issues/657)

Add mutexes to the following operations to resolve session conflicts:
- `Create()`, `Update()`, and `Delete()` in pkg/registry/porch/packagerevision.go
- `Update()` in pkg/registry/porch/packagerevisionresources.go
- `Update()` in pkg/registry/porch/packagerevisions_approval.go

This restricts concurrent incoming requests to operate one at a time on a given package revision; requests received while one of the above operations is in progress will immediately return a 409 Conflict error response.
For example, given a request X which attempts to `Update()` package revision P, while another request Y is already in progress to `Delete()` P, request X will return a 409 Conflict response.