### PR TITLE
Fix overwrite of package resources with empty resource map

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1004,11 +1004,12 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 		Contents: prevResources.Spec.Resources,
 	}
 
-	appliedResources, renderStatus, err := applyResourceMutations(ctx, draft, resources, mutations)
+	appliedResources, _, err := applyResourceMutations(ctx, draft, resources, mutations)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	var renderStatus *api.RenderStatus
 	if len(appliedResources.Contents) > 0 {
 		// render the package
 		// Render failure will not fail the overall API operation.
@@ -1023,7 +1024,10 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 				runnerOptions: runnerOptions,
 				runtime:       cad.runtime,
 			}})
+	} else {
+		renderStatus = nil
 	}
+
 	// No lifecycle change when updating package resources; updates are done.
 	repoPkgRev, err := draft.Close(ctx)
 	if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1039,8 +1039,8 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, 
 		updatedResources, taskResult, err := m.Apply(ctx, baseResources)
 		if taskResult == nil && err == nil {
 			// a nil taskResult means nothing changed
-		//	baseResources = updatedResources
-		//	applied = updatedResources
+			baseResources = updatedResources
+			applied = updatedResources
 			continue
 		}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1094,7 +1094,7 @@ func (m *updatePackageMutation) Apply(ctx context.Context, resources repository.
 	}
 
 	targetUpstream := m.updateTask.Update.Upstream
-	if targetUpstream.Type == api.RepositoryTypeGit || targetUpstream.Type == api.RepositoryTypeOCI || targetUpstream.Type == api.RepositoryTypeDB {
+	if targetUpstream.Type == api.RepositoryTypeGit || targetUpstream.Type == api.RepositoryTypeOCI {
 		return repository.PackageResources{}, nil, fmt.Errorf("update is not supported for non-porch upstream packages")
 	}
 
@@ -1159,7 +1159,7 @@ func (m *updatePackageMutation) currUpstream() (*api.PackageRevisionRef, error) 
 		return nil, fmt.Errorf("package %s does not have original upstream info", m.pkgName)
 	}
 	upstream := m.cloneTask.Clone.Upstream
-	if upstream.Type == api.RepositoryTypeGit || upstream.Type == api.RepositoryTypeOCI || upstream.Type == api.RepositoryTypeDB {
+	if upstream.Type == api.RepositoryTypeGit || upstream.Type == api.RepositoryTypeOCI {
 		return nil, fmt.Errorf("upstream package must be porch native package. Found it to be %s", upstream.Type)
 	}
 	return upstream.UpstreamRef, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1039,8 +1039,8 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, 
 		updatedResources, taskResult, err := m.Apply(ctx, baseResources)
 		if taskResult == nil && err == nil {
 			// a nil taskResult means nothing changed
-			baseResources = updatedResources
-			applied = updatedResources
+		//	baseResources = updatedResources
+		//	applied = updatedResources
 			continue
 		}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1039,7 +1039,9 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, 
 		updatedResources, taskResult, err := m.Apply(ctx, baseResources)
 		if taskResult == nil && err == nil {
 			// a nil taskResult means nothing changed
-			return baseResources, nil, nil
+			baseResources = updatedResources
+			applied = updatedResources
+			continue
 		}
 
 		var task *api.Task
@@ -1092,7 +1094,7 @@ func (m *updatePackageMutation) Apply(ctx context.Context, resources repository.
 	}
 
 	targetUpstream := m.updateTask.Update.Upstream
-	if targetUpstream.Type == api.RepositoryTypeGit || targetUpstream.Type == api.RepositoryTypeOCI {
+	if targetUpstream.Type == api.RepositoryTypeGit || targetUpstream.Type == api.RepositoryTypeOCI || targetUpstream.Type == api.RepositoryTypeDB {
 		return repository.PackageResources{}, nil, fmt.Errorf("update is not supported for non-porch upstream packages")
 	}
 
@@ -1157,7 +1159,7 @@ func (m *updatePackageMutation) currUpstream() (*api.PackageRevisionRef, error) 
 		return nil, fmt.Errorf("package %s does not have original upstream info", m.pkgName)
 	}
 	upstream := m.cloneTask.Clone.Upstream
-	if upstream.Type == api.RepositoryTypeGit || upstream.Type == api.RepositoryTypeOCI {
+	if upstream.Type == api.RepositoryTypeGit || upstream.Type == api.RepositoryTypeOCI || upstream.Type == api.RepositoryTypeDB {
 		return nil, fmt.Errorf("upstream package must be porch native package. Found it to be %s", upstream.Type)
 	}
 	return upstream.UpstreamRef, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1039,7 +1039,7 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, 
 		updatedResources, taskResult, err := m.Apply(ctx, baseResources)
 		if taskResult == nil && err == nil {
 			// a nil taskResult means nothing changed
-			continue
+			return baseResources, nil, nil
 		}
 
 		var task *api.Task

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -814,34 +814,44 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch(ctx context.Context) {
 	t.CreateF(ctx, pr)
 
 	// Check its task list
-	var newPackage porchapi.PackageRevision
+	var pkgBeforeUpdate porchapi.PackageRevision
 	t.GetF(ctx, client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
-	}, &newPackage)
-	tasksBeforeUpdate := newPackage.Spec.Tasks
+	}, &pkgBeforeUpdate)
+	tasksBeforeUpdate := pkgBeforeUpdate.Spec.Tasks
 	assert.Equal(t, 2, len(tasksBeforeUpdate))
 
 	// Get the package resources
-	var newPackageResources porchapi.PackageRevisionResources
+	var resourcesBeforeUpdate porchapi.PackageRevisionResources
 	t.GetF(ctx, client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
-	}, &newPackageResources)
+	}, &resourcesBeforeUpdate)
 
 	// "Update" the package resources, without changing anything
-	t.UpdateF(ctx, &newPackageResources)
+	t.UpdateF(ctx, &resourcesBeforeUpdate)
 
 	// Check the task list
-	var newPackageUpdated porchapi.PackageRevision
+	var pkgAfterUpdate porchapi.PackageRevision
 	t.GetF(ctx, client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
-	}, &newPackageUpdated)
-	tasksAfterUpdate := newPackageUpdated.Spec.Tasks
+	}, &pkgAfterUpdate)
+	tasksAfterUpdate := pkgAfterUpdate.Spec.Tasks
 	assert.Equal(t, 2, len(tasksAfterUpdate))
 
 	assert.True(t, reflect.DeepEqual(tasksBeforeUpdate, tasksAfterUpdate))
+
+	// Get the package resources
+	var resourcesAfterUpdate porchapi.PackageRevisionResources
+	t.GetF(ctx, client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      pr.Name,
+	}, &resourcesAfterUpdate)
+
+	assert.Equal(t, 3, len(resourcesAfterUpdate.Spec.Resources))
+	assert.True(t, reflect.DeepEqual(resourcesBeforeUpdate, resourcesAfterUpdate))
 }
 
 func (t *PorchSuite) TestConcurrentResourceUpdates(ctx context.Context) {


### PR DESCRIPTION
When changes are pushed to a package that are identical to the existing package, the `updatedResources` method returns the resources. However the 'if' block that starts at line 1053 does not set `applied` to the value of the resources, so when the loop terminates after the `continue` statement, the function returns with `applied` having a value of an empty string map. This value is set in the draft package revision, resulting in all the existing resources in the package draft being erased.