### PR TITLE
Add sonar props file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "sonarlint.connectedMode.project": {
+        "connectionId": "nephio-project",
+        "projectKey": "nephio-project_porch"
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+# Required metadata
+sonar.projectKey=nephio-project_porch
+sonar.projectName=porch
+sonar.organization=nephio-project
+
+sonar.language=go
+
+# Path to your Go source code
+sonar.sources=pkg, func, controllers, internal, cmd, build, deployments/porch, api
+
+# Exclude files if needed
+sonar.exclusions=**/test/*, **/examples/*, **/scripts/*, **/third_party/*, **/*_test.go, **/testing*, **/generated/**, **/testdata/**, **/*zz_generated.*
+
+# To include test coverage reports (optional)
+#sonar.tests=./
+sonar.test.inclusions=**/*_test.go
+sonar.coverage.exclusions=**/*_test.go, **/testing*, **/api/*
+sonar.go.tests.reportPaths=report.xml
+sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
Adding a sonar.properties file.
This setup was tested locally and verified that it covers and excludes the relevant areas.

The vscode settings entry was added when I boud my ide sonarlint to the sonarqube project. Users will have to genertse their own token to do the same.