### PR TITLE
Move functions

### DIFF
--- a/pkg/engine/clone_test.go
+++ b/pkg/engine/clone_test.go
@@ -115,7 +115,7 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 	return repo
 }
 
-func startGitServer(t *testing.T, repo *git.Repo, _ ...git.GitServerOption) string {
+func startGitServer(t *testing.T, repo *git.Repo, opts ...git.GitServerOption) string {
 	key := "default"
 	repos := git.NewStaticRepos()
 	if err := repos.Add(key, repo); err != nil {

--- a/pkg/engine/clone_test.go
+++ b/pkg/engine/clone_test.go
@@ -115,7 +115,7 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 	return repo
 }
 
-func startGitServer(t *testing.T, repo *git.Repo, opts ...git.GitServerOption) string {
+func startGitServer(t *testing.T, repo *git.Repo, _ ...git.GitServerOption) string {
 	key := "default"
 	repos := git.NewStaticRepos()
 	if err := repos.Add(key, repo); err != nil {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -16,6 +16,8 @@ package engine
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -101,4 +103,48 @@ func (m *defaultPackageUpdater) do(ctx context.Context, localPkgDir, originalPkg
 		}
 	}
 	return nil
+}
+
+func writeResourcesToDirectory(dir string, resources repository.PackageResources) error {
+	for k, v := range resources.Contents {
+		p := filepath.Join(dir, k)
+		dir := filepath.Dir(p)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", dir, err)
+		}
+		if err := os.WriteFile(p, []byte(v), 0644); err != nil {
+			return fmt.Errorf("failed to write file %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func loadResourcesFromDirectory(dir string) (repository.PackageResources, error) {
+	// TODO: return abstraction instead of loading everything
+	result := repository.PackageResources{
+		Contents: map[string]string{},
+	}
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("cannot compute relative path %q, %q, %w", dir, path, err)
+		}
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("cannot read file %q: %w", dir, err)
+		}
+		result.Contents[rel] = string(contents)
+		return nil
+	}); err != nil {
+		return repository.PackageResources{}, err
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
The `loadResourcesFromDirectory` and `writeResourcesToDirectory` functions are declared in `engine.go` but are only used in `update.go`. This PR moves those functions to the file `update.go` for readability.