### PR TITLE
Prevent creating "main" tag and release on Github

### DIFF
--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.22.2'
+          go-version: ">=1.22.2"
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -45,9 +45,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: porchctl.tgz
           asset_name: porchctl.tgz
-          tag: ${{ github.ref }}
+          tag: dev
           overwrite: true
           prerelease: true
           release_name: Porchctl build from main
           body: "This is dev porchctl binary built from main each merge"
-


### PR DESCRIPTION
A tag named "main" (same as the branch name "main") in the GitHub repo confuses git clients and scripts executing git operations, so we should avoid it if possible.

This 3 character long PR tries to fix the GH action that regularly recreates that tag,