### PR TITLE
Add tracing to cache close function

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,5 +23,5 @@ import (
 
 type Cache interface {
 	OpenRepository(ctx context.Context, repositorySpec *configapi.Repository) (repository.Repository, error)
-	CloseRepository(repositorySpec *configapi.Repository, allRepos []configapi.Repository) error
+	CloseRepository(ctx context.Context, repositorySpec *configapi.Repository, allRepos []configapi.Repository) error
 }

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -171,7 +171,10 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 	}
 }
 
-func (c *Cache) CloseRepository(repositorySpec *configapi.Repository, allRepos []configapi.Repository) error {
+func (c *Cache) CloseRepository(ctx context.Context, repositorySpec *configapi.Repository, allRepos []configapi.Repository) error {
+	_, span := tracer.Start(ctx, "Cache::OpenRepository", trace.WithAttributes())
+	defer span.End()
+
 	key, err := getCacheKey(repositorySpec)
 	if err != nil {
 		return err

--- a/pkg/cache/memory/cache_test.go
+++ b/pkg/cache/memory/cache_test.go
@@ -251,7 +251,7 @@ func openRepositoryFromArchive(t *testing.T, ctx context.Context, testPath, name
 	}
 
 	t.Cleanup(func() {
-		err := cache.CloseRepository(apiRepo, []v1alpha1.Repository{*apiRepo})
+		err := cache.CloseRepository(ctx, apiRepo, []v1alpha1.Repository{*apiRepo})
 		if err != nil {
 			t.Errorf("CloseRepository(%q) failed: %v", address, err)
 		}

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -144,7 +144,7 @@ func (b *background) updateCache(ctx context.Context, event watch.EventType, rep
 		if err := b.coreClient.List(ctx, &repoList); err != nil {
 			return err
 		}
-		return b.cache.CloseRepository(repository, repoList.Items)
+		return b.cache.CloseRepository(ctx, repository, repoList.Items)
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)
 	}


### PR DESCRIPTION
This PR adds passing of the context on the `cache.CloseRepository()` interface function signature and adds tracing to the cache `CloseRepository()` function.