### PR TITLE
Adding launch.json porchctl cmd debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,17 @@
             }
         },
         {
+            "name": "Run Porchctl command",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/porchctl/main.go",
+            "args": [
+                "rpkg", "init", "porch-package-name", "--workspace=v1", "--namespace=default", "--repository=repo-name"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "Launch test function",
             "type": "go",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,7 @@
             "mode": "auto",
             "program": "${workspaceFolder}/cmd/porchctl/main.go",
             "args": [
-                "rpkg", "init", "porch-package-name", "--workspace=v1", "--namespace=default", "--repository=repo-name"
+                "rpkg", "init", "porch-package-name", "--workspace=v1", "--namespace=repository-namespace", "--repository=repo-name"
             ],
             "cwd": "${workspaceFolder}"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,12 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
+
+    // A configuration for running the porch server through vscode for the use of debugging.
+    // Assumes a cluster is set up alongside Git (./scripts/setup-dev-env.sh) and porch components (make ../porch/run-in-kind-no-server) are pre-configured
+    // With the configuration above one can use Vscode (Run & Debug) and launch server.
+    // This launches the porch server through vscode outside the cluster and the logs can be viewed in the debug console.
+    // Breakpoints can be added throughout the porch server code to debug.
     "configurations": [
         {
             "name": "Launch Server",
@@ -36,6 +42,10 @@
                 "ENABLE_PACKAGEVARIANTSETS": "true"
             }
         },
+        // A configuration for running a porchctl command using the vscode debugger.
+        // Assumes a cluster is set up alongside Git (scripts/setup-dev-env.sh) and porch components (make run-in-kind) in the /porch directory are pre-configured
+        // This allows for the running of porchctl commands through vscode outside the cluster and the logs can be viewed in the debug console.
+        // Breakpoints can be added throughout the porch server code to debug.
         {
             "name": "Run Porchctl command",
             "type": "go",


### PR DESCRIPTION
This is a quick and simple PR for adding a sample configuration in the launch.json for running porchctl commands such that you can use the debugger on the command operation outside the porch server itself.