### PR TITLE
Bump go versions to 1.23.5

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,7 +4,7 @@ presubmits:
     run_if_changed: "(\\.go|Makefile|\\.mk)$"
     spec:
       containers:
-      - image: nephio/gotests:1782782171367346176
+      - image: nephio/gotests:1885274380137664512
         command:
         - make
         args:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /go/src
 

--- a/build/Dockerfile.apiserver
+++ b/build/Dockerfile.apiserver
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /workspace/src
 RUN git clone https://github.com/kubernetes/kubernetes --branch v1.30.1 --depth=1

--- a/build/Dockerfile.etcd
+++ b/build/Dockerfile.etcd
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /workspace
 ARG ETCD_VER=v3.5.1

--- a/controllers/Dockerfile
+++ b/controllers/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /go/src
 

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -14,7 +14,7 @@
 
 
 GOLANG_CI_VER ?= v1.62.2
-GO_VERSION ?= 1.22.0
+GO_VERSION ?= 1.23.5
 GIT_ROOT_DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
 include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 

--- a/default-go-test.mk
+++ b/default-go-test.mk
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-GO_VERSION ?= 1.22.2
+GO_VERSION ?= 1.23.5
 TEST_COVERAGE_FILE=lcov.info
 TEST_COVERAGE_HTML_FILE=coverage_unit.html
 TEST_COVERAGE_FUNC_FILE=func_coverage.out
@@ -25,7 +25,7 @@ unit: test
 .PHONY: test
 test: ## Run unit tests (go test)
 ifeq ($(CONTAINER_RUNNABLE), 0)
-		$(RUN_CONTAINER_COMMAND) docker.io/nephio/gotests:1782782171367346176 \
+		$(RUN_CONTAINER_COMMAND) docker.io/nephio/gotests:1885274380137664512 \
          sh -e -c "git config --global --add user.name test; \
 	 git config --global --add user.email test@nephio.org; \
 	 go test ./... -v -coverprofile ${TEST_COVERAGE_FILE}; \

--- a/examples/apps/hello-server/Dockerfile
+++ b/examples/apps/hello-server/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/func/Dockerfile
+++ b/func/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ FROM gcr.io/kpt-fn/set-project-id:v0.2.0 AS set-project-id
 FROM gcr.io/kpt-fn/starlark:v0.3.0 AS starlark
 FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 AS upsert-resource
 
-FROM golang:1.22.1-alpine3.18 AS builder
+FROM golang:1.23.5-alpine3.21 AS builder
 WORKDIR /go/src
 
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11
@@ -35,7 +35,7 @@ COPY . .
 RUN cd func ; go build -v -o /server ./server
 COPY func/config.yaml /config.yaml
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 COPY --from=apply-setters          /usr/local/bin/function /functions/apply-setters
 COPY --from=apply-setters-v1       /usr/local/bin/function /functions/apply-setters-v1

--- a/func/Dockerfile-wrapperserver
+++ b/func/Dockerfile-wrapperserver
@@ -1,4 +1,18 @@
-FROM golang:1.22.1-alpine3.18 AS builder
+# Copyright 2022-2025 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.23.5-alpine3.21 AS builder
 
 WORKDIR /go/src
 
@@ -12,6 +26,6 @@ COPY func/ func/
 RUN cd func ; go build -v -o /wrapper-server/wrapper-server ./wrapper-server
 RUN cp $GOPATH/bin/grpc-health-probe /wrapper-server/
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 COPY --from=builder /wrapper-server/* /wrapper-server/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nephio-project/porch
 
-go 1.22.0
+go 1.23.5
 
 retract v1.3.0
 

--- a/scripts/boilerplate.go.txt
+++ b/scripts/boilerplate.go.txt
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The kpt and Nephio Authors
+// Copyright 2022-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/boilerplate.yaml.txt
+++ b/scripts/boilerplate.yaml.txt
@@ -1,4 +1,4 @@
-# Copyright 2024 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -60,7 +60,7 @@ kind export kubeconfig --name="$porch_cluster_name"
 
 ##############################################
 h1 Instal MetalLB
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
 sleep 1
 echo "Waiting for controller to become ready..."
 kubectl wait --namespace metallb-system deploy controller \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.23.5-bookworm AS builder
 
 WORKDIR /go/src
 


### PR DESCRIPTION
Update Docker files to target version.
Update make targets with new go version.
Fix header templates.