### PR TITLE
Add workflow to archive coverage data

### DIFF
--- a/.github/workflows/sonar-ci-artifacts.yaml
+++ b/.github/workflows/sonar-ci-artifacts.yaml
@@ -29,8 +29,8 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: coverage.out
-        path: build/reports
+        name: coverage-report
+        path: ./coverage.out
 
     - name: Save PR number to file
       if: github.event_name == 'pull_request'

--- a/.github/workflows/sonar-ci-artifacts.yaml
+++ b/.github/workflows/sonar-ci-artifacts.yaml
@@ -23,10 +23,11 @@ jobs:
         go-version: ">=1.23.5"
 
     - name: Generate coverage report
+      id: test
       run: make test
 
     - name: Archive test results
-      if: failure()
+      if: steps.test.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report

--- a/.github/workflows/sonar-ci-artifacts.yaml
+++ b/.github/workflows/sonar-ci-artifacts.yaml
@@ -1,0 +1,44 @@
+name: Sonar CI Artifacts
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+      types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        # Disabling shallow clones is recommended for improving the relevancy of reporting
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ">=1.23.5"
+
+    - name: Generate coverage report
+      run: make test
+
+    - name: Archive test results
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage.out
+        path: build/reports
+
+    - name: Save PR number to file
+      if: github.event_name == 'pull_request'
+      run: echo ${{ github.event.number }} > PR_NUMBER.txt
+      
+    - name: Archive PR number
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: PR_NUMBER
+        path: PR_NUMBER.txt

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,29 +1,73 @@
 name: SonarCloud analysis
-on:
-  # Trigger analysis when pushing to your main branches, and when creating a pull request.
-  push:
-    branches:
-      - main
-  pull_request:
-      types: [opened, synchronize, reopened]
+
+on: 
+  workflow_run:
+    workflows: [Sonar CI Artifacts]
+    types: [completed]
 
 jobs:
   sonarqube:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
+
+    - name: echo event
+      run: cat $GITHUB_EVENT_PATH
+
+    - name: Download PR number artifact
+      if: github.event.workflow_run.event == 'pull_request'
+      uses: dawidd6/action-download-artifact@v9
       with:
-        go-version: ">=1.23.5"
+        workflow: Sonar CI Artifacts
+        run_id: ${{ github.event.workflow_run.id }}
+        name: PR_NUMBER
+
+    - name: Read PR_NUMBER.txt
+      if: github.event.workflow_run.event == 'pull_request'
+      id: pr_number
+      uses: juliangruber/read-file-action@v1.1.7
+      with:
+        path: ./PR_NUMBER.txt
+
+    - name: Request GitHub API for PR data
+      if: github.event.workflow_run.event == 'pull_request'
+      uses: octokit/request-action@v2.4.0
+      id: get_pr_data
+      with:
+        route: GET /repos/{full_name}/pulls/{number}
+        number: ${{ steps.pr_number.outputs.content }}
+        full_name: ${{ github.event.repository.full_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        # Disabling shallow clones is recommended for improving the relevancy of reporting
-        fetch-depth: 0
-    - name: Generate coverage report
-      run: make test
-    - name: SonarQube Scan
-      uses: SonarSource/sonarqube-scan-action@v5.0.0 # Ex: v4.1.0, See the latest version at https://github.com/marketplace/actions/official-sonarqube-scan
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+    - name: Checkout base branch
+      if: github.event.workflow_run.event == 'pull_request'
+      run: |
+        git remote add upstream ${{ github.event.repository.clone_url }}
+        git fetch upstream
+        git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+        git checkout ${{ github.event.workflow_run.head_branch }}
+        git clean -ffdx && git reset --hard HEAD
+
+    - name: Download coverage artifact
+      if: github.event.workflow_run.event == 'pull_request'
+      uses: dawidd6/action-download-artifact@v9
+      with:
+        workflow: Sonar CI Artifacts
+        run_id: ${{ github.event.workflow_run.id }}
+        name: coverage.out
+        use_unzip: true
+
+    - name: SonarQube Scan on PR
+      if: github.event.workflow_run.event == 'pull_request'
+      uses: SonarSource/sonarqube-scan-action@v5.0.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
@@ -31,3 +75,18 @@ jobs:
           -Dsonar.projectKey=nephio-project_porch
           -Dsonar.organization=nephio-project
           -Dproject.settings=sonar-project.properties
+          -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} 
+          -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} 
+          -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          ``
+    - name: SonarCloud Scan on push
+      if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.event.repository.full_name
+      uses: SonarSource/sonarqube-scan-action@v5.0.0
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      with:
+        args:
+          -Dsonar.projectKey=nephio-project_porch
+          -Dsonar.organization=nephio-project
+          -Dproject.settings=sonar-project.properties
+          -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
Github secrets are not passed to workflows triggered by PRs coming from forks.
This PR is adding a prestep workflow to produce and archive the coverage report and it's related PR number.
Then the sonar gh action retrieves this data and pushes the report to soanrqube.