### PR TITLE
Add missing OTel traces to major methods in Porch flows

### DIFF
--- a/pkg/cache/memory/cache_test.go
+++ b/pkg/cache/memory/cache_test.go
@@ -101,7 +101,7 @@ func TestPublishedLatest(t *testing.T) {
 
 	bucket := revisions[0]
 	// Expect draft package
-	if got, want := bucket.Lifecycle(), api.PackageRevisionLifecycleDraft; got != want {
+	if got, want := bucket.Lifecycle(ctx), api.PackageRevisionLifecycleDraft; got != want {
 		t.Fatalf("Bucket package lifecycle: got %s, want %s", got, want)
 	}
 
@@ -147,7 +147,7 @@ func TestDeletePublishedMain(t *testing.T) {
 
 	bucket := revisions[0]
 	// Expect draft package
-	if got, want := bucket.Lifecycle(), api.PackageRevisionLifecycleDraft; got != want {
+	if got, want := bucket.Lifecycle(ctx), api.PackageRevisionLifecycleDraft; got != want {
 		t.Fatalf("Bucket package lifecycle: got %s, want %s", got, want)
 	}
 
@@ -184,7 +184,7 @@ func TestDeletePublishedMain(t *testing.T) {
 
 	approvedBucket := publishedRevisions[0]
 
-	if got, want := approvedBucket.Lifecycle(), api.PackageRevisionLifecyclePublished; got != want {
+	if got, want := approvedBucket.Lifecycle(ctx), api.PackageRevisionLifecyclePublished; got != want {
 		t.Fatalf("Approved Bucket package lifecycle: got %s, want %s", got, want)
 	}
 

--- a/pkg/cache/memory/packagerevision.go
+++ b/pkg/cache/memory/packagerevision.go
@@ -19,6 +19,7 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // We take advantage of the cache having a global view of all the packages
@@ -35,6 +36,9 @@ type cachedPackageRevision struct {
 }
 
 func (c *cachedPackageRevision) GetPackageRevision(ctx context.Context) (*api.PackageRevision, error) {
+	ctx, span := tracer.Start(ctx, "cachedPackageRevision::GetPackageRevision", trace.WithAttributes())
+	defer span.End()
+
 	apiPR, err := c.PackageRevision.GetPackageRevision(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1337,7 +1337,7 @@ func (r *gitRepository) storeTree(tree *object.Tree) (plumbing.Hash, error) {
 }
 
 func (r *gitRepository) GetLifecycle(ctx context.Context, pkgRev *gitPackageRevision) v1alpha1.PackageRevisionLifecycle {
-	ctx, span := tracer.Start(ctx, "gitRepository::GetLifecycle", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "gitRepository::GetLifecycle", trace.WithAttributes())
 	defer span.End()
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/pkg/git/package_test.go
+++ b/pkg/git/package_test.go
@@ -66,7 +66,7 @@ func (g GitSuite) TestLock(t *testing.T) {
 	}
 
 	for _, rev := range revisions {
-		if rev.Lifecycle() != v1alpha1.PackageRevisionLifecyclePublished {
+		if rev.Lifecycle(ctx) != v1alpha1.PackageRevisionLifecyclePublished {
 			continue
 		}
 

--- a/pkg/git/package_tree.go
+++ b/pkg/git/package_tree.go
@@ -75,7 +75,7 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 		// the last commit for the package based on the porch commit tags. We don't
 		// use the revision here, since we are looking at the package branch while
 		// the revisions only helps identify the tags.
-		commit, err := repo.findLatestPackageCommit(ctx, p.parent.commit, p.path)
+		commit, err := repo.findLatestPackageCommit(p.parent.commit, p.path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/git/primitives_test.go
+++ b/pkg/git/primitives_test.go
@@ -467,7 +467,7 @@ func createTestCommit(t *testing.T, repo *git.Repository, parent plumbing.Hash, 
 		Email: "test@kpt.dev",
 		When:  time.Now(),
 	}
-	commit, err := wt.Commit("Hello", &git.CommitOptions{
+	commit, err := wt.Commit(message, &git.CommitOptions{
 		Author:    &sig,
 		Committer: &sig,
 		Parents:   []plumbing.Hash{parent},

--- a/pkg/meta/store.go
+++ b/pkg/meta/store.go
@@ -209,7 +209,7 @@ func (c *crdMetadataStore) Delete(ctx context.Context, namespacedName types.Name
 }
 
 func toPackageRevisionMeta(ctx context.Context, internalPkgRev *internalapi.PackageRev) metav1.ObjectMeta {
-	ctx, span := tracer.Start(ctx, "store.go::toPackageRevisionMeta", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "store.go::toPackageRevisionMeta", trace.WithAttributes())
 	defer span.End()
 
 	labels := internalPkgRev.Labels

--- a/pkg/oci/mutate.go
+++ b/pkg/oci/mutate.go
@@ -98,7 +98,7 @@ func (r *ociRepository) UpdatePackageRevision(ctx context.Context, old repositor
 		tasks:       []v1alpha1.Task{},
 		base:        base,
 		tag:         ref,
-		lifecycle:   oldPackage.Lifecycle(),
+		lifecycle:   oldPackage.Lifecycle(ctx),
 	}, nil
 }
 
@@ -241,11 +241,11 @@ func (r *ociRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 				}
 				var revs []string
 				for _, rev := range revisions {
-					if v1alpha1.LifecycleIsPublished(rev.Lifecycle()) {
+					if v1alpha1.LifecycleIsPublished(rev.Lifecycle(ctx)) {
 						revs = append(revs, rev.Key().Revision)
 					}
 				}
-				nextRevisionNumber, err := repository.NextRevisionNumber(revs)
+				nextRevisionNumber, err := repository.NextRevisionNumber(ctx, revs)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var tracer = otel.Tracer("apiserver")
+var tracer = otel.Tracer("packagerevision")
 
 type packageRevisions struct {
 	packageCommon
@@ -70,7 +70,7 @@ func (r *packageRevisions) NamespaceScoped() bool {
 
 // List selects resources in the storage which match to the selector. 'options' can be nil.
 func (r *packageRevisions) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisions::List", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::List", trace.WithAttributes())
 	defer span.End()
 
 	result := &api.PackageRevisionList{
@@ -85,7 +85,7 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 		return nil, err
 	}
 
-	if err := r.packageCommon.listPackageRevisions(ctx, filter, options.LabelSelector, func(p repository.PackageRevision) error {
+	if err := r.packageCommon.listPackageRevisions(ctx, filter, options.LabelSelector, func(ctx context.Context, p repository.PackageRevision) error {
 		item, err := p.GetPackageRevision(ctx)
 		if err != nil {
 			return err
@@ -101,7 +101,7 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 
 // Get implements the Getter interface
 func (r *packageRevisions) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisions::Get", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Get", trace.WithAttributes())
 	defer span.End()
 
 	repoPkgRev, err := r.getRepoPkgRev(ctx, name)
@@ -120,7 +120,7 @@ func (r *packageRevisions) Get(ctx context.Context, name string, options *metav1
 // Create implements the Creater interface.
 func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Object, createValidation rest.ValidateObjectFunc,
 	options *metav1.CreateOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisions::Create", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Create", trace.WithAttributes())
 	defer span.End()
 
 	ns, namespaced := genericapirequest.NamespaceFrom(ctx)
@@ -198,7 +198,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 // to true.
 func (r *packageRevisions) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisions::Update", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Update", trace.WithAttributes())
 	defer span.End()
 
 	return r.packageCommon.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate)
@@ -216,7 +216,7 @@ func (r *packageRevisions) Update(ctx context.Context, name string, objInfo rest
 // It also returns a boolean which is set to true if the resource was instantly
 // deleted or false if it will be deleted asynchronously.
 func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisions::Delete", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Delete", trace.WithAttributes())
 	defer span.End()
 
 	ns, namespaced := genericapirequest.NamespaceFrom(ctx)

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -68,7 +68,7 @@ func (r *packageRevisionResources) NamespaceScoped() bool {
 
 // List selects resources in the storage which match to the selector. 'options' can be nil.
 func (r *packageRevisionResources) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisionResources::List", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisionResources::List", trace.WithAttributes())
 	defer span.End()
 
 	result := &api.PackageRevisionResourcesList{
@@ -83,7 +83,7 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 		return nil, err
 	}
 
-	if err := r.packageCommon.listPackageRevisions(ctx, filter, options.LabelSelector, func(p repository.PackageRevision) error {
+	if err := r.packageCommon.listPackageRevisions(ctx, filter, options.LabelSelector, func(ctx context.Context, p repository.PackageRevision) error {
 		apiPkgResources, err := p.GetResources(ctx)
 		if err != nil {
 			return err
@@ -99,7 +99,7 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 
 // Get implements the Getter interface
 func (r *packageRevisionResources) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisionResources::Get", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisionResources::Get", trace.WithAttributes())
 	defer span.End()
 
 	pkg, err := r.packageCommon.getRepoPkgRev(ctx, name)
@@ -118,7 +118,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, options
 // may allow updates creates the object - they should set the created boolean
 // to true.
 func (r *packageRevisionResources) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "packageRevisionResources::Update", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisionResources::Update", trace.WithAttributes())
 	defer span.End()
 
 	ns, namespaced := genericapirequest.NamespaceFrom(ctx)

--- a/pkg/registry/porch/packagerevisions_approval.go
+++ b/pkg/registry/porch/packagerevisions_approval.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -61,6 +62,9 @@ func (a *packageRevisionsApproval) Get(ctx context.Context, name string, options
 // to true.
 func (a *packageRevisionsApproval) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc,
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisionsApproval::Update", trace.WithAttributes())
+	defer span.End()
+
 	allowCreate := false // do not allow create on update
 	return a.common.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, allowCreate)
 }

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,6 +36,9 @@ func (s packageRevisionStrategy) PrepareForUpdate(ctx context.Context, obj, old 
 }
 
 func (s packageRevisionStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	ctx, span := tracer.Start(ctx, "packageRevisionStrategy::ValidateUpdate", trace.WithAttributes())
+	defer span.End()
+
 	allErrs := field.ErrorList{}
 	oldRevision := old.(*api.PackageRevision)
 	newRevision := obj.(*api.PackageRevision)
@@ -116,6 +120,9 @@ var _ SimpleRESTCreateStrategy = packageRevisionStrategy{}
 // before the object is persisted.  This method should not mutate the
 // object.
 func (s packageRevisionStrategy) Validate(ctx context.Context, runtimeObj runtime.Object) field.ErrorList {
+	ctx, span := tracer.Start(ctx, "packageRevisionStrategy::Validate", trace.WithAttributes())
+	defer span.End()
+
 	allErrs := field.ErrorList{}
 
 	obj := runtimeObj.(*api.PackageRevision)

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -36,7 +36,7 @@ func (s packageRevisionStrategy) PrepareForUpdate(ctx context.Context, obj, old 
 }
 
 func (s packageRevisionStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	ctx, span := tracer.Start(ctx, "packageRevisionStrategy::ValidateUpdate", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "packageRevisionStrategy::ValidateUpdate", trace.WithAttributes())
 	defer span.End()
 
 	allErrs := field.ErrorList{}

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -120,7 +120,7 @@ var _ SimpleRESTCreateStrategy = packageRevisionStrategy{}
 // before the object is persisted.  This method should not mutate the
 // object.
 func (s packageRevisionStrategy) Validate(ctx context.Context, runtimeObj runtime.Object) field.ErrorList {
-	ctx, span := tracer.Start(ctx, "packageRevisionStrategy::Validate", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "packageRevisionStrategy::Validate", trace.WithAttributes())
 	defer span.End()
 
 	allErrs := field.ErrorList{}

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -36,7 +36,7 @@ func (r *packageRevisions) Watch(ctx context.Context, options *metainternalversi
 	// isn't supported. 'resourceVersion' allows for continuing/starting a watch at a
 	// particular version.
 
-	ctx, span := tracer.Start(ctx, "packageRevisions::Watch", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Watch", trace.WithAttributes())
 	defer span.End()
 
 	filter, err := parsePackageRevisionFieldSelector(options.FieldSelector)
@@ -93,7 +93,7 @@ func (w *watcher) ResultChan() <-chan watch.Event {
 
 type packageReader interface {
 	watchPackages(ctx context.Context, filter packageRevisionFilter, callback engine.ObjectWatcher) error
-	listPackageRevisions(ctx context.Context, filter packageRevisionFilter, selector labels.Selector, callback func(p repository.PackageRevision) error) error
+	listPackageRevisions(ctx context.Context, filter packageRevisionFilter, selector labels.Selector, callback func(ctx context.Context, p repository.PackageRevision) error) error
 }
 
 // listAndWatch implements watch by doing a list, then sending any observed changes.
@@ -145,7 +145,7 @@ func (w *watcher) listAndWatchInner(ctx context.Context, r packageReader, filter
 
 	sentAdd := 0
 	// TODO: Only if rv == 0?
-	if err := r.listPackageRevisions(ctx, filter, selector, func(p repository.PackageRevision) error {
+	if err := r.listPackageRevisions(ctx, filter, selector, func(ctx context.Context, p repository.PackageRevision) error {
 		obj, err := p.GetPackageRevision(ctx)
 		if err != nil {
 			w.mutex.Lock()

--- a/pkg/registry/porch/watch_test.go
+++ b/pkg/registry/porch/watch_test.go
@@ -97,6 +97,6 @@ func (f *fakePackageReader) watchPackages(ctx context.Context, filter packageRev
 	return nil
 }
 
-func (f *fakePackageReader) listPackageRevisions(ctx context.Context, filter packageRevisionFilter, selector labels.Selector, callback func(p repository.PackageRevision) error) error {
+func (f *fakePackageReader) listPackageRevisions(ctx context.Context, filter packageRevisionFilter, selector labels.Selector, callback func(ctx context.Context, p repository.PackageRevision) error) error {
 	return nil
 }

--- a/pkg/repository/fake/packagerevision.go
+++ b/pkg/repository/fake/packagerevision.go
@@ -63,7 +63,7 @@ func (pr *FakePackageRevision) Key() repository.PackageRevisionKey {
 	return pr.PackageRevisionKey
 }
 
-func (pr *FakePackageRevision) Lifecycle() v1alpha1.PackageRevisionLifecycle {
+func (pr *FakePackageRevision) Lifecycle(ctx context.Context) v1alpha1.PackageRevisionLifecycle {
 	return pr.PackageLifecycle
 }
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -68,7 +68,7 @@ type PackageRevision interface {
 	Key() PackageRevisionKey
 
 	// Lifecycle returns the current lifecycle state of the package.
-	Lifecycle() v1alpha1.PackageRevisionLifecycle
+	Lifecycle(ctx context.Context) v1alpha1.PackageRevisionLifecycle
 
 	// UpdateLifecycle updates the desired lifecycle of the package. This can only
 	// be used for Published package revisions to go from Published to DeletionProposed
@@ -150,7 +150,7 @@ type ListPackageRevisionFilter struct {
 }
 
 // Matches returns true if the provided PackageRevision satisfies the conditions in the filter.
-func (f *ListPackageRevisionFilter) Matches(p PackageRevision) bool {
+func (f *ListPackageRevisionFilter) Matches(ctx context.Context, p PackageRevision) bool {
 	packageKey := p.Key()
 
 	if f.Package != "" && f.Package != packageKey.Package {
@@ -165,7 +165,7 @@ func (f *ListPackageRevisionFilter) Matches(p PackageRevision) bool {
 	if f.KubeObjectName != "" && f.KubeObjectName != p.KubeObjectName() {
 		return false
 	}
-	if f.Lifecycle != "" && f.Lifecycle != p.Lifecycle() {
+	if f.Lifecycle != "" && f.Lifecycle != p.Lifecycle(ctx) {
 		return false
 	}
 	return true

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -15,6 +15,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -22,8 +23,12 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/mod/semver"
 )
+
+var tracer = otel.Tracer("repository/util")
 
 func ToApiReadinessGates(kf kptfile.KptFile) []api.ReadinessGate {
 	var readinessGates []api.ReadinessGate
@@ -65,7 +70,10 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 	}
 }
 
-func NextRevisionNumber(revs []string) (string, error) {
+func NextRevisionNumber(ctx context.Context, revs []string) (string, error) {
+	ctx, span := tracer.Start(ctx, "draft.go::NextRevisionNumber", trace.WithAttributes())
+	defer span.End()
+
 	// Computes the next revision number as the latest revision number + 1.
 	// This function only understands strict versioning format, e.g. v1, v2, etc. It will
 	// ignore all revision numbers it finds that do not adhere to this format.

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -71,7 +71,7 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 }
 
 func NextRevisionNumber(ctx context.Context, revs []string) (string, error) {
-	ctx, span := tracer.Start(ctx, "draft.go::NextRevisionNumber", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "util.go::NextRevisionNumber", trace.WithAttributes())
 	defer span.End()
 
 	// Computes the next revision number as the latest revision number + 1.

--- a/pkg/task/builtin.go
+++ b/pkg/task/builtin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nephio-project/porch/internal/kpt/fnruntime"
 	"github.com/nephio-project/porch/pkg/kpt/fn"
 	"github.com/nephio-project/porch/pkg/repository"
+	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -47,6 +48,9 @@ func newPackageContextGeneratorMutation(packageConfig *builtins.PackageConfig) (
 var _ mutation = &builtinEvalMutation{}
 
 func (m *builtinEvalMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
+	ctx, span := tracer.Start(ctx, "builtinEvalMutation::Apply", trace.WithAttributes())
+	defer span.End()
+
 	ff := &runtimeutil.FunctionFilter{
 		Run:     m.runner.Run,
 		Results: &yaml.RNode{},

--- a/pkg/task/builtin.go
+++ b/pkg/task/builtin.go
@@ -48,7 +48,7 @@ func newPackageContextGeneratorMutation(packageConfig *builtins.PackageConfig) (
 var _ mutation = &builtinEvalMutation{}
 
 func (m *builtinEvalMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "builtinEvalMutation::Apply", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "builtinEvalMutation::Apply", trace.WithAttributes())
 	defer span.End()
 
 	ff := &runtimeutil.FunctionFilter{

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -51,7 +51,7 @@ type clonePackageMutation struct {
 }
 
 func (m *clonePackageMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "clonePackageMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "clonePackageMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	var cloned repository.PackageResources

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -35,7 +35,7 @@ type editPackageMutation struct {
 var _ mutation = &editPackageMutation{}
 
 func (m *editPackageMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "editPackageMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "editPackageMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	sourceRef := m.task.Edit.Source
@@ -55,7 +55,7 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	}
 
 	// We only allow edit to create new revisions from published packages.
-	if !api.LifecycleIsPublished(revision.Lifecycle()) {
+	if !api.LifecycleIsPublished(revision.Lifecycle(ctx)) {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be published")
 	}
 

--- a/pkg/task/eval.go
+++ b/pkg/task/eval.go
@@ -38,7 +38,7 @@ type evalFunctionMutation struct {
 }
 
 func (m *evalFunctionMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "evalFunctionMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "evalFunctionMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	e := m.task.Eval

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -443,6 +443,9 @@ func isRenderMutation(m mutation) bool {
 
 // applyResourceMutations mutates the resources and returns the most recent renderResult.
 func applyResourceMutations(ctx context.Context, draft repository.PackageRevisionDraft, baseResources repository.PackageResources, mutations []mutation) (applied repository.PackageResources, renderStatus *api.RenderStatus, err error) {
+	ctx, span := tracer.Start(ctx, "genericTaskHandler::applyResourceMutations", trace.WithAttributes())
+	defer span.End()
+
 	var lastApplied mutation
 	for _, m := range mutations {
 		updatedResources, taskResult, err := m.apply(ctx, baseResources)

--- a/pkg/task/init.go
+++ b/pkg/task/init.go
@@ -36,7 +36,7 @@ type initPackageMutation struct {
 var _ mutation = &initPackageMutation{}
 
 func (m *initPackageMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "initPackageMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "initPackageMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	fs := filesys.MakeFsInMemory()

--- a/pkg/task/patchgen.go
+++ b/pkg/task/patchgen.go
@@ -53,7 +53,7 @@ type applyPatchMutation struct {
 var _ mutation = &applyPatchMutation{}
 
 func (m *applyPatchMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	_, span := tracer.Start(ctx, "applyPatchMutation:::Apply", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "applyPatchMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	result := repository.PackageResources{

--- a/pkg/task/render.go
+++ b/pkg/task/render.go
@@ -40,7 +40,7 @@ type renderPackageMutation struct {
 var _ mutation = &renderPackageMutation{}
 
 func (m *renderPackageMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "renderPackageMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "renderPackageMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	fs := filesys.MakeFsInMemory()

--- a/pkg/task/replaceresources.go
+++ b/pkg/task/replaceresources.go
@@ -31,7 +31,7 @@ type replaceResourcesMutation struct {
 }
 
 func (m *replaceResourcesMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	_, span := tracer.Start(ctx, "mutationReplaceResources::Apply", trace.WithAttributes())
+	_, span := tracer.Start(ctx, "mutationReplaceResources::apply", trace.WithAttributes())
 	defer span.End()
 
 	patch := &api.PackagePatchTaskSpec{}

--- a/pkg/task/update.go
+++ b/pkg/task/update.go
@@ -37,7 +37,7 @@ type updatePackageMutation struct {
 }
 
 func (m *updatePackageMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
-	ctx, span := tracer.Start(ctx, "updatePackageMutation::Apply", trace.WithAttributes())
+	ctx, span := tracer.Start(ctx, "updatePackageMutation::apply", trace.WithAttributes())
 	defer span.End()
 
 	currUpstreamPkgRef, err := m.currUpstream()


### PR DESCRIPTION
Implements [#828](https://github.com/nephio-project/nephio/issues/828).

- added OpenTelemetry traces to cover the holes @kushnaidu encountered that made debugging more difficult
  - in some cases this required wiring Context objects in to link isolated traces up with the flows that actually triggered them
- edited trace names at API entrypoints and other points where flows start, to aid in identifying them in Jaeger
- fixed a few compiler warnings on the side