### PR TITLE
Remove confusing else statement in cache.go

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -152,10 +152,9 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 				UseGitCaBundle:     c.useGitCaBundle,
 			}); err != nil {
 				return nil, err
-			} else {
-				cachedRepo = newRepository(key, repositorySpec, r, c.objectNotifier, c.metadataStore, c.repoSyncFrequency)
-				c.repositories[key] = cachedRepo
 			}
+			cachedRepo = newRepository(key, repositorySpec, r, c.objectNotifier, c.metadataStore, c.repoSyncFrequency)
+			c.repositories[key] = cachedRepo
 		} else {
 			// If there is an error from the background refresh goroutine, return it.
 			if err := cachedRepo.getRefreshError(); err != nil {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,14 +145,17 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 			} else {
 				mbs = git.ErrorIfMissing
 			}
-			if r, err := git.OpenRepository(ctx, repositorySpec.Name, repositorySpec.Namespace, gitSpec, repositorySpec.Spec.Deployment, filepath.Join(c.cacheDir, "git"), git.GitRepositoryOptions{
+
+			r, err := git.OpenRepository(ctx, repositorySpec.Name, repositorySpec.Namespace, gitSpec, repositorySpec.Spec.Deployment, filepath.Join(c.cacheDir, "git"), git.GitRepositoryOptions{
 				CredentialResolver: c.credentialResolver,
 				UserInfoProvider:   c.userInfoProvider,
 				MainBranchStrategy: mbs,
 				UseGitCaBundle:     c.useGitCaBundle,
-			}); err != nil {
+			})
+			if err != nil {
 				return nil, err
 			}
+
 			cachedRepo = newRepository(key, repositorySpec, r, c.objectNotifier, c.metadataStore, c.repoSyncFrequency)
 			c.repositories[key] = cachedRepo
 		} else {


### PR DESCRIPTION
There is no need for the `else` block here because the if `err` is nil, it always returns in the `if` block.