### PR TITLE
Add additional info to error when blockOwnerDeletion is enabled

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -198,7 +198,7 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	}
 	pkgRevMeta, err = cad.metadataStore.Create(ctx, pkgRevMeta, repositoryObj.Name, repoPkgRev.UID())
 	if err != nil {
-		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && anyBlockOwnerDeletionSet(obj) {
+		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(obj) {
 			return nil, fmt.Errorf("failed to create PackageRev because blockOwnerDeletion is enabled for some ownerReference: %w", err)
 		}
 		return nil, err
@@ -219,15 +219,6 @@ func ensureUniqueWorkspaceName(obj *api.PackageRevision, existingRevs []reposito
 		}
 	}
 	return nil
-}
-
-func anyBlockOwnerDeletionSet(pr *api.PackageRevision) bool {
-	for _, owner := range pr.OwnerReferences {
-		if owner.BlockOwnerDeletion == nil || *owner.BlockOwnerDeletion {
-			return true
-		}
-	}
-	return false
 }
 
 func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version string, repositoryObj *configapi.Repository, repoPr repository.PackageRevision, oldObj, newObj *api.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error) {
@@ -330,7 +321,7 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version string,
 
 	err = cad.updatePkgRevMeta(ctx, repoPkgRev, newObj)
 	if err != nil {
-		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && anyBlockOwnerDeletionSet(newObj) {
+		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(newObj) {
 			return nil, fmt.Errorf("failed to update PackageRev because blockOwnerDeletion is set for some ownerReference: %w", err)
 		}
 		return nil, err

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -199,7 +199,8 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	pkgRevMeta, err = cad.metadataStore.Create(ctx, pkgRevMeta, repositoryObj.Name, repoPkgRev.UID())
 	if err != nil {
 		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(obj) {
-			return nil, fmt.Errorf("failed to create PackageRev because blockOwnerDeletion is enabled for some ownerReference: %w", err)
+			return nil, fmt.Errorf("failed to create internal PackageRev object, because blockOwnerDeletion is enabled for some ownerReference "+
+				"(it is likely that the serviceaccount of porch-server does not have the rights to update finalizers in the owner object): %w", err)
 		}
 		return nil, err
 	}
@@ -322,7 +323,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version string,
 	err = cad.updatePkgRevMeta(ctx, repoPkgRev, newObj)
 	if err != nil {
 		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(newObj) {
-			return nil, fmt.Errorf("failed to update PackageRev because blockOwnerDeletion is set for some ownerReference: %w", err)
+			return nil, fmt.Errorf("failed to update internal PackageRev object, because blockOwnerDeletion is enabled for some ownerReference "+
+				"(it is likely that the serviceaccount of porch-server does not have the rights to update finalizers in the owner object): %w", err)
 		}
 		return nil, err
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -198,6 +198,9 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	}
 	pkgRevMeta, err = cad.metadataStore.Create(ctx, pkgRevMeta, repositoryObj.Name, repoPkgRev.UID())
 	if err != nil {
+		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && anyBlockOwnerDeletionSet(obj) {
+			return nil, fmt.Errorf("failed to create PackageRev because blockOwnerDeletion is enabled for some ownerReference: %w", err)
+		}
 		return nil, err
 	}
 	repoPkgRev.SetMeta(pkgRevMeta)
@@ -216,6 +219,15 @@ func ensureUniqueWorkspaceName(obj *api.PackageRevision, existingRevs []reposito
 		}
 	}
 	return nil
+}
+
+func anyBlockOwnerDeletionSet(pr *api.PackageRevision) bool {
+	for _, owner := range pr.OwnerReferences {
+		if owner.BlockOwnerDeletion == nil || *owner.BlockOwnerDeletion {
+			return true
+		}
+	}
+	return false
 }
 
 func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version string, repositoryObj *configapi.Repository, repoPr repository.PackageRevision, oldObj, newObj *api.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error) {
@@ -318,6 +330,9 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version string,
 
 	err = cad.updatePkgRevMeta(ctx, repoPkgRev, newObj)
 	if err != nil {
+		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && anyBlockOwnerDeletionSet(newObj) {
+			return nil, fmt.Errorf("failed to update PackageRev because blockOwnerDeletion is set for some ownerReference: %w", err)
+		}
 		return nil, err
 	}
 

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/mod/semver"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var tracer = otel.Tracer("repository/util")
@@ -135,4 +136,15 @@ func ValidateWorkspaceName(workspace api.WorkspaceName) error {
 	}
 
 	return nil
+}
+
+// AnyBlockOwnerDeletionSet checks whether there are any ownerReferences in the Object
+// which have blockOwnerDeletion enabled (meaning either nil or true).
+func AnyBlockOwnerDeletionSet(obj client.Object) bool {
+	for _, owner := range obj.GetOwnerReferences() {
+		if owner.BlockOwnerDeletion == nil || *owner.BlockOwnerDeletion {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Related issue: [#835](https://github.com/nephio-project/nephio/issues/835)
This change is meant more as a mitigation than a solution to the problem, returning a more clear error message for a PackageRevision create/update failure when blockOwnerDeletion is enabled.