### PR TITLE
Stop PackageRevision updates from changing creationTimestamp

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -513,6 +513,8 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 	if err != nil {
 		return nil, renderStatus, err
 	}
+	repoPkgRev.SetMeta(rev.ObjectMeta)
+
 	return repoPkgRev, renderStatus, nil
 }
 

--- a/pkg/git/package.go
+++ b/pkg/git/package.go
@@ -174,7 +174,7 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),
 			CreationTimestamp: metav1.Time{
-				Time: p.updated,
+				Time: p.metadata.CreationTimestamp.Time,
 			},
 		},
 		Spec: v1alpha1.PackageRevisionSpec{
@@ -209,7 +209,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),
 			CreationTimestamp: metav1.Time{
-				Time: p.updated,
+				Time: p.metadata.CreationTimestamp.Time,
 			},
 			OwnerReferences: []metav1.OwnerReference{}, // TODO: should point to repository resource
 		},

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -289,7 +289,7 @@ func (p *ociPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			Name:      p.KubeObjectName(),
 			Namespace: p.parent.namespace,
 			CreationTimestamp: metav1.Time{
-				Time: p.created,
+				Time: p.metadata.CreationTimestamp.Time,
 			},
 			ResourceVersion: p.resourceVersion,
 			UID:             p.uid,
@@ -351,7 +351,7 @@ func (p *ociPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 			Name:      p.KubeObjectName(),
 			Namespace: p.parent.namespace,
 			CreationTimestamp: metav1.Time{
-				Time: p.created,
+				Time: p.metadata.CreationTimestamp.Time,
 			},
 			ResourceVersion: p.resourceVersion,
 			UID:             p.uid,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -851,7 +851,7 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch(ctx context.Context) {
 	}, &resourcesAfterUpdate)
 
 	assert.Equal(t, 3, len(resourcesAfterUpdate.Spec.Resources))
-	assert.True(t, reflect.DeepEqual(resourcesBeforeUpdate, resourcesAfterUpdate))
+	assert.EqualValues(t, resourcesBeforeUpdate, resourcesAfterUpdate)
 }
 
 func (t *PorchSuite) TestConcurrentResourceUpdates(ctx context.Context) {


### PR DESCRIPTION
Fixes [#630](https://github.com/nephio-project/nephio/issues/630)

- wire CreationTimestamp in from underlying PackageRev CR when getting a PackageRevision together from Git
  - as mentioned as an option in old comment https://github.com/kptdev/kpt/issues/3992#issuecomment-1614959782
  - and same in OCI implementation for consistency's sake
  - previous implementation got CreationTimestamp from 'updated' attribute which is got from the creation timestamp of the latest commit to the branch in Git, and so kept changing
    - underlying PackageRev CR is a Kubernetes object and has a static creationTimestamp
- wire PackageRev details/ObjectMeta data into PackageRevision returned from update-package-resources flow
  - was previously just empty values with a zero timestamp
  - which broke a test once the creationTimestamp fix was applied