### PR TITLE
Fix hardcoded background job periodic poll interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,7 @@ run-local: porch
 	--kubeconfig="$(CURDIR)/deployments/local/kubeconfig" \
 	--cache-directory="$(CACHEDIR)" \
 	--function-runner 192.168.8.202:9445 \
-	--repo-sync-frequency=60s \
-	--background-job-interval=10m
+	--repo-sync-frequency=10m
 
 .PHONY: run-jaeger
 run-jaeger:

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,8 @@ run-local: porch
 	--kubeconfig="$(CURDIR)/deployments/local/kubeconfig" \
 	--cache-directory="$(CACHEDIR)" \
 	--function-runner 192.168.8.202:9445 \
-	--repo-sync-frequency=60s
+	--repo-sync-frequency=60s \
+	--background-job-interval=10m
 
 .PHONY: run-jaeger
 run-jaeger:

--- a/cmd/porchctl/run/run.go
+++ b/cmd/porchctl/run/run.go
@@ -213,6 +213,7 @@ func hideFlags(cmd *cobra.Command) {
 		"password",
 		"token",
 		"username",
+		"request-timeout",
 	}
 	for _, f := range flags {
 		_ = cmd.PersistentFlags().MarkHidden(f)

--- a/deployments/porch/3-porch-server.yaml
+++ b/deployments/porch/3-porch-server.yaml
@@ -75,9 +75,8 @@ spec:
             - --cache-directory=/cache
             - --cert-dir=/tmp/certs
             - --secure-port=4443
-            - --repo-sync-frequency=60s
+            - --repo-sync-frequency=10m
             - --disable-validating-admissions-policy=true
-            - --background-job-interval=10m
 
 ---
 apiVersion: v1

--- a/deployments/porch/3-porch-server.yaml
+++ b/deployments/porch/3-porch-server.yaml
@@ -77,6 +77,7 @@ spec:
             - --secure-port=4443
             - --repo-sync-frequency=60s
             - --disable-validating-admissions-policy=true
+            - --background-job-interval=10m
 
 ---
 apiVersion: v1

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -91,10 +91,10 @@ type Config struct {
 
 // PorchServer contains state for a Kubernetes cluster master/api server.
 type PorchServer struct {
-	GenericAPIServer  *genericapiserver.GenericAPIServer
-	coreClient        client.WithWatch
-	cache             cache.Cache
-	RepoSyncFrequency time.Duration
+	GenericAPIServer          *genericapiserver.GenericAPIServer
+	coreClient                client.WithWatch
+	cache                     cache.Cache
+	PeriodicRepoSyncFrequency time.Duration
 }
 
 type completedConfig struct {
@@ -265,10 +265,11 @@ func (c completedConfig) New() (*PorchServer, error) {
 	}
 
 	s := &PorchServer{
-		GenericAPIServer:  genericServer,
-		coreClient:        coreClient,
-		cache:             memoryCache,
-		RepoSyncFrequency: c.ExtraConfig.RepoSyncFrequency,
+		GenericAPIServer: genericServer,
+		coreClient:       coreClient,
+		cache:            memoryCache,
+		// Set background job periodic frequency the same as repo sync frequency.
+		PeriodicRepoSyncFrequency: c.ExtraConfig.RepoSyncFrequency,
 	}
 
 	// Install the groups.
@@ -280,7 +281,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 }
 
 func (s *PorchServer) Run(ctx context.Context) error {
-	porch.RunBackground(ctx, s.coreClient, s.cache, s.RepoSyncFrequency)
+	porch.RunBackground(ctx, s.coreClient, s.cache, s.PeriodicRepoSyncFrequency)
 
 	// TODO: Reconsider if the existence of CERT_STORAGE_DIR was a good inidcator for webhook setup,
 	// but for now we keep backward compatiblity

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -81,7 +81,6 @@ type ExtraConfig struct {
 	DefaultImagePrefix    string
 	RepoSyncFrequency     time.Duration
 	UseGitCaBundle        bool
-	BackgroundJobInterval time.Duration
 }
 
 // Config defines the config for the apiserver
@@ -92,10 +91,10 @@ type Config struct {
 
 // PorchServer contains state for a Kubernetes cluster master/api server.
 type PorchServer struct {
-	GenericAPIServer      *genericapiserver.GenericAPIServer
-	coreClient            client.WithWatch
-	cache                 cache.Cache
-	BackgroundJobInterval time.Duration
+	GenericAPIServer  *genericapiserver.GenericAPIServer
+	coreClient        client.WithWatch
+	cache             cache.Cache
+	RepoSyncFrequency time.Duration
 }
 
 type completedConfig struct {
@@ -266,10 +265,10 @@ func (c completedConfig) New() (*PorchServer, error) {
 	}
 
 	s := &PorchServer{
-		GenericAPIServer:      genericServer,
-		coreClient:            coreClient,
-		cache:                 memoryCache,
-		BackgroundJobInterval: c.ExtraConfig.BackgroundJobInterval,
+		GenericAPIServer:  genericServer,
+		coreClient:        coreClient,
+		cache:             memoryCache,
+		RepoSyncFrequency: c.ExtraConfig.RepoSyncFrequency,
 	}
 
 	// Install the groups.
@@ -281,7 +280,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 }
 
 func (s *PorchServer) Run(ctx context.Context) error {
-	porch.RunBackground(ctx, s.coreClient, s.cache, s.BackgroundJobInterval)
+	porch.RunBackground(ctx, s.coreClient, s.cache, s.RepoSyncFrequency)
 
 	// TODO: Reconsider if the existence of CERT_STORAGE_DIR was a good inidcator for webhook setup,
 	// but for now we keep backward compatiblity

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -59,7 +59,6 @@ type PorchServerOptions struct {
 	UseGitCaBundle                   bool
 	DisableValidatingAdmissionPolicy bool
 	MaxRequestBodySize               int64
-	BackgroundJobInterval            time.Duration
 
 	SharedInformerFactory informers.SharedInformerFactory
 	StdOut                io.Writer
@@ -201,7 +200,6 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 			FunctionRunnerAddress: o.FunctionRunnerAddress,
 			DefaultImagePrefix:    o.DefaultImagePrefix,
 			UseGitCaBundle:        o.UseGitCaBundle,
-			BackgroundJobInterval: o.BackgroundJobInterval,
 		},
 	}
 	return config, nil
@@ -243,12 +241,12 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 			"Under the local-debug mode the apiserver will allow all access to its resources without "+
 				"authorizing the requests, this flag is only intended for debugging in your workstation.")
 	}
-	fs.DurationVar(&o.BackgroundJobInterval, "background-job-interval", 10*time.Minute, "Time interval in minutes at which the background job will poll the git repository to maintain the correct state.")
+
 	fs.StringVar(&o.FunctionRunnerAddress, "function-runner", "", "Address of the function runner gRPC service.")
 	fs.StringVar(&o.DefaultImagePrefix, "default-image-prefix", "gcr.io/kpt-fn/", "Default prefix for unqualified function names")
 	fs.StringVar(&o.CacheDirectory, "cache-directory", "", "Directory where Porch server stores repository and package caches.")
 	fs.Int64Var(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes.")
 	fs.BoolVar(&o.UseGitCaBundle, "use-git-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards git.")
 	fs.BoolVar(&o.DisableValidatingAdmissionPolicy, "disable-validating-admissions-policy", true, "Determine whether to (dis|en)able the Validating Admission Policy, which requires k8s version >= v1.30")
-	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 60*time.Second, "Frequency in seconds at which registered repositories will be synced.")
+	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced.")
 }

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -59,6 +59,7 @@ type PorchServerOptions struct {
 	UseGitCaBundle                   bool
 	DisableValidatingAdmissionPolicy bool
 	MaxRequestBodySize               int64
+	BackgroundJobInterval            time.Duration
 
 	SharedInformerFactory informers.SharedInformerFactory
 	StdOut                io.Writer
@@ -200,6 +201,7 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 			FunctionRunnerAddress: o.FunctionRunnerAddress,
 			DefaultImagePrefix:    o.DefaultImagePrefix,
 			UseGitCaBundle:        o.UseGitCaBundle,
+			BackgroundJobInterval: o.BackgroundJobInterval,
 		},
 	}
 	return config, nil
