### PR TITLE
Fix rendering big (>4MB) packages with function-runner

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,8 +18,8 @@
                 "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
-            "env": { 
-                "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp", 
+            "env": {
+                "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp",
                 "WEBHOOK_HOST": "localhost",
                 "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
             }
@@ -31,9 +31,9 @@
             "mode": "auto",
             "program": "${workspaceFolder}/controllers",
             "cwd": "${workspaceFolder}",
-            "env": { 
-                "ENABLE_PACKAGEVARIANTS": "true", 
-                "ENABLE_PACKAGEVARIANTSETS": "true" 
+            "env": {
+                "ENABLE_PACKAGEVARIANTS": "true",
+                "ENABLE_PACKAGEVARIANTSETS": "true"
             }
         },
         {
@@ -45,9 +45,11 @@
             "args": [
                 "-test.v",
                 "-test.run",
-                "TestE2E/PorchSuite/TestGitRepositoryWithReleaseTagsAndDirectory"
+                "TestE2E/PorchSuite/TestPodEvaluatorWithLargeObjects"
             ],
-            "env": { "E2E": "1"}
+            "env": {
+                "E2E": "1"
+            }
         },
         {
             "name": "Launch Func Client",

--- a/Makefile
+++ b/Makefile
@@ -362,5 +362,5 @@ test-e2e: ## Run end-to-end tests
 	E2E=1 go test -v -failfast ./test/e2e/cli
 
 .PHONY: test-e2e-clean
-test-e2e-clean: porchctl ## Run end-to-end tests aginst a newly deployed porch in a newly created kind cluster
+test-e2e-clean: porchctl ## Run end-to-end tests against a newly deployed porch in a newly created kind cluster
 	./scripts/clean-e2e-test.sh

--- a/deployments/porch/2-function-runner.yaml
+++ b/deployments/porch/2-function-runner.yaml
@@ -44,6 +44,7 @@ spec:
             - --config=/config.yaml
             - --functions=/functions
             - --pod-namespace=porch-fn-system
+            - --max-request-body-size=6291456 # Keep this in sync with porch-server's corresponding argument
           env:
             - name: WRAPPER_SERVER_IMAGE
               value: docker.io/nephio/porch-wrapper-server:latest

--- a/deployments/porch/3-porch-server.yaml
+++ b/deployments/porch/3-porch-server.yaml
@@ -61,15 +61,15 @@ spec:
             - name: api-server-certs
               mountPath: /tmp/certs
           env:
-          # Uncomment to enable trace-reporting to jaeger
-          #- name: OTEL
-          #  value: otel://jaeger-oltp:4317
-          - name: OTEL_SERVICE_NAME
-            value: porch-server
-          - name: CERT_STORAGE_DIR
-            value: "/etc/webhook/certs"
-          - name: GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB
-            value: "true"
+            # Uncomment to enable trace-reporting to jaeger
+            #- name: OTEL
+            #  value: otel://jaeger-oltp:4317
+            - name: OTEL_SERVICE_NAME
+              value: porch-server
+            - name: CERT_STORAGE_DIR
+              value: "/etc/webhook/certs"
+            - name: GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB
+              value: "true"
           args:
             - --function-runner=function-runner:9445
             - --cache-directory=/cache
@@ -77,6 +77,7 @@ spec:
             - --secure-port=4443
             - --repo-sync-frequency=10m
             - --disable-validating-admissions-policy=true
+            - --max-request-body-size=6291456 # Keep this in sync with function-runner's corresponding argument
 
 ---
 apiVersion: v1

--- a/func/internal/podevaluator_podmanager_test.go
+++ b/func/internal/podevaluator_podmanager_test.go
@@ -635,6 +635,15 @@ func TestPodManager(t *testing.T) {
 				podReadyTimeout:         1 * time.Second,
 				functionPodTemplateName: tt.functionPodTemplateName,
 				managerNamespace:        tt.managerNamespace,
+
+				maxGrpcMessageSize: 4 * 1024 * 1024,
+
+				enablePrivateRegistries: false,
+				registryAuthSecretPath:  "/var/tmp/config-secret/.dockerconfigjson",
+				registryAuthSecretName:  "auth-secret",
+
+				enablePrivateRegistriesTls: false,
+				tlsSecretPath:              "/var/tmp/tls-secret/",
 			}
 
 			for k, v := range tt.imageMetadataCache {
@@ -644,7 +653,7 @@ func TestPodManager(t *testing.T) {
 			fakeServer.evalFunc = tt.evalFunc
 
 			//Execute the function under test
-			go pm.getFuncEvalPodClient(ctx, tt.functionImage, time.Hour, tt.useGenerateName, false, "/var/tmp/config-secret/.dockerconfigjson", "auth-secret", false, "/var/tmp/tls-secret/")
+			go pm.getFuncEvalPodClient(ctx, tt.functionImage, time.Hour, tt.useGenerateName)
 
 			if tt.podPatch != nil {
 				go func() {
@@ -683,7 +692,7 @@ func TestPodManager(t *testing.T) {
 				}
 
 				if !strings.HasPrefix(pod.Labels[krmFunctionLabel], tt.functionImage) {
-					t.Errorf("Expected pod to have label starting wiht %s, got %s", tt.functionImage, pod.Labels[krmFunctionLabel])
+					t.Errorf("Expected pod to have label starting with %s, got %s", tt.functionImage, pod.Labels[krmFunctionLabel])
 				}
 				if pod.Spec.Containers[0].Image != tt.functionImage {
 					t.Errorf("Expected pod to have image %s, got %s", tt.functionImage, pod.Spec.Containers[0].Image)

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -68,7 +68,7 @@ func main() {
 	flag.StringVar(&o.pod.RegistryAuthSecretName, "registry-auth-secret-name", "auth-secret", "The name of the secret used for authenticating to custom registries")
 	flag.BoolVar(&o.pod.EnablePrivateRegistriesTls, "enable-private-registries-tls", false, "if enabled, will prioritize use of user provided TLS secret when accessing registries")
 	flag.StringVar(&o.pod.TlsSecretPath, "tls-secret-path", "/var/tmp/tls-secret/", "The path of the secret used in tls configuration")
-	flag.IntVar(&o.pod.MaxGrpcMessageSize, "max-request-body-size", 6*1024*1024, "Maximum size of grpc messages in bytes.")
+	flag.IntVar(&o.pod.MaxGrpcMessageSize, "max-request-body-size", 6*1024*1024, "Maximum size of grpc messages in bytes. Keep this in sync with porch-server's corresponding argument.")
 
 	flag.Parse()
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -81,6 +81,7 @@ type ExtraConfig struct {
 	DefaultImagePrefix    string
 	RepoSyncFrequency     time.Duration
 	UseGitCaBundle        bool
+	MaxGrpcMessageSize    int
 }
 
 // Config defines the config for the apiserver
@@ -247,7 +248,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 		// evaluating a function, the runtimes will be tried in the same
 		// order as they are registered.
 		engine.WithBuiltinFunctionRuntime(),
-		engine.WithGRPCFunctionRuntime(c.ExtraConfig.FunctionRunnerAddress),
+		engine.WithGRPCFunctionRuntime(c.ExtraConfig.FunctionRunnerAddress, c.ExtraConfig.MaxGrpcMessageSize),
 		engine.WithCredentialResolver(credentialResolver),
 		engine.WithRunnerOptionsResolver(runnerOptionsResolver),
 		engine.WithReferenceResolver(referenceResolver),

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -58,7 +58,7 @@ type PorchServerOptions struct {
 	RepoSyncFrequency                time.Duration
 	UseGitCaBundle                   bool
 	DisableValidatingAdmissionPolicy bool
-	MaxRequestBodySize               int64
+	MaxRequestBodySize               int
 
 	SharedInformerFactory informers.SharedInformerFactory
 	StdOut                io.Writer
@@ -185,7 +185,7 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(sampleopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(apiserver.Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = OpenAPITitle
 	serverConfig.OpenAPIConfig.Info.Version = OpenAPIVersion
-	serverConfig.MaxRequestBodyBytes = o.MaxRequestBodySize
+	serverConfig.MaxRequestBodyBytes = int64(o.MaxRequestBodySize)
 
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return nil, err
@@ -200,6 +200,7 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 			FunctionRunnerAddress: o.FunctionRunnerAddress,
 			DefaultImagePrefix:    o.DefaultImagePrefix,
 			UseGitCaBundle:        o.UseGitCaBundle,
+			MaxGrpcMessageSize:    o.MaxRequestBodySize,
 		},
 	}
 	return config, nil
@@ -245,7 +246,7 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.FunctionRunnerAddress, "function-runner", "", "Address of the function runner gRPC service.")
 	fs.StringVar(&o.DefaultImagePrefix, "default-image-prefix", "gcr.io/kpt-fn/", "Default prefix for unqualified function names")
 	fs.StringVar(&o.CacheDirectory, "cache-directory", "", "Directory where Porch server stores repository and package caches.")
-	fs.Int64Var(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes.")
+	fs.IntVar(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes.")
 	fs.BoolVar(&o.UseGitCaBundle, "use-git-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards git.")
 	fs.BoolVar(&o.DisableValidatingAdmissionPolicy, "disable-validating-admissions-policy", true, "Determine whether to (dis|en)able the Validating Admission Policy, which requires k8s version >= v1.30")
 	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced and the background job repository refresh runs.")

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -246,7 +246,7 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.FunctionRunnerAddress, "function-runner", "", "Address of the function runner gRPC service.")
 	fs.StringVar(&o.DefaultImagePrefix, "default-image-prefix", "gcr.io/kpt-fn/", "Default prefix for unqualified function names")
 	fs.StringVar(&o.CacheDirectory, "cache-directory", "", "Directory where Porch server stores repository and package caches.")
-	fs.IntVar(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes.")
+	fs.IntVar(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes. Keep this in sync with function-runner's corresponding argument.")
 	fs.BoolVar(&o.UseGitCaBundle, "use-git-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards git.")
 	fs.BoolVar(&o.DisableValidatingAdmissionPolicy, "disable-validating-admissions-policy", true, "Determine whether to (dis|en)able the Validating Admission Policy, which requires k8s version >= v1.30")
 	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced and the background job repository refresh runs.")

--- a/pkg/engine/clone_test.go
+++ b/pkg/engine/clone_test.go
@@ -159,7 +159,7 @@ func startGitServer(t *testing.T, repo *git.Repo, _ ...git.GitServerOption) stri
 	return fmt.Sprintf("http://%s/%s", address, key)
 }
 
-// TODO(mortent): See if we can restruture the packages to
+// TODO(mortent): See if we can restructure the packages to
 // avoid having to create separate implementations of the auth
 // interfaces here.
 type credentialResolver struct {

--- a/pkg/engine/grpcruntime.go
+++ b/pkg/engine/grpcruntime.go
@@ -33,14 +33,20 @@ type grpcRuntime struct {
 	client evaluator.FunctionEvaluatorClient
 }
 
-func newGRPCFunctionRuntime(address string) (*grpcRuntime, error) {
+func newGRPCFunctionRuntime(address string, maxGrpcMessageSize int) (*grpcRuntime, error) {
 	if address == "" {
 		return nil, fmt.Errorf("address is required to instantiate gRPC function runtime")
 	}
 
 	klog.Infof("Dialing grpc function runner %q", address)
 
-	cc, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.Dial(address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxGrpcMessageSize),
+			grpc.MaxCallSendMsgSize(maxGrpcMessageSize),
+		),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial grpc function evaluator: %w", err)
 	}

--- a/pkg/engine/options.go
+++ b/pkg/engine/options.go
@@ -58,9 +58,9 @@ func WithBuiltinFunctionRuntime() EngineOption {
 	})
 }
 
-func WithGRPCFunctionRuntime(address string) EngineOption {
+func WithGRPCFunctionRuntime(address string, maxGrpcMessageSize int) EngineOption {
 	return EngineOptionFunc(func(engine *cadEngine) error {
-		runtime, err := newGRPCFunctionRuntime(address)
+		runtime, err := newGRPCFunctionRuntime(address, maxGrpcMessageSize)
 		if err != nil {
 			return fmt.Errorf("failed to create function runtime: %w", err)
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2016,7 +2016,7 @@ func (t *PorchSuite) TestPodEvaluator(ctx context.Context) {
 
 	const (
 		generateFolderImage = "gcr.io/kpt-fn/generate-folders:v0.1.1" // This function is a TS based function.
-		setAnnotationsImage = "gcr.io/kpt-fn/set-annotations:v0.1.3"  // set-annotations:v0.1.3 is an older version that porch maps it neither to built-in nor exec.
+		setAnnotationsImage = "gcr.io/kpt-fn/set-annotations:v0.1.3"  // set-annotations:v0.1.3 is an older version that porch maps neither to built-in nor exec.
 	)
 
 	// Register the repository as 'git-fn'
@@ -2214,6 +2214,108 @@ func (t *PorchSuite) TestPodEvaluatorWithFailure(ctx context.Context) {
 	expectedErrMsg := "Validating arbitrary CRDs is not supported"
 	if err == nil || !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Fatalf("expected the error to contain %q, but got %v", expectedErrMsg, err)
+	}
+}
+
+func (t *PorchSuite) TestPodEvaluatorWithLargeObjects(ctx context.Context) {
+	if t.TestRunnerIsLocal {
+		t.Skipf("Skipping due to not having pod evaluator in local mode")
+	}
+	const (
+		setAnnotationsImage = "gcr.io/kpt-fn/set-annotations:v0.1.3" // set-annotations:v0.1.3 is an older version that porch maps neither to built-in nor exec.
+	)
+
+	t.RegisterMainGitRepositoryF(ctx, "git-fn-pod-large")
+
+	// Create Package Revision
+	pr := &porchapi.PackageRevision{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       porchapi.PackageRevisionGVR.Resource,
+			APIVersion: porchapi.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.Namespace,
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			PackageName:    "new-package",
+			WorkspaceName:  "workspace",
+			RepositoryName: "git-fn-pod-large",
+			Tasks: []porchapi.Task{
+				{
+					Type: porchapi.TaskTypeInit,
+					Init: &porchapi.PackageInitTaskSpec{
+						Description: "this is a test",
+					},
+				},
+			},
+		},
+	}
+
+	t.CreateF(ctx, pr)
+
+	var prr porchapi.PackageRevisionResources
+	t.GetF(ctx, client.ObjectKeyFromObject(pr), &prr)
+
+	testDataSize := 5 * 1024 * 1024
+
+	// set-annotations:v0.1.3 is an older version that porch maps neither to built-in nor exec runtimes.
+	prr.Spec.Resources["Kptfile"] += `
+pipeline:
+  mutators:
+  - image: ` + setAnnotationsImage + `
+    configMap:
+      test-key: test-val
+    selectors:
+       - name: test-data
+`
+	prr.Spec.Resources["largefile.yaml"] = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-data
+  labels:
+    something: somewhere
+data:
+  value: "` + strings.Repeat("a", testDataSize) + `"
+`
+
+	t.UpdateF(ctx, &prr)
+
+	rs := prr.Status.RenderStatus
+	if rs.Err != "" || rs.Result.ExitCode != 0 {
+		t.Fatalf("Couldn't render large package! exit code: %v,\n%v", rs.Result.ExitCode, rs.Err)
+	}
+
+	// Get package resources
+	t.GetF(ctx, client.ObjectKeyFromObject(pr), &prr)
+
+	for name, obj := range prr.Spec.Resources {
+		if !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		node, err := yaml.Parse(obj)
+		if err != nil {
+			t.Errorf("failed to parse object: %v", err)
+		}
+		switch node.GetName() {
+		case "kptfile.kpt.dev":
+			continue
+		case "test-data":
+			f := node.Field("data")
+			if f.IsNilOrEmpty() {
+				t.Fatalf("couldn't find data field in test-data")
+			}
+			long_string, err := f.Value.GetString("value")
+			if err != nil {
+				t.Fatalf("couldn't find large string in test-data: %v", err)
+			}
+			if len(long_string) != testDataSize {
+				t.Fatalf("large string size mismatch. want: %v, got: %v", testDataSize, len(long_string))
+			}
+			if node.GetAnnotations()["test-key"] != "test-val" {
+				t.Errorf("Object (%s %q) should contain annotation `test-key:test-val`, but we got: %v", node.GetKind(), node.GetName(), node.GetAnnotations())
+			}
+		}
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2297,10 +2297,7 @@ data:
 		if err != nil {
 			t.Errorf("failed to parse object: %v", err)
 		}
-		switch node.GetName() {
-		case "kptfile.kpt.dev":
-			continue
-		case "test-data":
+		if node.GetName() == "test-data" {
 			f := node.Field("data")
 			if f.IsNilOrEmpty() {
 				t.Fatalf("couldn't find data field in test-data")


### PR DESCRIPTION
Fixes https://github.com/nephio-project/nephio/issues/823

PR #121 successfully solved the issue of creating/updating/querying big packages via the porch API. However if a big package has a non-empty pipeline, the rendering of those large packages fail with an error message mentioning grpc max message size (see the issue referenced above). This PR fixes that.

(It also contains some minor refactoring that eliminates some unnecessarily long argument lists in function-runner.)
