### PR TITLE
Fix two warnings in repository.go

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,15 +14,14 @@
                 "--secure-port=4443",
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
-                "--function-runner=localhost:30001",
+                "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
                 "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
             "env": { 
                 "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp", 
                 "WEBHOOK_HOST": "localhost",
-                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true",
-                "OTEL": "otel://localhost:4317"
+                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
             }
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,14 +14,15 @@
                 "--secure-port=4443",
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
-                "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
+                "--function-runner=localhost:30001",
                 "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
             "env": { 
                 "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp", 
                 "WEBHOOK_HOST": "localhost",
-                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
+                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true",
+                "OTEL": "otel://localhost:4317"
             }
         },
         {

--- a/pkg/cache/memory/repository.go
+++ b/pkg/cache/memory/repository.go
@@ -28,7 +28,6 @@ import (
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -214,9 +213,7 @@ func (r *cachedRepository) update(ctx context.Context, updated repository.Packag
 			Package:       k.Package,
 			WorkspaceName: k.WorkspaceName,
 		}
-		if _, ok := r.cachedPackageRevisions[oldKey]; ok {
-			delete(r.cachedPackageRevisions, oldKey)
-		}
+		delete(r.cachedPackageRevisions, oldKey)
 	}
 
 	cached := &cachedPackageRevision{PackageRevision: updated}
@@ -264,7 +261,7 @@ func (r *cachedRepository) createMainPackageRevision(ctx context.Context, update
 
 	// Create the package if it doesn't exist
 	_, err := r.metadataStore.Get(ctx, pkgRevMetaNN)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		pkgRevMeta := meta.PackageRevisionMeta{
 			Name:      updatedMain.KubeObjectName(),
 			Namespace: updatedMain.KubeObjectNamespace(),


### PR DESCRIPTION
This PR fixes two code warnings in repository.go:
- A double import
- An unnecessary guard around a delete in a slice