### PR TITLE
Add golangci-lint gh action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,54 @@
+# Copyright 2024 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: golangci-lint
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "release/**"
+      - ".prow.yaml"
+      - "OWNERS"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "release/**"
+      - ".prow.yaml"
+      - "OWNERS"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+env:
+  GO_VERSION: 1.22.0
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Porch
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.62.2
+          args: --timeout=10m --go=${{ env.GO_VERSION }} --exclude-dirs=test --exclude-generated=true --issues-exit-code=0

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -1,4 +1,4 @@
-#  Copyright 2023 The Nephio Authors.
+#  Copyright 2023-2024 The Nephio Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
 #  limitations under the License.
 
 
-GOLANG_CI_VER ?= v1.57
+GOLANG_CI_VER ?= v1.62.2
+GO_VERSION ?= 1.22.0
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 
@@ -22,7 +23,7 @@ include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 lint: ## Run Go linter against the codebase
 ifeq ($(CONTAINER_RUNNABLE), 0)
 	$(RUN_CONTAINER_COMMAND) docker.io/golangci/golangci-lint:${GOLANG_CI_VER}-alpine \
-	 golangci-lint run ./... -v --timeout 10m
+	 golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-dirs=test --exclude-generated=true
 else
-	golangci-lint run ./... -v --timeout 10m
+	golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-dirs=test --exclude-generated=true
 endif


### PR DESCRIPTION
Adding a golangci-lint gh action. At present, it will report linting errors with exitcode 0. Once linting errors are resolved, we can enable it as a blockng presubmit.
Updating the existing local make target for linting "make lint"