### PR TITLE
Fix misleading error msg & adding Stderr "contains" argument check in CLI tests

### DIFF
--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -458,10 +458,14 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageRevisio
 		}
 		if taskResult != nil && task.Type == api.TaskTypeEval {
 			renderStatus = taskResult.RenderStatus
+			if err != nil {
+				klog.Error(err)
+				err = fmt.Errorf("%w\n\n%s\n%s\n%s", err, "Error occurred rendering package in kpt function pipeline.", "Package has NOT been pushed to remote.", "Please fix package locally (modify until 'kpt fn render' succeeds) and retry.")
+				return updatedResources, renderStatus, err
+			}
 		}
 		if err != nil {
 			klog.Error(err)
-			err = fmt.Errorf("%w\n\n%s\n%s\n%s", err, "Error occurred rendering package in kpt function pipeline.", "Package has NOT been pushed to remote.", "Please fix package locally (modify until 'kpt fn render' succeeds) and retry.")
 			return updatedResources, renderStatus, err
 		}
 

--- a/test/e2e/cli/config.go
+++ b/test/e2e/cli/config.go
@@ -40,6 +40,8 @@ type Command struct {
 	IgnoreWhitespace bool `yaml:"ignoreWhitespace,omitempty"`
 	// StdErrTabToWhitespace replaces "\t" (tab) character with whitespace "  "
 	StdErrTabToWhitespace bool `yaml:"stdErrTabToWhitespace,omitempty"`
+	// ContainsErrorString changes Stderr check from exact string match to contains string match
+	ContainsErrorString bool `yaml:"containsErrorString,omitempty"`
 }
 
 type TestCaseConfig struct {

--- a/test/e2e/cli/suite.go
+++ b/test/e2e/cli/suite.go
@@ -148,7 +148,7 @@ func (s *CliTestSuite) RunTestCase(t *testing.T, tc TestCaseConfig) {
 			command.Stdout = strings.ReplaceAll(command.Stdout, search, replace)
 			command.Stderr = strings.ReplaceAll(command.Stderr, search, replace)
 		}
-				
+
 		if command.StdErrTabToWhitespace {
 			stderrStr = strings.ReplaceAll(stderrStr, "\t", "  ") // Replace tabs with spaces
 		}
@@ -173,8 +173,14 @@ func (s *CliTestSuite) RunTestCase(t *testing.T, tc TestCaseConfig) {
 		got, want := stderrStr, command.Stderr
 		got = removeArmPlatformWarning(got)
 
-		if got != want {
-			t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+		if command.ContainsErrorString {
+			if !strings.Contains(got, want) {
+				t.Errorf("unexpected stderr content from '%s'; \n Error we got = \n(%s) \n Should contain substring = \n(%s)\n", strings.Join(command.Args, " "), got, want)
+			}
+		} else {
+			if got != want {
+				t.Errorf("unexpected stderr content from '%s'; (-want, +got) %s", strings.Join(command.Args, " "), cmp.Diff(want, got))
+			}
 		}
 
 		// hack here; but if the command registered a repo, give a few extra seconds for the repo to reach readiness

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -258,12 +258,8 @@ commands:
       - git-efe3d01c68dfdcdd69114c9a7c65cce0d662a46f
       - /tmp/porch-e2e/testing-invalid-render
     stderr: |
-      Error: Internal error occurred: fn.render: pkg /:
-        pkg.render:
-        pipeline.run: func eval "gcr.io/kpt-fn/set-annotations:v0.1.4" failed: rpc error: code = Internal desc = Failed to execute function "gcr.io/kpt-fn/set-annotations:v0.1.4": exit status 1 ([error] : failed to configure function: `functionConfig` must be a `ConfigMap` or `SetAnnotations`)
-
       Error occurred rendering package in kpt function pipeline.
       Package has NOT been pushed to remote.
       Please fix package locally (modify until 'kpt fn render' succeeds) and retry. 
-    stdErrTabToWhitespace: true
+    containsErrorString: true
     exitCode: 1


### PR DESCRIPTION
This PR tackles 2 small bugs.

The first was mistakenly introduced in [#145](https://github.com/nephio-project/porch/pull/145).
The bug causes the error message of porchctl cmd's that edit the package-revision's resources AND they fail e.g. copy failing due to not being published, will also be padded with the error message related to rendering error.

Example error with bug
```
porchctl -n porch-demo rpkg copy porch-test-3a6d81f91097fa9b935edd53e4f20110785cc25a --workspace=asdsqweaasdads 
Error: Internal error occurred: source revision must be published

Error occurred rendering package in kpt function pipeline.
Package has NOT been pushed to remote.
Please fix package locally (modify until 'kpt fn render' succeeds) and retry.
```
Error should be as follows
```
porchctl -n porch-demo rpkg copy porch-test-3a6d81f91097fa9b935edd53e4f20110785cc25a --workspace=asdsqweaasdads 
Error: Internal error occurred: source revision must be published
```
The reason this occurred is because the code did not include a wrapping/check for the task type being of type=eval which is the render tasks only which has been rectified in this PR.

Secondly added a argument called ContainsErrorString in the CLI tests. this argument allows tests to check the output if it contains a sub-string instead of an exact string match which it currently does.
This was added to amend an issue with certain error messages returned by porch CLI not being consistent. 
For example [here](https://github.com/Nordix/porch/actions/runs/12143926735/job/33861992712)