### PR TITLE
Fixing typo in path pkg/cache/memory/cache.go at line 174

### DIFF
--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -211,4 +211,3 @@ func (c *Cache) CloseRepository(ctx context.Context, repositorySpec *configapi.R
 		return nil
 	}
 }
-

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -210,4 +210,5 @@ func (c *Cache) CloseRepository(ctx context.Context, repositorySpec *configapi.R
 	} else {
 		return nil
 	}
-} 
+}
+

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -172,7 +172,7 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 }
 
 func (c *Cache) CloseRepository(ctx context.Context, repositorySpec *configapi.Repository, allRepos []configapi.Repository) error {
-	_, span := tracer.Start(ctx, "Cache::OpenRepository", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "Cache::CloseRepository", trace.WithAttributes())
 	defer span.End()
 
 	key, err := getCacheKey(repositorySpec)

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -210,4 +210,4 @@ func (c *Cache) CloseRepository(ctx context.Context, repositorySpec *configapi.R
 	} else {
 		return nil
 	}
-}
+} 


### PR DESCRIPTION
I see there was a typo error at line number 174 in file path pkg/cache/memory/cache.go
It should be CloseRepository instead of OpenRepository.