### PR TITLE
Propose delete cache updated when package revision is deleted

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -505,6 +505,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 	if err := r.pushAndCleanup(ctx, refSpecs); err != nil {
 		return fmt.Errorf("failed to update git references: %v", err)
 	}
+
 	return nil
 }
 
@@ -521,6 +522,8 @@ func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context
 			return err
 		}
 	}
+	delete(r.deletionProposedCache, deletionProposedBranch)
+
 	return nil
 }
 


### PR DESCRIPTION
The git repo code holds a cache of the package revisions that are in state "proposed-delete". Entries in this cache were not removed when the package revision was actually deleted. This bug was not noticed before because the periodic job fixed up the proposed-delete cache and it ran every minute. Now that the periodic job is running every 10 minutes, this bug became more obvious.

Before:
```
% porchctl -n porch-demo rpkg init network-function --repository=porch-test --workspace=myws
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b created

% porchctl -n porch-demo rpkg propose porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed

% porchctl -n porch-demo rpkg approve porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b approved

% porchctl -n porch-demo rpkg propose-delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b deleted

% porchctl -n porch-demo rpkg propose-delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 deleted

% porchctl -n porch-demo rpkg init network-function --repository=porch-test --workspace=myws
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b created

% porchctl -n porch-demo rpkg propose porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed

% porchctl -n porch-demo rpkg approve porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b approved

# The bug!
% porchctl -n porch-demo rpkg propose-delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b is already proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b deleted

# The bug!
% porchctl -n porch-demo rpkg propose-delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 is already proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 deleted
```

After:
```
% porchctl -n porch-demo rpkg init network-function --repository=porch-test --workspace=myws
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b created

% porchctl -n porch-demo rpkg propose porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed

% porchctl -n porch-demo rpkg approve porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b approved

% porchctl -n porch-demo rpkg propose-delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b deleted

% porchctl -n porch-demo rpkg propose-delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 deleted

% porchctl -n porch-demo rpkg init network-function --repository=porch-test --workspace=myws
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b created

% porchctl -n porch-demo rpkg propose porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b proposed

% porchctl -n porch-demo rpkg approve porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b approved

# Bug fixed
% porchctl -n porch-demo rpkg propose-delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-f41b63652745952371579b668bc42dda013003a1 proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-ed65de69336c5d0d329867dd874a568460ffda0b
porch-test-ed65de69336c5d0d329867dd874a568460ffda0b deleted

# Bug fixed
% porchctl -n porch-demo rpkg propose-delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 proposed for deletion

% porchctl -n porch-demo rpkg delete porch-test-f41b63652745952371579b668bc42dda013003a1
porch-test-f41b63652745952371579b668bc42dda013003a1 deleted
```