### PR TITLE
fix for sporadic porch crash during new package revision

### DIFF
--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
@@ -119,7 +119,10 @@ func ensureConfigInjection(ctx context.Context,
 		return err
 	}
 
-	setInjectionPointConditionsAndGates(kptfile, injectionPoints)
+	err = setInjectionPointConditionsAndGates(kptfile, injectionPoints)
+	if err != nil {
+		return err
+	}
 
 	prr.Spec.Resources["Kptfile"] = kptfile.String()
 

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2024 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The kpt and Nephio Authors
+// Copyright 2023-2024 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -611,6 +611,8 @@ func (r *PackageVariantReconciler) isUpToDate(pv *api.PackageVariant, downstream
 		// will always be a published revision, so we will need to do an update.
 		return false
 	}
+	currentUpstreamRevision := upstreamLock.Git.Ref[lastIndex+1:]
+	return currentUpstreamRevision == pv.Spec.Upstream.Revision
 }
 
 func (r *PackageVariantReconciler) copyPublished(ctx context.Context,

--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The kpt and Nephio Authors
+// Copyright 2023-2024 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -597,12 +597,12 @@ func (r *PackageVariantReconciler) deletePackageRevision(ctx context.Context, pr
 // determine if the downstream PR needs to be updated
 func (r *PackageVariantReconciler) isUpToDate(pv *api.PackageVariant, downstream *porchapi.PackageRevision) bool {
 	if downstream.Status.UpstreamLock == nil {
-		klog.Warningf("status.upstreamLock is nil for PackageRevision %s.", pv.ObjectMeta.Name)
+		klog.Warningf("status.upstreamLock field is empty/missing in downstream PackageRevision: %s", pv.ObjectMeta.Name)
 		return true
 	}
 	upstreamLock := downstream.Status.UpstreamLock
 	if upstreamLock.Git == nil || upstreamLock.Git.Ref == "" {
-		klog.Warningf("status.upstreamLock.git or status.upstreamLock.git.ref is nil for PackageRevision %s.", pv.ObjectMeta.Name)
+		klog.Warningf("status.upstreamLock.git or status.upstreamLock.git.ref field is empty/missing in downstream PackageRevision: %s", pv.ObjectMeta.Name)
 		return true
 	}
 	lastIndex := strings.LastIndex(upstreamLock.Git.Ref, "/")


### PR DESCRIPTION
Current code in package variant controller was assuming that "status.upstreamLock.Git.Ref" in PackageRevision resource will always having proper value. But status.upstreamLock field in PackageRevision could be nil in initial transition stage. Due to which Porch was crashing. Issue is fixed as part of this PR 