### PR TITLE
Implement improvements identified by static linting

### DIFF
--- a/pkg/engine/clone.go
+++ b/pkg/engine/clone.go
@@ -193,7 +193,7 @@ func (m *clonePackageMutation) cloneFromGit(ctx context.Context, gitPackage *api
 	}, nil
 }
 
-func (m *clonePackageMutation) cloneFromOci(ctx context.Context, ociPackage *api.OciPackage) (repository.PackageResources, error) {
+func (m *clonePackageMutation) cloneFromOci(_ context.Context, _ *api.OciPackage) (repository.PackageResources, error) {
 	return repository.PackageResources{}, errors.New("clone from OCI is not implemented")
 }
 

--- a/pkg/engine/clone_test.go
+++ b/pkg/engine/clone_test.go
@@ -115,7 +115,7 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 	return repo
 }
 
-func startGitServer(t *testing.T, repo *git.Repo, opts ...git.GitServerOption) string {
+func startGitServer(t *testing.T, repo *git.Repo, _ ...git.GitServerOption) string {
 	key := "default"
 	repos := git.NewStaticRepos()
 	if err := repos.Add(key, repo); err != nil {

--- a/pkg/engine/mergekey.go
+++ b/pkg/engine/mergekey.go
@@ -27,7 +27,7 @@ import (
 // identity of resources in a downstream package with the ones in upstream package
 // This is required to ensure package update is able to merge resources in
 // downstream package with upstream.
-func ensureMergeKey(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, error) {
+func ensureMergeKey(_ context.Context, resources repository.PackageResources) (repository.PackageResources, error) {
 	pr := &packageReader{
 		input: resources,
 		extra: map[string]string{},

--- a/pkg/engine/patchgen.go
+++ b/pkg/engine/patchgen.go
@@ -53,7 +53,7 @@ type applyPatchMutation struct {
 var _ mutation = &applyPatchMutation{}
 
 func (m *applyPatchMutation) Apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "applyPatchMutation:::Apply", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "applyPatchMutation:::Apply", trace.WithAttributes())
 	defer span.End()
 
 	result := repository.PackageResources{

--- a/pkg/engine/patchgen.go
+++ b/pkg/engine/patchgen.go
@@ -128,7 +128,7 @@ func (m *applyPatchMutation) Apply(ctx context.Context, resources repository.Pac
 	return result, &api.TaskResult{Task: m.task}, nil
 }
 
-func buildPatchMutation(ctx context.Context, task *api.Task) (mutation, error) {
+func buildPatchMutation(_ context.Context, task *api.Task) (mutation, error) {
 	if task.Patch == nil {
 		return nil, fmt.Errorf("patch not set for task of type %q", task.Type)
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -20,14 +20,8 @@ import (
 	"path/filepath"
 
 	"github.com/nephio-project/porch/internal/kpt/util/update"
-	"github.com/nephio-project/porch/pkg/kpt/printer"
 	"github.com/nephio-project/porch/pkg/repository"
 )
-
-// packageUpdater knows how to update a local package given original and upstream package resources.
-type packageUpdater interface {
-	Update(ctx context.Context, localResources, originalResources, upstreamResources repository.PackageResources) (updatedResources repository.PackageResources, err error)
-}
 
 // defaultPackageUpdater implements packageUpdater interface.
 type defaultPackageUpdater struct{}
@@ -76,29 +70,24 @@ func (m *defaultPackageUpdater) Update(
 }
 
 // PkgUpdate is a wrapper around `kpt pkg update`, running it against the package in packageDir
-func (m *defaultPackageUpdater) do(ctx context.Context, localPkgDir, originalPkgDir, upstreamPkgDir string) error {
-	// TODO: Printer should be a logr
-	pr := printer.New(os.Stdout, os.Stderr)
-	ctx = printer.WithContext(ctx, pr)
+func (m *defaultPackageUpdater) do(_ context.Context, localPkgDir, originalPkgDir, upstreamPkgDir string) error {
+	relPath := "."
+	localPath := filepath.Join(localPkgDir, relPath)
+	updatedPath := filepath.Join(upstreamPkgDir, relPath)
+	originPath := filepath.Join(originalPkgDir, relPath)
+	isRoot := true
 
-	{
-		relPath := "."
-		localPath := filepath.Join(localPkgDir, relPath)
-		updatedPath := filepath.Join(upstreamPkgDir, relPath)
-		originPath := filepath.Join(originalPkgDir, relPath)
-		isRoot := true
-
-		updateOptions := update.Options{
-			RelPackagePath: relPath,
-			LocalPath:      localPath,
-			UpdatedPath:    updatedPath,
-			OriginPath:     originPath,
-			IsRoot:         isRoot,
-		}
-		updater := update.ResourceMergeUpdater{}
-		if err := updater.Update(updateOptions); err != nil {
-			return err
-		}
+	updateOptions := update.Options{
+		RelPackagePath: relPath,
+		LocalPath:      localPath,
+		UpdatedPath:    updatedPath,
+		OriginPath:     originPath,
+		IsRoot:         isRoot,
 	}
+	updater := update.ResourceMergeUpdater{}
+	if err := updater.Update(updateOptions); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
- Use "_" instead of names for unused function parameters
- Use "_" instead of names for unused variables
- Remove unused functions and variables
- Replace `fmt.Errorf` with `errors.New` when error message contains no formatting