### PR TITLE
Rename interface PackageDraft to PackageRevisionDraft

### DIFF
--- a/pkg/cache/memory/draft.go
+++ b/pkg/cache/memory/draft.go
@@ -23,11 +23,11 @@ import (
 )
 
 type cachedDraft struct {
-	repository.PackageDraft
+	repository.PackageRevisionDraft
 	cache *cachedRepository
 }
 
-var _ repository.PackageDraft = &cachedDraft{}
+var _ repository.PackageRevisionDraft = &cachedDraft{}
 
 func (cd *cachedDraft) Close(ctx context.Context, version string) (repository.PackageRevision, error) {
 	ctx, span := tracer.Start(ctx, "cachedDraft::Close", trace.WithAttributes())
@@ -62,7 +62,7 @@ func (cd *cachedDraft) Close(ctx context.Context, version string) (repository.Pa
 		return nil, err
 	}
 
-	if closed, err := cd.PackageDraft.Close(ctx, nextVersion); err != nil {
+	if closed, err := cd.PackageRevisionDraft.Close(ctx, nextVersion); err != nil {
 		return nil, err
 	} else {
 		return cd.cache.update(ctx, closed)

--- a/pkg/cache/memory/repository.go
+++ b/pkg/cache/memory/repository.go
@@ -165,19 +165,19 @@ func (r *cachedRepository) getCachedPackages(ctx context.Context, forceRefresh b
 	return packages, packageRevisions, err
 }
 
-func (r *cachedRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageDraft, error) {
+func (r *cachedRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageRevisionDraft, error) {
 	created, err := r.repo.CreatePackageRevision(ctx, obj)
 	if err != nil {
 		return nil, err
 	}
 
 	return &cachedDraft{
-		PackageDraft: created,
-		cache:        r,
+		PackageRevisionDraft: created,
+		cache:                r,
 	}, nil
 }
 
-func (r *cachedRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageDraft, error) {
+func (r *cachedRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
 	// Unwrap
 	unwrapped := old.(*cachedPackageRevision).PackageRevision
 	created, err := r.repo.UpdatePackageRevision(ctx, unwrapped)
@@ -186,8 +186,8 @@ func (r *cachedRepository) UpdatePackageRevision(ctx context.Context, old reposi
 	}
 
 	return &cachedDraft{
-		PackageDraft: created,
-		cache:        r,
+		PackageRevisionDraft: created,
+		cache:                r,
 	}, nil
 }
 

--- a/pkg/git/draft.go
+++ b/pkg/git/draft.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type gitPackageDraft struct {
+type gitPackageRevisionDraft struct {
 	parent        *gitRepository // repo is repo containing the package
 	path          string         // the path to the package from the repo root
 	revision      string
@@ -49,29 +49,29 @@ type gitPackageDraft struct {
 	tree plumbing.Hash
 }
 
-var _ repository.PackageDraft = &gitPackageDraft{}
+var _ repository.PackageRevisionDraft = &gitPackageRevisionDraft{}
 
-func (d *gitPackageDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
+func (d *gitPackageRevisionDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
 	ctx, span := tracer.Start(ctx, "gitPackageDraft::UpdateResources", trace.WithAttributes())
 	defer span.End()
 
 	return d.parent.UpdateDraftResources(ctx, d, new, change)
 }
 
-func (d *gitPackageDraft) UpdateLifecycle(ctx context.Context, new v1alpha1.PackageRevisionLifecycle) error {
+func (d *gitPackageRevisionDraft) UpdateLifecycle(ctx context.Context, new v1alpha1.PackageRevisionLifecycle) error {
 	d.lifecycle = new
 	return nil
 }
 
 // Finish round of updates.
-func (d *gitPackageDraft) Close(ctx context.Context, version string) (repository.PackageRevision, error) {
+func (d *gitPackageRevisionDraft) Close(ctx context.Context, version string) (repository.PackageRevision, error) {
 	ctx, span := tracer.Start(ctx, "gitPackageDraft::Close", trace.WithAttributes())
 	defer span.End()
 
 	return d.parent.CloseDraft(ctx, version, d)
 }
 
-func (d *gitPackageDraft) GetName() string {
+func (d *gitPackageRevisionDraft) GetName() string {
 	packageDirectory := d.parent.directory
 	packageName := strings.TrimPrefix(d.path, packageDirectory+"/")
 	return packageName

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -350,7 +350,7 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 	return result, nil
 }
 
-func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageDraft, error) {
+func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageRevisionDraft, error) {
 	ctx, span := tracer.Start(ctx, "gitRepository::CreatePackageRevision", trace.WithAttributes())
 	defer span.End()
 	r.mutex.Lock()
@@ -378,7 +378,7 @@ func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 
 	// TODO: This should also create a new 'Package' resource if one does not already exist
 
-	return &gitPackageDraft{
+	return &gitPackageRevisionDraft{
 		parent:        r,
 		path:          packagePath,
 		workspaceName: obj.Spec.WorkspaceName,
@@ -391,7 +391,7 @@ func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 	}, nil
 }
 
-func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageDraft, error) {
+func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
 	ctx, span := tracer.Start(ctx, "gitRepository::UpdatePackageRevision", trace.WithAttributes())
 	defer span.End()
 	r.mutex.Lock()
@@ -424,7 +424,7 @@ func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repositor
 	// sure we don't end up requesting the same lock twice.
 	lifecycle := r.getLifecycle(ctx, oldGitPackage)
 
-	return &gitPackageDraft{
+	return &gitPackageRevisionDraft{
 		parent:        r,
 		path:          oldGitPackage.path,
 		revision:      oldGitPackage.revision,
@@ -1427,7 +1427,7 @@ func (r *gitRepository) UpdateLifecycle(ctx context.Context, pkgRev *gitPackageR
 	return nil
 }
 
-func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPackageDraft, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
+func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPackageRevisionDraft, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
 	ctx, span := tracer.Start(ctx, "gitPackageDraft::UpdateResources", trace.WithAttributes())
 	defer span.End()
 	r.mutex.Lock()
@@ -1480,7 +1480,7 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 	return nil
 }
 
-func (r *gitRepository) CloseDraft(ctx context.Context, version string, d *gitPackageDraft) (*gitPackageRevision, error) {
+func (r *gitRepository) CloseDraft(ctx context.Context, version string, d *gitPackageRevisionDraft) (*gitPackageRevision, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -1601,7 +1601,7 @@ func (r *gitRepository) doGitWithAuth(ctx context.Context, op func(transport.Aut
 	return nil
 }
 
-func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageDraft) (commitHash, newPackageTreeHash plumbing.Hash, base *plumbing.Reference, err error) {
+func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageRevisionDraft) (commitHash, newPackageTreeHash plumbing.Hash, base *plumbing.Reference, err error) {
 	branch := r.branch
 	localRef := branch.RefInLocal()
 

--- a/pkg/oci/mutate.go
+++ b/pkg/oci/mutate.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (r *ociRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageDraft, error) {
+func (r *ociRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (repository.PackageRevisionDraft, error) {
 	base := empty.Image
 
 	packageName := obj.Spec.PackageName
@@ -65,7 +65,7 @@ func (r *ociRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 	}, nil
 }
 
-func (r *ociRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageDraft, error) {
+func (r *ociRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
 	oldPackage := old.(*ociPackageRevision)
 	packageName := oldPackage.packageName
 	workspace := oldPackage.workspaceName
@@ -118,7 +118,7 @@ type ociPackageDraft struct {
 	lifecycle v1alpha1.PackageRevisionLifecycle // New value of the package revision lifecycle
 }
 
-var _ repository.PackageDraft = (*ociPackageDraft)(nil)
+var _ repository.PackageRevisionDraft = (*ociPackageDraft)(nil)
 
 func (p *ociPackageDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, task *v1alpha1.Task) error {
 	_, span := tracer.Start(ctx, "ociPackageDraft::UpdateResources", trace.WithAttributes())

--- a/pkg/repository/fake/repository.go
+++ b/pkg/repository/fake/repository.go
@@ -57,7 +57,7 @@ func (r *Repository) ListPackageRevisions(_ context.Context, filter repository.L
 	return revs, nil
 }
 
-func (r *Repository) CreatePackageRevision(_ context.Context, pr *v1alpha1.PackageRevision) (repository.PackageDraft, error) {
+func (r *Repository) CreatePackageRevision(_ context.Context, pr *v1alpha1.PackageRevision) (repository.PackageRevisionDraft, error) {
 	return nil, nil
 }
 
@@ -65,7 +65,7 @@ func (r *Repository) DeletePackageRevision(context.Context, repository.PackageRe
 	return nil
 }
 
-func (r *Repository) UpdatePackageRevision(context.Context, repository.PackageRevision) (repository.PackageDraft, error) {
+func (r *Repository) UpdatePackageRevision(context.Context, repository.PackageRevision) (repository.PackageRevisionDraft, error) {
 	return nil, nil
 }
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -95,9 +95,14 @@ type PackageRevision interface {
 	// ResourceVersion returns the Kube resource version of the package
 	ResourceVersion() string
 
+	// Create the main package revision
+	// TODO: This is a git thing and probably shouldn't be on the generic PackageRevision interface
 	ToMainPackageRevision() PackageRevision
 
+	// Get the Kubernetes metadata for the package revision
 	GetMeta() meta.PackageRevisionMeta
+
+	// Set the Kubernetes metadata for the package revision
 	SetMeta(meta.PackageRevisionMeta)
 }
 
@@ -118,7 +123,7 @@ type Package interface {
 	GetLatestRevision() string
 }
 
-type PackageDraft interface {
+type PackageRevisionDraft interface {
 	UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, task *v1alpha1.Task) error
 	// Updates desired lifecycle of the package. The lifecycle is applied on Close.
 	UpdateLifecycle(ctx context.Context, new v1alpha1.PackageRevisionLifecycle) error
@@ -196,13 +201,13 @@ type Repository interface {
 	ListPackageRevisions(ctx context.Context, filter ListPackageRevisionFilter) ([]PackageRevision, error)
 
 	// CreatePackageRevision creates a new package revision
-	CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (PackageDraft, error)
+	CreatePackageRevision(ctx context.Context, obj *v1alpha1.PackageRevision) (PackageRevisionDraft, error)
 
 	// DeletePackageRevision deletes a package revision
 	DeletePackageRevision(ctx context.Context, old PackageRevision) error
 
 	// UpdatePackageRevision updates a package
-	UpdatePackageRevision(ctx context.Context, old PackageRevision) (PackageDraft, error)
+	UpdatePackageRevision(ctx context.Context, old PackageRevision) (PackageRevisionDraft, error)
 
 	// ListPackages lists all packages in the repository
 	ListPackages(ctx context.Context, filter ListPackageFilter) ([]Package, error)

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -69,7 +69,7 @@ func (th *genericTaskHandler) SetReferenceResolver(referenceResolver repository.
 	th.referenceResolver = referenceResolver
 }
 
-func (th *genericTaskHandler) ApplyTasks(ctx context.Context, draft repository.PackageDraft, repositoryObj *configapi.Repository, obj *api.PackageRevision, packageConfig *builtins.PackageConfig) error {
+func (th *genericTaskHandler) ApplyTasks(ctx context.Context, draft repository.PackageRevisionDraft, repositoryObj *configapi.Repository, obj *api.PackageRevision, packageConfig *builtins.PackageConfig) error {
 	var mutations []mutation
 
 	// Unless first task is Init or Clone, insert Init to create an empty package.
@@ -106,7 +106,7 @@ func (th *genericTaskHandler) ApplyTasks(ctx context.Context, draft repository.P
 	return nil
 }
 
-func (th *genericTaskHandler) DoPRMutations(ctx context.Context, namespace string, repoPR repository.PackageRevision, oldObj *api.PackageRevision, newObj *api.PackageRevision, draft repository.PackageDraft) error {
+func (th *genericTaskHandler) DoPRMutations(ctx context.Context, namespace string, repoPR repository.PackageRevision, oldObj *api.PackageRevision, newObj *api.PackageRevision, draft repository.PackageRevisionDraft) error {
 	ctx, span := tracer.Start(ctx, "genericTaskHandler::DoPRMutations", trace.WithAttributes())
 	defer span.End()
 
@@ -198,7 +198,7 @@ func taskTypeOneOf(taskType api.TaskType, oneOf ...api.TaskType) bool {
 	return false
 }
 
-func (th *genericTaskHandler) DoPRResourceMutations(ctx context.Context, pr2Update repository.PackageRevision, draft repository.PackageDraft, oldRes, newRes *api.PackageRevisionResources) (*api.RenderStatus, error) {
+func (th *genericTaskHandler) DoPRResourceMutations(ctx context.Context, pr2Update repository.PackageRevision, draft repository.PackageRevisionDraft, oldRes, newRes *api.PackageRevisionResources) (*api.RenderStatus, error) {
 	ctx, span := tracer.Start(ctx, "genericTaskHandler::DoPRResourceMutations", trace.WithAttributes())
 	defer span.End()
 
@@ -438,7 +438,7 @@ func isRenderMutation(m mutation) bool {
 }
 
 // applyResourceMutations mutates the resources and returns the most recent renderResult.
-func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, baseResources repository.PackageResources, mutations []mutation) (applied repository.PackageResources, renderStatus *api.RenderStatus, err error) {
+func applyResourceMutations(ctx context.Context, draft repository.PackageRevisionDraft, baseResources repository.PackageResources, mutations []mutation) (applied repository.PackageResources, renderStatus *api.RenderStatus, err error) {
 	var lastApplied mutation
 	for _, m := range mutations {
 		updatedResources, taskResult, err := m.apply(ctx, baseResources)

--- a/pkg/task/taskhandler.go
+++ b/pkg/task/taskhandler.go
@@ -37,9 +37,9 @@ type TaskHandler interface {
 	SetCredentialResolver(repository.CredentialResolver)
 	SetReferenceResolver(repository.ReferenceResolver)
 
-	ApplyTasks(ctx context.Context, draft repository.PackageDraft, repositoryObj *configapi.Repository, obj *api.PackageRevision, packageConfig *builtins.PackageConfig) error
-	DoPRMutations(ctx context.Context, namespace string, repoPR repository.PackageRevision, oldObj *api.PackageRevision, newObj *api.PackageRevision, draft repository.PackageDraft) error
-	DoPRResourceMutations(ctx context.Context, pr2Update repository.PackageRevision, draft repository.PackageDraft, oldRes, newRes *api.PackageRevisionResources) (*api.RenderStatus, error)
+	ApplyTasks(ctx context.Context, draft repository.PackageRevisionDraft, repositoryObj *configapi.Repository, obj *api.PackageRevision, packageConfig *builtins.PackageConfig) error
+	DoPRMutations(ctx context.Context, namespace string, repoPR repository.PackageRevision, oldObj *api.PackageRevision, newObj *api.PackageRevision, draft repository.PackageRevisionDraft) error
+	DoPRResourceMutations(ctx context.Context, pr2Update repository.PackageRevision, draft repository.PackageRevisionDraft, oldRes, newRes *api.PackageRevisionResources) (*api.RenderStatus, error)
 }
 
 type mutation interface {


### PR DESCRIPTION
This is a cleanup PR that renames the interface `PackageDraft` to `PackageRevisionDraft`. This interface is used to manage package revision drafts. The interface is renamed to improve the readability of the Porch code.