### PR TITLE
Add gosec gh action

### DIFF
--- a/.github/workflows/gosec-scan.yaml
+++ b/.github/workflows/gosec-scan.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Gosec security scan
+
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "release/**"
+      - ".prow.yaml"
+      - "OWNERS"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "release/**"
+      - ".prow.yaml"
+      - "OWNERS"
+
+jobs:
+  tests:
+    name: Porch gosec scan
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Porch
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.2'
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          # we let the report trigger content trigger a failure using the GitHub Security features.
+          args: '-no-fail -exclude-dir=generated -exclude-dir=test -exclude-generated=true -fmt=sarif -out=results.sarif ./...'
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: results.sarif
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gosec-scan.yaml
+++ b/.github/workflows/gosec-scan.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: '>=1.22.2'
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.21.4
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -exclude-dir=generated -exclude-dir=test -exclude-generated=true -fmt=sarif -out=results.sarif ./...'

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __debug*
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 **/.history
+
+# gosec artifacts
+*results.html

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ __debug*
 
 # gosec artifacts
 *results.html
-=======
 
 ### Jetbrains IDEs ###
 .idea/*

--- a/default-gosec.mk
+++ b/default-gosec.mk
@@ -1,4 +1,4 @@
-#  Copyright 2023 The Nephio Authors.
+#  Copyright 2023-2024 The Nephio Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-GOSEC_VER ?= 2.19.0
+GOSEC_VER ?= 2.21.4
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 
@@ -20,7 +20,8 @@ include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 .PHONY: gosec
 gosec: ## Inspect the source code for security problems by scanning the Go Abstract Syntax Tree
 ifeq ($(CONTAINER_RUNNABLE), 0)
-		$(RUN_CONTAINER_COMMAND) docker.io/securego/gosec:${GOSEC_VER} ./...
+		$(RUN_CONTAINER_COMMAND) docker.io/securego/gosec:${GOSEC_VER} -fmt=html -out=gosec-results.html \
+		-stdout -verbose=text -exclude-dir=generated -exclude-dir=test -exclude-generated ./...
 else
-		gosec ./...
+		gosec -fmt=html -out=gosec-results.html -stdout -verbose=text -exclude-dir=generated -exclude-dir=test -exclude-generated ./...
 endif


### PR DESCRIPTION
Adding a gh action to run gosec scans on PRs. Non blocking presubmit job will be enabled once all issues are resolved.
Update the existing gosec make target "make gosec" to align with the gh action verison