@@ -241,7 +243,7 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 			"Under the local-debug mode the apiserver will allow all access to its resources without "+
 				"authorizing the requests, this flag is only intended for debugging in your workstation.")
 	}
-
+	fs.DurationVar(&o.BackgroundJobInterval, "background-job-interval", 10*time.Minute, "Time interval in minutes at which the background job will poll the git repository to maintain the correct state.")
 	fs.StringVar(&o.FunctionRunnerAddress, "function-runner", "", "Address of the function runner gRPC service.")
 	fs.StringVar(&o.DefaultImagePrefix, "default-image-prefix", "gcr.io/kpt-fn/", "Default prefix for unqualified function names")
 	fs.StringVar(&o.CacheDirectory, "cache-directory", "", "Directory where Porch server stores repository and package caches.")

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -248,5 +248,5 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.Int64Var(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes.")
 	fs.BoolVar(&o.UseGitCaBundle, "use-git-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards git.")
 	fs.BoolVar(&o.DisableValidatingAdmissionPolicy, "disable-validating-admissions-policy", true, "Determine whether to (dis|en)able the Validating Admission Policy, which requires k8s version >= v1.30")
-	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced.")
+	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced and the background job repository refresh runs.")
 }

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -15,13 +15,14 @@
 package server
 
 import (
+	"testing"
+	"time"
+
 	porchv1alpha1 "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/apiserver"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
-	"testing"
-	"time"
 )
 
 func TestAddFlags(t *testing.T) {
@@ -35,7 +36,7 @@ func TestAddFlags(t *testing.T) {
 		),
 	}
 	o.AddFlags(&pflag.FlagSet{})
