### PR TITLE
Add missing mutex to refreshAllCachedPackages

### DIFF
--- a/pkg/cache/memory/draft.go
+++ b/pkg/cache/memory/draft.go
@@ -36,12 +36,15 @@ func (cd *cachedDraft) Close(ctx context.Context, version string) (repository.Pa
 	if err != nil {
 		return nil, err
 	}
+	//refreshAllCachedPackages requires mutex to be held.
+	cd.cache.mutex.Lock()
 	if v != cd.cache.lastVersion {
 		_, _, err = cd.cache.refreshAllCachedPackages(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
+	cd.cache.mutex.Unlock()
 
 	revisions, err := cd.cache.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 		Package: cd.GetName(),

--- a/pkg/cache/memory/repository.go
+++ b/pkg/cache/memory/repository.go
@@ -83,13 +83,6 @@ func newRepository(id string, repoSpec *configapi.Repository, repo repository.Re
 	return r
 }
 
-func (r *cachedRepository) Refresh(ctx context.Context) error {
-
-	_, _, err := r.refreshAllCachedPackages(ctx)
-
-	return err
-}
-
 func (r *cachedRepository) Version(ctx context.Context) (string, error) {
 	return r.repo.Version(ctx)
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1709,10 +1709,6 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 	return t, nil
 }
 
-func (r *gitRepository) Refresh(_ context.Context) error {
-	return nil
-}
-
 // See https://eli.thegreenplace.net/2021/generic-functions-on-slices-with-go-type-parameters/
 // func ReverseSlice[T any](s []T) { // Ready for generics!
 func reverseSlice(s []v1alpha1.Task) {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -245,10 +245,6 @@ func (r *ociRepository) buildPackageRevision(ctx context.Context, name oci.Image
 	return p, nil
 }
 
-func (r *ociRepository) Refresh(_ context.Context) error {
-	return nil
-}
-
 // ToMainPackageRevision implements repository.PackageRevision.
 func (p *ociPackageRevision) ToMainPackageRevision() repository.PackageRevision {
 	panic("unimplemented")

--- a/pkg/repository/fake/repository.go
+++ b/pkg/repository/fake/repository.go
@@ -80,7 +80,3 @@ func (r *Repository) CreatePackage(_ context.Context, pr *v1alpha1.PorchPackage)
 func (r *Repository) DeletePackage(_ context.Context, pr repository.Package) error {
 	return nil
 }
-
-func (r *Repository) Refresh(_ context.Context) error {
-	return nil
-}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -218,9 +218,6 @@ type Repository interface {
 
 	// Close cleans up any resources associated with the repository
 	Close() error
-
-	// Refresh the repository
-	Refresh(ctx context.Context) error
 }
 
 // The definitions below would be more appropriately located in a package usable by any Porch component.


### PR DESCRIPTION
This PR adds a missing mutex to the draft.go and removes the redundant refresh function.