### PR TITLE
Render pipeline failure should block package push to remote

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -504,7 +504,9 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 	}
 
 	renderStatus, err := cad.taskHandler.DoPRResourceMutations(ctx, pr2Update, draft, oldRes, newRes)
-
+	if err != nil {
+		return nil, renderStatus, err
+	}
 	// No lifecycle change when updating package resources; updates are done.
 	repoPkgRev, err := draft.Close(ctx, "")
 	if err != nil {

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -183,6 +183,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 
 	rev, renderStatus, err := r.cad.UpdatePackageResources(ctx, &repositoryObj, oldRepoPkgRev, oldApiPkgRevResources, newObj)
 	if err != nil {
+		err := fmt.Errorf("%w%s%s%s", err, "\n\nKpt function pipeline error occurred during render.", "\nPackage has NOT been pushed to remote.", "\nAmend local package using error message above & retry.")
 		return nil, false, apierrors.NewInternalError(err)
 	}
 

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -22,6 +22,7 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/api/porchconfig/v1alpha1"
+	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/pkg/repository"
 	"github.com/nephio-project/porch/pkg/util"
 	"go.opentelemetry.io/otel/trace"
@@ -183,7 +184,11 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 
 	rev, renderStatus, err := r.cad.UpdatePackageResources(ctx, &repositoryObj, oldRepoPkgRev, oldApiPkgRevResources, newObj)
 	if err != nil {
-		err := fmt.Errorf("%w%s%s%s", err, "\n\nKpt function pipeline error occurred during render.", "\nPackage has NOT been pushed to remote.", "\nAmend local package using error message above & retry.")
+		var specificErr *errors.Error
+		if errors.As(err, &specificErr) {
+			err := fmt.Errorf("%w%s%s%s", err, "\n\nKpt function pipeline error occurred during render.", "\nPackage has NOT been pushed to remote.", "\nAmend local package using error message above & retry.")
+			return nil, false, apierrors.NewInternalError(err)
+		}
 		return nil, false, apierrors.NewInternalError(err)
 	}
 

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -22,7 +22,6 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/api/porchconfig/v1alpha1"
-	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/pkg/repository"
 	"github.com/nephio-project/porch/pkg/util"
 	"go.opentelemetry.io/otel/trace"
@@ -184,11 +183,6 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 
 	rev, renderStatus, err := r.cad.UpdatePackageResources(ctx, &repositoryObj, oldRepoPkgRev, oldApiPkgRevResources, newObj)
 	if err != nil {
-		var specificErr *errors.Error
-		if errors.As(err, &specificErr) {
-			err := fmt.Errorf("%w%s%s%s", err, "\n\nKpt function pipeline error occurred during render.", "\nPackage has NOT been pushed to remote.", "\nAmend local package using error message above & retry.")
-			return nil, false, apierrors.NewInternalError(err)
-		}
 		return nil, false, apierrors.NewInternalError(err)
 	}
 

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -462,6 +462,7 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageDraft, 
 			renderStatus = taskResult.RenderStatus
 		}
 		if err != nil {
+			err = fmt.Errorf("%w%s%s%s", err, "\n\nKpt function pipeline error occured during render.", "\nPackage has NOT been pushed to remote.", "\nAmend local package using error message above & retry.")
 			return updatedResources, renderStatus, err
 		}
 

--- a/test/e2e/cli/config.go
+++ b/test/e2e/cli/config.go
@@ -38,6 +38,8 @@ type Command struct {
 	Yaml bool `yaml:"yaml,omitempty"`
 	// IgnoreWhitespace indicates that whitespace differences should be ignored in the output
 	IgnoreWhitespace bool `yaml:"ignoreWhitespace,omitempty"`
+	// StdErrTabToWhitespace replaces "\t" (tab) character with whitespace "  "
+	StdErrTabToWhitespace bool `yaml:"stdErrTabToWhitespace,omitempty"`
 }
 
 type TestCaseConfig struct {

--- a/test/e2e/cli/suite.go
+++ b/test/e2e/cli/suite.go
@@ -148,6 +148,10 @@ func (s *CliTestSuite) RunTestCase(t *testing.T, tc TestCaseConfig) {
 			command.Stdout = strings.ReplaceAll(command.Stdout, search, replace)
 			command.Stderr = strings.ReplaceAll(command.Stderr, search, replace)
 		}
+				
+		if command.StdErrTabToWhitespace {
+			stderrStr = strings.ReplaceAll(stderrStr, "\t", "  ") // Replace tabs with spaces
+		}
 
 		if command.IgnoreWhitespace {
 			command.Stdout = normalizeWhitespace(command.Stdout)

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -188,3 +188,82 @@ commands:
           name: kptfile.kpt.dev
       kind: ResourceList
     yaml: true
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+    stdin: |
+      apiVersion: config.kubernetes.io/v1
+      items:
+      - apiVersion: ""
+        kind: KptRevisionMetadata
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: .KptRevisionMetadata
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: .KptRevisionMetadata
+          name: git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+          namespace: rpkg-push
+          uid: 8d61685e-584c-5b89-bd30-a8d8dccb13f9
+          resourceVersion: "1"
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Updated Test Package Description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+      kind: ResourceList
+    stderr: |
+      Error: Internal error occurred: Operation cannot be fulfilled on packagerevisionresources.porch.kpt.dev "git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f": the object has been modified; please apply your changes to the latest version and try again 
+    exitCode: 1
+    yaml: true
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+      - /tmp/porch-e2e/testing-invalid-render
+  - args:
+    - sh
+    - -c
+    - |
+      echo "pipeline:\n  mutators:\n  - image: gcr.io/kpt-fn/set-namespace:v0.4.0\n    configMap:\n      namespace: example-ns\n  - image: gcr.io/kpt-fn/set-annotations:v0.1.4\n" >> /tmp/porch-e2e/testing-invalid-render/Kptfile
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - --namespace=rpkg-push
+      - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
+      - /tmp/porch-e2e/testing-invalid-render
+    stderr: |
+      Error: Internal error occurred: fn.render: pkg /:
+        pkg.render:
+        pipeline.run: func eval "gcr.io/kpt-fn/set-annotations:v0.1.4" failed: rpc error: code = Internal desc = Failed to execute function "gcr.io/kpt-fn/set-annotations:v0.1.4": exit status 1 ([error] : failed to configure function: `functionConfig` must be a `ConfigMap` or `SetAnnotations`)
+
+      Error occurred rendering package in kpt function pipeline.
+      Package has NOT been pushed to remote.
+      Please fix package locally (modify until 'kpt fn render' succeeds) and retry. 
+    stdErrTabToWhitespace: true
+    exitCode: 1


### PR DESCRIPTION
Tackles [#818](https://github.com/nephio-project/nephio/issues/818) and potentially [#658](https://github.com/nephio-project/nephio/issues/658).
The main change this PR proposes is that a package who's render pipeline has failed during a [porchctl rpkg push] should not be allowed to go further into git. 
There are fundamental issues with the package in this scenario and can lead to more issues down the line for example in #818. 
They should be handled by the user on the local version and retry should be attempted until the package's kpt function pipeline succeeds.