### PR TITLE
Rename GitCaBundle to UserDefinedCaBundle

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -75,13 +75,13 @@ func init() {
 
 // ExtraConfig holds custom apiserver config
 type ExtraConfig struct {
-	CoreAPIKubeconfigPath string
-	CacheDirectory        string
-	FunctionRunnerAddress string
-	DefaultImagePrefix    string
-	RepoSyncFrequency     time.Duration
-	UseGitCaBundle        bool
-	MaxGrpcMessageSize    int
+	CoreAPIKubeconfigPath  string
+	CacheDirectory         string
+	FunctionRunnerAddress  string
+	DefaultImagePrefix     string
+	RepoSyncFrequency      time.Duration
+	UseUserDefinedCaBundle bool
+	MaxGrpcMessageSize     int
 }
 
 // Config defines the config for the apiserver
@@ -228,7 +228,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 
 	watcherMgr := engine.NewWatcherManager()
 
-	memoryCache := memorycache.NewCache(c.ExtraConfig.CacheDirectory, c.ExtraConfig.RepoSyncFrequency, c.ExtraConfig.UseGitCaBundle, memorycache.CacheOptions{
+	memoryCache := memorycache.NewCache(c.ExtraConfig.CacheDirectory, c.ExtraConfig.RepoSyncFrequency, c.ExtraConfig.UseUserDefinedCaBundle, memorycache.CacheOptions{
 		CredentialResolver: credentialResolver,
 		UserInfoProvider:   userInfoProvider,
 		MetadataStore:      metadataStore,

--- a/pkg/cache/memory/cache.go
+++ b/pkg/cache/memory/cache.go
@@ -44,15 +44,15 @@ import (
 // * We Cache flattened tar files in <cacheDir>/oci/ (so we don't need to pull to read resources)
 // * We poll the repositories (every minute) and Cache the discovered images in memory.
 type Cache struct {
-	mutex              sync.Mutex
-	repositories       map[string]*cachedRepository
-	cacheDir           string
-	credentialResolver repository.CredentialResolver
-	userInfoProvider   repository.UserInfoProvider
-	metadataStore      meta.MetadataStore
-	repoSyncFrequency  time.Duration
-	objectNotifier     objectNotifier
-	useGitCaBundle     bool
+	mutex                  sync.Mutex
+	repositories           map[string]*cachedRepository
+	cacheDir               string
+	credentialResolver     repository.CredentialResolver
+	userInfoProvider       repository.UserInfoProvider
+	metadataStore          meta.MetadataStore
+	repoSyncFrequency      time.Duration
+	objectNotifier         objectNotifier
+	useUserDefinedCaBundle bool
 }
 
 var _ cache.Cache = &Cache{}
@@ -68,16 +68,16 @@ type CacheOptions struct {
 	ObjectNotifier     objectNotifier
 }
 
-func NewCache(cacheDir string, repoSyncFrequency time.Duration, useGitCaBundle bool, opts CacheOptions) *Cache {
+func NewCache(cacheDir string, repoSyncFrequency time.Duration, useUserDefinedCaBundle bool, opts CacheOptions) *Cache {
 	return &Cache{
-		repositories:       make(map[string]*cachedRepository),
-		cacheDir:           cacheDir,
-		credentialResolver: opts.CredentialResolver,
-		userInfoProvider:   opts.UserInfoProvider,
-		metadataStore:      opts.MetadataStore,
-		objectNotifier:     opts.ObjectNotifier,
-		repoSyncFrequency:  repoSyncFrequency,
-		useGitCaBundle:     useGitCaBundle,
+		repositories:           make(map[string]*cachedRepository),
+		cacheDir:               cacheDir,
+		credentialResolver:     opts.CredentialResolver,
+		userInfoProvider:       opts.UserInfoProvider,
+		metadataStore:          opts.MetadataStore,
+		objectNotifier:         opts.ObjectNotifier,
+		repoSyncFrequency:      repoSyncFrequency,
+		useUserDefinedCaBundle: useUserDefinedCaBundle,
 	}
 }
 
@@ -147,10 +147,10 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 			}
 
 			r, err := git.OpenRepository(ctx, repositorySpec.Name, repositorySpec.Namespace, gitSpec, repositorySpec.Spec.Deployment, filepath.Join(c.cacheDir, "git"), git.GitRepositoryOptions{
-				CredentialResolver: c.credentialResolver,
-				UserInfoProvider:   c.userInfoProvider,
-				MainBranchStrategy: mbs,
-				UseGitCaBundle:     c.useGitCaBundle,
+				CredentialResolver:     c.credentialResolver,
+				UserInfoProvider:       c.userInfoProvider,
+				MainBranchStrategy:     mbs,
+				UseUserDefinedCaBundle: c.useUserDefinedCaBundle,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -57,7 +57,7 @@ type PorchServerOptions struct {
 	FunctionRunnerAddress            string
 	DefaultImagePrefix               string
 	RepoSyncFrequency                time.Duration
-	UseGitCaBundle                   bool
+	UseUserDefinedCaBundle           bool
 	DisableValidatingAdmissionPolicy bool
 	MaxRequestBodySize               int
 
@@ -195,13 +195,13 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 	config := &apiserver.Config{
 		GenericConfig: serverConfig,
 		ExtraConfig: apiserver.ExtraConfig{
-			CoreAPIKubeconfigPath: o.CoreAPIKubeconfigPath,
-			CacheDirectory:        o.CacheDirectory,
-			RepoSyncFrequency:     o.RepoSyncFrequency,
-			FunctionRunnerAddress: o.FunctionRunnerAddress,
-			DefaultImagePrefix:    o.DefaultImagePrefix,
-			UseGitCaBundle:        o.UseGitCaBundle,
-			MaxGrpcMessageSize:    o.MaxRequestBodySize,
+			CoreAPIKubeconfigPath:  o.CoreAPIKubeconfigPath,
+			CacheDirectory:         o.CacheDirectory,
+			RepoSyncFrequency:      o.RepoSyncFrequency,
+			FunctionRunnerAddress:  o.FunctionRunnerAddress,
+			DefaultImagePrefix:     o.DefaultImagePrefix,
+			UseUserDefinedCaBundle: o.UseUserDefinedCaBundle,
+			MaxGrpcMessageSize:     o.MaxRequestBodySize,
 		},
 	}
 	return config, nil
@@ -248,7 +248,7 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.DefaultImagePrefix, "default-image-prefix", fnruntime.GCRImagePrefix, "Default prefix for unqualified function names")
 	fs.StringVar(&o.CacheDirectory, "cache-directory", "", "Directory where Porch server stores repository and package caches.")
 	fs.IntVar(&o.MaxRequestBodySize, "max-request-body-size", 6*1024*1024, "Maximum size of the request body in bytes. Keep this in sync with function-runner's corresponding argument.")
-	fs.BoolVar(&o.UseGitCaBundle, "use-git-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards git.")
+	fs.BoolVar(&o.UseUserDefinedCaBundle, "use-user-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards the repository system.")
 	fs.BoolVar(&o.DisableValidatingAdmissionPolicy, "disable-validating-admissions-policy", true, "Determine whether to (dis|en)able the Validating Admission Policy, which requires k8s version >= v1.30")
 	fs.DurationVar(&o.RepoSyncFrequency, "repo-sync-frequency", 10*time.Minute, "Frequency in seconds at which registered repositories will be synced and the background job repository refresh runs.")
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -68,10 +68,10 @@ const (
 )
 
 type GitRepositoryOptions struct {
-	CredentialResolver repository.CredentialResolver
-	UserInfoProvider   repository.UserInfoProvider
-	MainBranchStrategy MainBranchStrategy
-	UseGitCaBundle     bool
+	CredentialResolver     repository.CredentialResolver
+	UserInfoProvider       repository.UserInfoProvider
+	MainBranchStrategy     MainBranchStrategy
+	UseUserDefinedCaBundle bool
 }
 
 func OpenRepository(ctx context.Context, name, namespace string, spec *configapi.GitRepository, deployment bool, root string, opts GitRepositoryOptions) (GitRepository, error) {
@@ -142,7 +142,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 		deployment:         deployment,
 	}
 
-	if opts.UseGitCaBundle {
+	if opts.UseUserDefinedCaBundle {
 		if caBundle, err := opts.CredentialResolver.ResolveCredential(ctx, namespace, namespace+"-ca-bundle"); err != nil {
 			klog.Errorf("failed to obtain caBundle from secret %s/%s: %v", namespace, namespace+"-ca-bundle", err)
 		} else {


### PR DESCRIPTION
This is the first in a series of PRs to rationalize the option passing in Porch, ultimately to make it easier to implement alternative cache implementations and also to allow repository systems as well as git to be used.

In this PR, the `use-git-cabundle` option and the `UseGitCaBundle` variables are renamed to remove references to GIT because a user defined CA bundle could be used for systems other than Git.