### PR TITLE
Adding TLS configuration for fn-runner image registries

### DIFF
--- a/func/internal/podevaluator_podmanager_test.go
+++ b/func/internal/podevaluator_podmanager_test.go
@@ -644,7 +644,7 @@ func TestPodManager(t *testing.T) {
 			fakeServer.evalFunc = tt.evalFunc
 
 			//Execute the function under test
-			go pm.getFuncEvalPodClient(ctx, tt.functionImage, time.Hour, tt.useGenerateName, false, "", "auth-secret")
+			go pm.getFuncEvalPodClient(ctx, tt.functionImage, time.Hour, tt.useGenerateName, false, "/var/tmp/config-secret/.dockerconfigjson", "auth-secret", false, "/var/tmp/tls-secret/")
 
 			if tt.podPatch != nil {
 				go func() {

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -44,6 +44,8 @@ var (
 	enablePrivateRegistries = flag.Bool("enable-private-registry", false, "if true enables the use of private registries and their authentication")
 	registryAuthSecretPath  = flag.String("registry-auth-secret-path", "/var/tmp/config-secret/.dockerconfigjson", "The path of the secret used in custom registry authentication")
 	registryAuthSecretName  = flag.String("registry-auth-secret-name", "auth-secret", "The name of the secret used in custom registry authentication")
+	enableTlsRegistries     = flag.Bool("enable-tls-registry", false, "if true enables tls configuration of registries")
+	tlsSecretPath           = flag.String("tls-secret-path", "/var/tmp/tls-secret/", "The path of the secret used in tls configuration")
 	podCacheConfig          = flag.String("pod-cache-config", "/pod-cache-config/pod-cache-config.yaml", "Path to the pod cache config file. The file is map of function name to TTL.")
 	podNamespace            = flag.String("pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
 	podTTL                  = flag.Duration("pod-ttl", 30*time.Minute, "TTL for pods before GC.")
@@ -92,7 +94,7 @@ func run() error {
 			if wrapperServerImage == "" {
 				return fmt.Errorf("environment variable %v must be set to use pod function evaluator runtime", wrapperServerImageEnv)
 			}
-			podEval, err := internal.NewPodEvaluator(*podNamespace, wrapperServerImage, *scanInterval, *podTTL, *podCacheConfig, *functionPodTemplateName, *enablePrivateRegistries, *registryAuthSecretPath, *registryAuthSecretName)
+			podEval, err := internal.NewPodEvaluator(*podNamespace, wrapperServerImage, *scanInterval, *podTTL, *podCacheConfig, *functionPodTemplateName, *enablePrivateRegistries, *registryAuthSecretPath, *registryAuthSecretName, *enableTlsRegistries, *tlsSecretPath)
 			if err != nil {
 				return fmt.Errorf("failed to initialize pod evaluator: %w", err)
 			}


### PR DESCRIPTION
Tackles issue [#819](https://github.com/nephio-project/nephio/issues/819).

Adds the ability to utilize a user's TLS certificates in the function runner for interacting with private TLS registries.

Documentation for how to configure the function runner in this way can be found [here]().