### PR TITLE
Add properties file for automatic analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,21 @@
+# Required metadata
+sonar.projectKey=nephio-project_porch
+sonar.projectName=porch
+sonar.organization=nephio-project
+
+sonar.language=go
+
+# Path to your Go source code
+sonar.sources=pkg, func, controllers, internal, cmd, build, deployments/porch, api
+
+# Exclude files if needed
+sonar.exclusions=**/test/*, **/examples/*, **/scripts/*, **/third_party/*, **/*_test.go, **/testing*, **/generated/**, **/testdata/**, **/*zz_generated.*
+
+# To include test coverage reports (optional)
+#sonar.tests=./
+sonar.test.inclusions=**/*_test.go
+sonar.coverage.exclusions=**/*_test.go, **/testing*, **/api/*
+sonar.go.tests.reportPaths=report.xml
+sonar.go.coverage.reportPaths=coverage.out
+# To exclude duplicated blocks from CPD (Copy-Paste Detection)
+sonar.cpd.exclusions=**/*_test.go, **/test/**


### PR DESCRIPTION
Based on the documentation 
https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/automatic-analysis/#deactivating-automatic-analysis

> You can refine the configuration of your analyses by adding a .sonarcloud.properties file to your repository’s default branch. Note that this is different from the sonar-project.properties file used for CI-based analysis.


And a test on a private fork (on the graph started with these properties and then without, the duplications and issues increase)
![image](https://github.com/user-attachments/assets/2b2466c8-b93f-4a96-a2d8-a31dbaa3a4f7)

I based it on this app https://github.com/marketplace/sonarcloud

[My previous PR](https://github.com/nephio-project/porch/pull/195) was based on a local instance of SonarCloud






Change-Id: I9b904a192f4b51d51066151aa552277ac3782090