### PR TITLE
Move shebang before copyright notices in scripts

### DIFF
--- a/scripts/cleanup-after-tests.sh
+++ b/scripts/cleanup-after-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #  Copyright 2025 The Nephio Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-#!/usr/bin/env bash
 # Stricter error handling
 set -e # Exit on error
 set -u # Must predefine variables

--- a/scripts/generate-api.sh
+++ b/scripts/generate-api.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #  Copyright 2025 The Nephio Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-#!/bin/bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]

--- a/scripts/run-load-test.sh
+++ b/scripts/run-load-test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #  Copyright 2025 The Nephio Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#! /usr/bin/env bash
 
 script_name=$(basename "$0")
 


### PR DESCRIPTION
This PR added missing copyrights to files in the Porch codebase.
https://github.com/nephio-project/porch/pull/189

However, in scripts, the shebang #! must be on the first line.

This PR fixes the scripts and moves the shebang to the first line of the file.