-	if o.RepoSyncFrequency < 30*time.Second {
-		t.Fatalf("AddFlags(): repo-sync-frequency cannot be less that 30 seconds.")
+	if o.RepoSyncFrequency < 5*time.Minute {
+		t.Fatalf("AddFlags(): repo-sync-frequency cannot be less that 5 minutes.")
 	}
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -52,7 +52,6 @@ const (
 // run will run until ctx is done
 func (b *background) run(ctx context.Context) {
 	klog.Infof("Background routine starting ...")
-	klog.Infof("\n\n\n\n\n------------------- Time-Interval  %v     -------------\n\n\n\n\n", b.backgroundJobInterval)
 
 	// Repository watch.
 	var events <-chan watch.Event

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -28,20 +28,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache, backgroundJobInterval time.Duration) {
+func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache, RepoSyncFrequency time.Duration) {
 	b := background{
-		coreClient:            coreClient,
-		cache:                 cache,
-		backgroundJobInterval: backgroundJobInterval,
+		coreClient:        coreClient,
+		cache:             cache,
+		RepoSyncFrequency: RepoSyncFrequency,
 	}
 	go b.run(ctx)
 }
 
 // background manages background tasks
 type background struct {
-	coreClient            client.WithWatch
-	cache                 cache.Cache
-	backgroundJobInterval time.Duration
+	coreClient        client.WithWatch
+	cache             cache.Cache
+	RepoSyncFrequency time.Duration
 }
 
 const (
@@ -67,7 +67,7 @@ func (b *background) run(ctx context.Context) {
 	defer reconnect.Stop()
 
 	// Start ticker
-	ticker := time.NewTicker(b.backgroundJobInterval)
+	ticker := time.NewTicker(b.RepoSyncFrequency)
 	defer ticker.Stop()
 
 loop:

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -28,18 +28,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache) {
+func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache, backgroundJobInterval time.Duration) {
 	b := background{
-		coreClient: coreClient,
-		cache:      cache,
+		coreClient:            coreClient,
+		cache:                 cache,
+		backgroundJobInterval: backgroundJobInterval,
 	}
 	go b.run(ctx)
 }
 
 // background manages background tasks
 type background struct {
-	coreClient client.WithWatch
-	cache      cache.Cache
+	coreClient            client.WithWatch
+	cache                 cache.Cache
+	backgroundJobInterval time.Duration
 }
 
 const (
@@ -50,6 +52,7 @@ const (
 // run will run until ctx is done
 func (b *background) run(ctx context.Context) {
 	klog.Infof("Background routine starting ...")
+	klog.Infof("\n\n\n\n\n------------------- Time-Interval  %v     -------------\n\n\n\n\n", b.backgroundJobInterval)
 
 	// Repository watch.
 	var events <-chan watch.Event
@@ -65,7 +68,7 @@ func (b *background) run(ctx context.Context) {
 	defer reconnect.Stop()
 
 	// Start ticker
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(b.backgroundJobInterval)
 	defer ticker.Stop()
 
 loop:

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -28,20 +28,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache, RepoSyncFrequency time.Duration) {
+func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache.Cache, PeriodicRepoSyncFrequency time.Duration) {
 	b := background{
-		coreClient:        coreClient,
-		cache:             cache,
-		RepoSyncFrequency: RepoSyncFrequency,
+		coreClient:                coreClient,
+		cache:                     cache,
+		PeriodicRepoSyncFrequency: PeriodicRepoSyncFrequency,
 	}
 	go b.run(ctx)
 }
 
 // background manages background tasks
 type background struct {
-	coreClient        client.WithWatch
-	cache             cache.Cache
-	RepoSyncFrequency time.Duration
+	coreClient                client.WithWatch
+	cache                     cache.Cache
+	PeriodicRepoSyncFrequency time.Duration
 }
 
 const (
@@ -67,7 +67,7 @@ func (b *background) run(ctx context.Context) {
 	defer reconnect.Stop()
 
 	// Start ticker
-	ticker := time.NewTicker(b.RepoSyncFrequency)
+	ticker := time.NewTicker(b.PeriodicRepoSyncFrequency)
 	defer ticker.Stop()
 
 loop:


### PR DESCRIPTION
This change makes the background job periodic polling interval configurable and matches with the repo sync interval. 

This change makes the default repo sync and periodic sync intervals 10 minutes by default.

This change also hides the request-timeout parameter from the porchctl command. This is done because currently in Kubernetes source code, client context is cancelled at exactly 34 seconds - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go#L53. 
