### PR TITLE
Fix "release" GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]"
       - "v[0-9]+.[0-9]+.[0-9]-pre[0-9]+"
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,21 +31,25 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.22.2'
+          go-version: ">=1.22.2"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
+      - name: Download kpt CLI
+        run: mkdir -p bin && wget -O bin/kpt https://github.com/kptdev/kpt/releases/download/v1.0.0-beta.55/kpt_linux_amd64 && chmod +x bin/kpt
+
       - name: Build porch blueprint
-        run: IMAGE_REPO=docker.io/nephio IMAGE_TAG=${{ github.ref_name }} make deployment-config
+        run: PATH=./bin:$PATH IMAGE_REPO=docker.io/nephio IMAGE_TAG=${{ github.ref_name }} make deployment-config
 
       - name: Run GoReleaser
         id: run-goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release --skip-validate -f release/tag/goreleaser.yaml
+          version: "~> v2"
+          args: release --skip=validate -f release/tag/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Unfortunately my previous PR #133 broke the release script, since it relied on the kpt CLI that is missing from the runner.
This PR hopefully fixes that.