### PR TITLE
adding e2e test validation for PR #167 Modify event on the porch Repo Custom Resource

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2968,3 +2968,87 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors(ctx context.Context) {
 		}
 	}
 }
+
+func (t *PorchSuite) TestRepositoryModify(ctx context.Context) {
+	const (
+		repositoryName = "repo-modify-test"
+		newDescription = "Updated Repository Description"
+	)
+
+	// Create initial repository
+	t.CreateF(ctx, &configapi.Repository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       configapi.TypeRepository.Kind,
+			APIVersion: configapi.TypeRepository.APIVersion(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      repositoryName,
+			Namespace: t.Namespace,
+		},
+		Spec: configapi.RepositorySpec{
+			Description: "Initial Repository",
+			Type:        configapi.RepositoryTypeGit,
+			Git: &configapi.GitRepository{
+				Repo: testBlueprintsRepo,
+			},
+		},
+	})
+
+	// Clean up after test
+	t.Cleanup(func() {
+		t.DeleteL(ctx, &configapi.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      repositoryName,
+				Namespace: t.Namespace,
+			},
+		})
+	})
+
+	// Get the repository to modify
+	var repository configapi.Repository
+	t.GetF(ctx, client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      repositoryName,
+	}, &repository)
+
+	// Modify the repository
+	repository.Spec.Description = newDescription
+	t.UpdateF(ctx, &repository)
+
+	// Wait and verify the repository condition
+	giveUp := time.Now().Add(60 * time.Second)
+	for {
+		if time.Now().After(giveUp) {
+			t.Errorf("Timed out waiting for Repository Condition")
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+
+		var updatedRepo configapi.Repository
+		t.GetF(ctx, client.ObjectKey{
+			Namespace: t.Namespace,
+			Name:      repositoryName,
+		}, &updatedRepo)
+
+		// Verify description was updated
+		if updatedRepo.Spec.Description != newDescription {
+			t.Errorf("Repository description not updated; got %q, want %q",
+				updatedRepo.Spec.Description, newDescription)
+		}
+
+		ready := meta.FindStatusCondition(updatedRepo.Status.Conditions, configapi.RepositoryReady)
+		if ready == nil {
+			t.Logf("Repository condition not yet available")
+			continue
+		}
+
+		if got, want := ready.Status, metav1.ConditionTrue; got != want {
+			t.Errorf("Repository Ready Condition Status; got %q, want %q", got, want)
+		}
+		if got, want := ready.Reason, configapi.ReasonReady; got != want {
+			t.Errorf("Repository Ready Condition Reason: got %q, want %q", got, want)
+		}
+		break
+	}
+}


### PR DESCRIPTION
This PR adds an e2e test to verify the Repository Modify operation functionality. The test ensures that:

1. Repository modifications are processed correctly
2. Modified repositories maintain proper Ready state
3. Repository conditions are updated appropriately after modification

The test follows existing e2e test patterns and verifies:
- Repository can be modified successfully
- Description updates are persisted
- Repository Ready condition remains True after modification
- Proper cleanup is performed after test completion

Related PR: #167 (Repository Modify event implementation)

Testing:
- Added new e2e test: TestRepositoryModify
- Ran e2e tests locally
- Follows existing test patterns in the codebase