### PR TITLE
Port main E2E test suite to testify

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -51,4 +51,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.62.2
-          args: --timeout=10m --go=${{ env.GO_VERSION }} --exclude-dirs=test --exclude-generated=true
+          args: --timeout=10m --go=${{ env.GO_VERSION }} --exclude-generated=true

--- a/default-go-lint.mk
+++ b/default-go-lint.mk
@@ -23,7 +23,7 @@ include $(GIT_ROOT_DIR)/detect-container-runtime.mk
 lint: ## Run Go linter against the codebase
 ifeq ($(CONTAINER_RUNNABLE), 0)
 	$(RUN_CONTAINER_COMMAND) docker.io/golangci/golangci-lint:${GOLANG_CI_VER}-alpine \
-	 golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-dirs=test --exclude-generated=true
+	 golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-generated=true
 else
-	golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-dirs=test --exclude-generated=true
+	golangci-lint run ./... -v --go=${GO_VERSION} --timeout=10m --exclude-generated=true
 endif

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -66,7 +66,7 @@ func TestE2E(t *testing.T) {
 
 func (t *PorchSuite) TestGitRepository() {
 	// Register the repository as 'git'
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git")
+	t.RegisterMainGitRepositoryF("git")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -103,11 +103,11 @@ func (t *PorchSuite) TestGitRepository() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get package resources
 	var resources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resources)
@@ -126,11 +126,11 @@ func (t *PorchSuite) TestGitRepository() {
 }
 
 func (t *PorchSuite) TestGitRepositoryWithReleaseTagsAndDirectory() {
-	t.RegisterGitRepositoryF(t.GetContext(), kptRepo, "kpt-repo", "package-examples")
+	t.RegisterGitRepositoryF(kptRepo, "kpt-repo", "package-examples")
 
 	t.Log("Listing PackageRevisions in " + t.Namespace)
 	var list porchapi.PackageRevisionList
-	t.ListF(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListF(&list, client.InNamespace(t.Namespace))
 
 	for _, pr := range list.Items {
 		if strings.HasPrefix(pr.Spec.PackageName, "package-examples") {
@@ -141,15 +141,15 @@ func (t *PorchSuite) TestGitRepositoryWithReleaseTagsAndDirectory() {
 
 func (t *PorchSuite) TestCloneFromUpstream() {
 	// Register Upstream Repository
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	upstreamPr := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v1"})
 
 	// Register the repository as 'downstream'
-	t.RegisterMainGitRepositoryF(t.GetContext(), "downstream")
+	t.RegisterMainGitRepositoryF("downstream")
 
 	// Create PackageRevision from upstream repo
 	clonedPr := &porchapi.PackageRevision{
@@ -179,11 +179,11 @@ func (t *PorchSuite) TestCloneFromUpstream() {
 		},
 	}
 
-	t.CreateF(t.GetContext(), clonedPr)
+	t.CreateF(clonedPr)
 
 	// Get istions resources
 	var istions porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      clonedPr.Name,
 	}, &istions)
@@ -242,11 +242,11 @@ func (t *PorchSuite) TestConcurrentClones() {
 	)
 
 	// Register Upstream and Downstream Repositories
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, upstreamRepository, "")
-	t.RegisterMainGitRepositoryF(t.GetContext(), downstreamRepository)
+	t.RegisterGitRepositoryF(testBlueprintsRepo, upstreamRepository, "")
+	t.RegisterMainGitRepositoryF(downstreamRepository)
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 	upstreamPr := t.MustFindPackageRevision(
 		&list,
 		repository.PackageRevisionKey{
@@ -294,7 +294,7 @@ func (t *PorchSuite) TestInitEmptyPackage() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -311,11 +311,11 @@ func (t *PorchSuite) TestInitEmptyPackage() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get the package
 	var newPackage porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &newPackage)
@@ -342,7 +342,7 @@ func (t *PorchSuite) TestConcurrentInits() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Two clients try to create the same new draft package
 	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
@@ -376,7 +376,7 @@ func (t *PorchSuite) TestInitTaskPackage() {
 	keywords := []string{"test"}
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -403,11 +403,11 @@ func (t *PorchSuite) TestInitTaskPackage() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get the package
 	var newPackage porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &newPackage)
@@ -431,13 +431,13 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository() {
 	const downstreamWorkspace = "test-workspace"
 
 	// Register the deployment repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), downstreamRepository, WithDeployment())
+	t.RegisterMainGitRepositoryF(downstreamRepository, WithDeployment())
 
 	// Register the upstream repository
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var upstreamPackages porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &upstreamPackages, client.InNamespace(t.Namespace))
+	t.ListE(&upstreamPackages, client.InNamespace(t.Namespace))
 	upstreamPackage := t.MustFindPackageRevision(&upstreamPackages, repository.PackageRevisionKey{
 		Repository:    "test-blueprints",
 		Package:       "basens",
@@ -472,11 +472,11 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get istions resources
 	var istions porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &istions)
@@ -544,7 +544,7 @@ func (t *PorchSuite) TestEditPackageRevision() {
 		workspace2       = "workspace2"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -561,7 +561,7 @@ func (t *PorchSuite) TestEditPackageRevision() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Create a new revision, but with a different package as the source.
 	// This is not allowed.
@@ -625,18 +625,18 @@ func (t *PorchSuite) TestEditPackageRevision() {
 
 	// Publish the source package to make it a valid source for edit.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), pr)
+	t.UpdateF(pr)
 
 	// Approve the package
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), pr, metav1.UpdateOptions{})
+	t.UpdateApprovalF(pr, metav1.UpdateOptions{})
 
 	// Create a new revision with the edit task.
-	t.CreateF(t.GetContext(), editPR)
+	t.CreateF(editPR)
 
 	// Check its task list
 	var pkgRev porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      editPR.Name,
 	}, &pkgRev)
@@ -655,17 +655,17 @@ func (t *PorchSuite) TestConcurrentEdits() {
 		workspace2  = "workspace2"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Publish and approve the source package to make it a valid source for edit.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), pr)
+	t.UpdateF(pr)
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), pr, metav1.UpdateOptions{})
+	t.UpdateApprovalF(pr, metav1.UpdateOptions{})
 
 	// Create a new revision of the package with a source that is a revision
 	// of the same package.
@@ -698,7 +698,7 @@ func (t *PorchSuite) TestConcurrentEdits() {
 
 	// Check its task list
 	var pkgRev porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      editPR.Name,
 	}, &pkgRev)
@@ -715,7 +715,7 @@ func (t *PorchSuite) TestUpdateResources() {
 		workspace   = "workspace"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -732,11 +732,11 @@ func (t *PorchSuite) TestUpdateResources() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get the package resources
 	var newPackage porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &newPackage)
@@ -763,7 +763,7 @@ func (t *PorchSuite) TestUpdateResources() {
 		t.Fatalf("Failed to read ConfigMap from %q: %v", filename, err)
 	}
 	newPackage.Spec.Resources["config-map.yaml"] = string(cm)
-	t.UpdateF(t.GetContext(), &newPackage)
+	t.UpdateF(&newPackage)
 
 	updated, ok := newPackage.Spec.Resources["config-map.yaml"]
 	if !ok {
@@ -791,7 +791,7 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {
 		workspace   = "workspace"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -808,11 +808,11 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Check its task list
 	var pkgBeforeUpdate porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &pkgBeforeUpdate)
@@ -821,17 +821,17 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {
 
 	// Get the package resources
 	var resourcesBeforeUpdate porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resourcesBeforeUpdate)
 
 	// "Update" the package resources, without changing anything
-	t.UpdateF(t.GetContext(), &resourcesBeforeUpdate)
+	t.UpdateF(&resourcesBeforeUpdate)
 
 	// Check the task list
 	var pkgAfterUpdate porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &pkgAfterUpdate)
@@ -842,7 +842,7 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {
 
 	// Get the package resources
 	var resourcesAfterUpdate porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resourcesAfterUpdate)
@@ -858,15 +858,15 @@ func (t *PorchSuite) TestConcurrentResourceUpdates() {
 		workspace   = "workspace"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get the package resources
 	var newPackageResources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &newPackageResources)
@@ -898,10 +898,10 @@ func (t *PorchSuite) NewClientWithTimeout(timeout time.Duration) client.Client {
 }
 
 func (t *PorchSuite) TestPublicGitRepository() {
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "demo-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "demo-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	if got := len(list.Items); got == 0 {
 		t.Errorf("Found no package revisions in %s; expected at least one", testBlueprintsRepo)
@@ -916,7 +916,7 @@ func (t *PorchSuite) TestProposeApprove() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -939,20 +939,20 @@ func (t *PorchSuite) TestProposeApprove() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	var pkg porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &pkg)
 
 	// Propose the package revision to be finalized
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 
 	var proposed porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &proposed)
@@ -969,7 +969,7 @@ func (t *PorchSuite) TestProposeApprove() {
 
 	// Approve the package
 	proposed.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	approved := t.UpdateApprovalF(t.GetContext(), &proposed, metav1.UpdateOptions{})
+	approved := t.UpdateApprovalF(&proposed, metav1.UpdateOptions{})
 	if got, want := approved.Spec.Lifecycle, porchapi.PackageRevisionLifecyclePublished; got != want {
 		t.Fatalf("Approved package lifecycle value: got %s, want %s", got, want)
 	}
@@ -988,7 +988,7 @@ func (t *PorchSuite) TestConcurrentProposeApprove() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
@@ -998,10 +998,10 @@ func (t *PorchSuite) TestConcurrentProposeApprove() {
 			Init: &porchapi.PackageInitTaskSpec{},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	var pkg porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &pkg)
@@ -1021,7 +1021,7 @@ func (t *PorchSuite) TestConcurrentProposeApprove() {
 	assert.True(t, conflictFailurePresent, "expected one 'propose' request to fail with a conflict, but did not happen - results: %v", proposeResults)
 
 	var proposed porchapi.PackageRevision
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &proposed)
@@ -1054,23 +1054,23 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 	)
 
 	// Register the repositories
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
-	t.RegisterGitRepositoryWithDirectoryF(t.GetContext(), subfolderRepository, subfolderDirectory)
+	t.RegisterMainGitRepositoryF(repository)
+	t.RegisterGitRepositoryWithDirectoryF(subfolderRepository, subfolderDirectory)
 
 	// Create a new package (via init)
-	subfolderPr := t.CreatePackageDraftF(t.GetContext(), repository, subfolderPackageName, workspace)
-	prInSubfolder := t.CreatePackageDraftF(t.GetContext(), subfolderRepository, normalPackageName, workspace)
+	subfolderPr := t.CreatePackageDraftF(repository, subfolderPackageName, workspace)
+	prInSubfolder := t.CreatePackageDraftF(subfolderRepository, normalPackageName, workspace)
 
 	// Propose and approve the package revisions
 	subfolderPr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
 	prInSubfolder.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), subfolderPr)
-	t.UpdateF(t.GetContext(), prInSubfolder)
+	t.UpdateF(subfolderPr)
+	t.UpdateF(prInSubfolder)
 
 	subfolderPr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	prInSubfolder.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	subfolderPr = t.UpdateApprovalF(t.GetContext(), subfolderPr, metav1.UpdateOptions{})
-	prInSubfolder = t.UpdateApprovalF(t.GetContext(), prInSubfolder, metav1.UpdateOptions{})
+	subfolderPr = t.UpdateApprovalF(subfolderPr, metav1.UpdateOptions{})
+	prInSubfolder = t.UpdateApprovalF(prInSubfolder, metav1.UpdateOptions{})
 
 	assert.Equal(t, porchapi.PackageRevisionLifecyclePublished, subfolderPr.Spec.Lifecycle)
 	assert.Equal(t, "v1", subfolderPr.Spec.Revision)
@@ -1089,7 +1089,7 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), editedSubfolderPr)
+	t.CreateF(editedSubfolderPr)
 	editedPrInSubfolder := t.CreatePackageSkeleton(subfolderRepository, normalPackageName, workspace2)
 	editedPrInSubfolder.Spec.Tasks = []porchapi.Task{
 		{
@@ -1101,18 +1101,18 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), editedPrInSubfolder)
+	t.CreateF(editedPrInSubfolder)
 
 	// Propose and approve these package revisions as well
 	editedSubfolderPr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
 	editedPrInSubfolder.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), editedSubfolderPr)
-	t.UpdateF(t.GetContext(), editedPrInSubfolder)
+	t.UpdateF(editedSubfolderPr)
+	t.UpdateF(editedPrInSubfolder)
 
 	editedSubfolderPr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	editedPrInSubfolder.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	editedSubfolderPr = t.UpdateApprovalF(t.GetContext(), editedSubfolderPr, metav1.UpdateOptions{})
-	editedPrInSubfolder = t.UpdateApprovalF(t.GetContext(), editedPrInSubfolder, metav1.UpdateOptions{})
+	editedSubfolderPr = t.UpdateApprovalF(editedSubfolderPr, metav1.UpdateOptions{})
+	editedPrInSubfolder = t.UpdateApprovalF(editedPrInSubfolder, metav1.UpdateOptions{})
 
 	assert.Equal(t, porchapi.PackageRevisionLifecyclePublished, editedSubfolderPr.Spec.Lifecycle)
 	assert.Equal(t, "v2", editedSubfolderPr.Spec.Revision)
@@ -1129,24 +1129,24 @@ func (t *PorchSuite) TestDeleteDraft() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a draft package
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var draft porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &draft)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &draft)
 
 	// Delete the package
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      created.Name,
 		},
 	})
 
-	t.MustNotExist(t.GetContext(), &draft)
+	t.MustNotExist(&draft)
 }
 
 func (t *PorchSuite) TestConcurrentDeletes() {
@@ -1158,12 +1158,12 @@ func (t *PorchSuite) TestConcurrentDeletes() {
 	)
 
 	// Register the repository and create a draft package
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	t.RegisterMainGitRepositoryF(repository)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var draft porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &draft)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &draft)
 
 	// Delete the same package with two clients at the same time
 	deleteFunction := func() any {
@@ -1188,7 +1188,7 @@ func (t *PorchSuite) TestConcurrentDeletes() {
 		return eachResult != nil && strings.Contains(eachResult.(error).Error(), "another request is already in progress")
 	})
 	assert.True(t, conflictFailurePresent, "expected one request to fail with a conflict, but did not happen - results: %v", results)
-	t.MustNotExist(t.GetContext(), &draft)
+	t.MustNotExist(&draft)
 }
 
 func (t *PorchSuite) TestDeleteProposed() {
@@ -1200,28 +1200,28 @@ func (t *PorchSuite) TestDeleteProposed() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a draft package
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var pkg porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose the package revision to be finalized
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 
 	// Delete the package
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      created.Name,
 		},
 	})
 
-	t.MustNotExist(t.GetContext(), &pkg)
+	t.MustNotExist(&pkg)
 }
 
 func (t *PorchSuite) TestDeleteFinal() {
@@ -1232,50 +1232,50 @@ func (t *PorchSuite) TestDeleteFinal() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a draft package
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var pkg porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose the package revision to be finalized
 	t.Log("Proposing package")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 
 	t.Log("Approving package")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
 
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Try to delete the package. This should fail because it hasn't been proposed for deletion.
 	t.Log("Trying to delete package (should fail)")
-	t.DeleteL(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteL(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      created.Name,
 		},
 	})
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose deletion and then delete the package
 	t.Log("Proposing deletion of  package")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
 
 	t.Log("Deleting package")
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      created.Name,
 		},
 	})
 
-	t.MustNotExist(t.GetContext(), &pkg)
+	t.MustNotExist(&pkg)
 }
 
 func (t *PorchSuite) TestConcurrentProposeDeletes() {
@@ -1286,19 +1286,19 @@ func (t *PorchSuite) TestConcurrentProposeDeletes() {
 	)
 
 	// Register the repository and create a draft package
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	t.RegisterMainGitRepositoryF(repository)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 	// Check the package exists
 	var pkg porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose and approve the package revision to be finalized
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
 
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose deletion with two clients at once
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
@@ -1324,60 +1324,60 @@ func (t *PorchSuite) TestProposeDeleteAndUndo() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a draft package
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var pkg porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Propose the package revision to be finalized
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
-	_ = t.WaitUntilPackageRevisionExists(t.GetContext(), repository, packageName, "main")
+	_ = t.WaitUntilPackageRevisionExists(repository, packageName, "main")
 
 	var list porchapi.PackageRevisionList
-	t.ListF(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListF(&list, client.InNamespace(t.Namespace))
 
 	for i := range list.Items {
 		pkgRev := list.Items[i]
 		t.Run(fmt.Sprintf("revision %s", pkgRev.Spec.Revision), func() {
 			// Propose deletion
 			pkgRev.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-			t.UpdateApprovalF(t.GetContext(), &pkgRev, metav1.UpdateOptions{})
+			t.UpdateApprovalF(&pkgRev, metav1.UpdateOptions{})
 
 			// Undo proposal of deletion
 			pkgRev.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-			t.UpdateApprovalF(t.GetContext(), &pkgRev, metav1.UpdateOptions{})
+			t.UpdateApprovalF(&pkgRev, metav1.UpdateOptions{})
 
 			// Try to delete the package. This should fail because the lifecycle should be changed back to Published.
-			t.DeleteL(t.GetContext(), &porchapi.PackageRevision{
+			t.DeleteL(&porchapi.PackageRevision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: t.Namespace,
 					Name:      pkgRev.Name,
 				},
 			})
-			t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: pkgRev.Name}, &pkgRev)
+			t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: pkgRev.Name}, &pkgRev)
 
 			// Propose deletion and then delete the package
 			pkgRev.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-			t.UpdateApprovalF(t.GetContext(), &pkgRev, metav1.UpdateOptions{})
+			t.UpdateApprovalF(&pkgRev, metav1.UpdateOptions{})
 
-			t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+			t.DeleteE(&porchapi.PackageRevision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: t.Namespace,
 					Name:      pkgRev.Name,
 				},
 			})
 
-			t.MustNotExist(t.GetContext(), &pkgRev)
+			t.MustNotExist(&pkgRev)
 		})
 	}
 }
@@ -1391,56 +1391,56 @@ func (t *PorchSuite) TestDeleteAndRecreate() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a draft package
-	created := t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created := t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
 	var pkg porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	t.Log("Propose the package revision to be finalized")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkg)
+	t.UpdateF(&pkg)
 
 	t.Log("Approve the package revision to be finalized")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
 
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
-	mainPkg := t.WaitUntilPackageRevisionExists(t.GetContext(), repository, packageName, "main")
+	mainPkg := t.WaitUntilPackageRevisionExists(repository, packageName, "main")
 
 	t.Log("Propose deletion and then delete the package with revision v1")
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateApprovalF(t.GetContext(), &pkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkg, metav1.UpdateOptions{})
 
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      created.Name,
 		},
 	})
-	t.MustNotExist(t.GetContext(), &pkg)
+	t.MustNotExist(&pkg)
 
 	t.Log("Propose deletion and then delete the package with revision main")
 	mainPkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateApprovalF(t.GetContext(), mainPkg, metav1.UpdateOptions{})
+	t.UpdateApprovalF(mainPkg, metav1.UpdateOptions{})
 
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      mainPkg.Name,
 		},
 	})
-	t.MustNotExist(t.GetContext(), mainPkg)
+	t.MustNotExist(mainPkg)
 
 	// Recreate the package with the same name and workspace
-	created = t.CreatePackageDraftF(t.GetContext(), repository, packageName, workspace)
+	created = t.CreatePackageDraftF(repository, packageName, workspace)
 
 	// Check the package exists
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: created.Name}, &pkg)
 
 	// Ensure that there is only one init task in the package revision history
 	foundInitTask := false
@@ -1464,52 +1464,52 @@ func (t *PorchSuite) TestDeleteFromMain() {
 	)
 
 	// Register the repository
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	t.Logf("Create and approve package: %s", packageNameFirst)
-	createdFirst := t.CreatePackageDraftF(t.GetContext(), repository, packageNameFirst, workspace)
+	createdFirst := t.CreatePackageDraftF(repository, packageNameFirst, workspace)
 
 	// Check the package exists
 	var pkgFirst porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: createdFirst.Name}, &pkgFirst)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: createdFirst.Name}, &pkgFirst)
 
 	// Propose the package revision to be finalized
 	pkgFirst.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkgFirst)
+	t.UpdateF(&pkgFirst)
 
 	pkgFirst.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkgFirst, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkgFirst, metav1.UpdateOptions{})
 
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: createdFirst.Name}, &pkgFirst)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: createdFirst.Name}, &pkgFirst)
 
 	t.Logf("Create and approve package: %s", packageNameSecond)
-	createdSecond := t.CreatePackageDraftF(t.GetContext(), repository, packageNameSecond, workspace)
+	createdSecond := t.CreatePackageDraftF(repository, packageNameSecond, workspace)
 
 	// Check the package exists
 	var pkgSecond porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: createdSecond.Name}, &pkgSecond)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: createdSecond.Name}, &pkgSecond)
 
 	// Propose the package revision to be finalized
 	pkgSecond.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pkgSecond)
+	t.UpdateF(&pkgSecond)
 
 	pkgSecond.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), &pkgSecond, metav1.UpdateOptions{})
+	t.UpdateApprovalF(&pkgSecond, metav1.UpdateOptions{})
 
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: createdSecond.Name}, &pkgSecond)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: createdSecond.Name}, &pkgSecond)
 
 	t.Log("Wait for the 'main' revisions to get created")
-	firstPkgRevFromMain := t.WaitUntilPackageRevisionExists(t.GetContext(), repository, packageNameFirst, "main")
-	secondPkgRevFromMain := t.WaitUntilPackageRevisionExists(t.GetContext(), repository, packageNameSecond, "main")
+	firstPkgRevFromMain := t.WaitUntilPackageRevisionExists(repository, packageNameFirst, "main")
+	secondPkgRevFromMain := t.WaitUntilPackageRevisionExists(repository, packageNameSecond, "main")
 
 	t.Log("Propose deletion of both main packages")
 	firstPkgRevFromMain.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateApprovalF(t.GetContext(), firstPkgRevFromMain, metav1.UpdateOptions{})
+	t.UpdateApprovalF(firstPkgRevFromMain, metav1.UpdateOptions{})
 	secondPkgRevFromMain.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateApprovalF(t.GetContext(), secondPkgRevFromMain, metav1.UpdateOptions{})
+	t.UpdateApprovalF(secondPkgRevFromMain, metav1.UpdateOptions{})
 
 	t.Log("Delete the first package revision from main")
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      firstPkgRevFromMain.Name,
@@ -1517,7 +1517,7 @@ func (t *PorchSuite) TestDeleteFromMain() {
 	})
 
 	t.Log("Delete the second package revision from main")
-	t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+	t.DeleteE(&porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      secondPkgRevFromMain.Name,
@@ -1526,12 +1526,12 @@ func (t *PorchSuite) TestDeleteFromMain() {
 
 	// Propose and delete the original package revisions (cleanup)
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 	for _, pkgrev := range list.Items {
 		t.Logf("Propose deletion and delete package revision: %s", pkgrev.Name)
 		pkgrev.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-		t.UpdateApprovalF(t.GetContext(), &pkgrev, metav1.UpdateOptions{})
-		t.DeleteE(t.GetContext(), &porchapi.PackageRevision{
+		t.UpdateApprovalF(&pkgrev, metav1.UpdateOptions{})
+		t.DeleteE(&porchapi.PackageRevision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: t.Namespace,
 				Name:      pkgrev.Name,
@@ -1548,7 +1548,7 @@ func (t *PorchSuite) TestCloneLeadingSlash() {
 		workspace   = "workspace"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Clone the package. Use leading slash in the directory (regression test)
 	new := &porchapi.PackageRevision{
@@ -1582,10 +1582,10 @@ func (t *PorchSuite) TestCloneLeadingSlash() {
 		},
 	}
 
-	t.CreateF(t.GetContext(), new)
+	t.CreateF(new)
 
 	var pr porchapi.PackageRevision
-	t.MustExist(t.GetContext(), client.ObjectKey{Namespace: t.Namespace, Name: new.Name}, &pr)
+	t.MustExist(client.ObjectKey{Namespace: t.Namespace, Name: new.Name}, &pr)
 }
 
 func (t *PorchSuite) TestPackageUpdate() {
@@ -1593,16 +1593,16 @@ func (t *PorchSuite) TestPackageUpdate() {
 		gitRepository = "package-update"
 	)
 
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	basensV1 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v1"})
 	basensV2 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
 
 	// Register the repository as 'downstream'
-	t.RegisterMainGitRepositoryF(t.GetContext(), gitRepository)
+	t.RegisterMainGitRepositoryF(gitRepository)
 
 	// Create PackageRevision from upstream repo
 	pr := &porchapi.PackageRevision{
@@ -1632,10 +1632,10 @@ func (t *PorchSuite) TestPackageUpdate() {
 		},
 	}
 
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	var revisionResources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &revisionResources)
@@ -1646,10 +1646,10 @@ func (t *PorchSuite) TestPackageUpdate() {
 		t.Fatalf("Failed to read ConfigMap from %q: %v", filename, err)
 	}
 	revisionResources.Spec.Resources["config-map.yaml"] = string(cm)
-	t.UpdateF(t.GetContext(), &revisionResources)
+	t.UpdateF(&revisionResources)
 
 	var newrr porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &newrr)
@@ -1657,7 +1657,7 @@ func (t *PorchSuite) TestPackageUpdate() {
 	by, _ := yaml.Marshal(&newrr)
 	t.Logf("PRR: %s", string(by))
 
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, pr)
@@ -1671,9 +1671,9 @@ func (t *PorchSuite) TestPackageUpdate() {
 		},
 	})
 
-	t.UpdateE(t.GetContext(), pr, &client.UpdateOptions{})
+	t.UpdateE(pr, &client.UpdateOptions{})
 
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &revisionResources)
@@ -1690,16 +1690,16 @@ func (t *PorchSuite) TestConcurrentPackageUpdates() {
 		workspace     = "test-workspace"
 	)
 
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	basensV1 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v1"})
 	basensV2 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
 
 	// Register the repository as 'downstream'
-	t.RegisterMainGitRepositoryF(t.GetContext(), gitRepository)
+	t.RegisterMainGitRepositoryF(gitRepository)
 
 	// Create PackageRevision from upstream repo
 	pr := t.CreatePackageSkeleton(gitRepository, packageName, workspace)
@@ -1715,7 +1715,7 @@ func (t *PorchSuite) TestConcurrentPackageUpdates() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	upstream := pr.Spec.Tasks[0].Clone.Upstream.DeepCopy()
 	upstream.UpstreamRef.Name = basensV2.Name
@@ -1744,12 +1744,12 @@ func (t *PorchSuite) TestRegisterRepository() {
 	const (
 		repository = "register"
 	)
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository,
+	t.RegisterMainGitRepositoryF(repository,
 		withType(configapi.RepositoryTypeGit),
 		WithDeployment())
 
 	var repo configapi.Repository
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      repository,
 	}, &repo)
@@ -1764,7 +1764,7 @@ func (t *PorchSuite) TestRegisterRepository() {
 
 func (t *PorchSuite) TestBuiltinFunctionEvaluator() {
 	// Register the repository as 'git-fn'
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-builtin-fn")
+	t.RegisterMainGitRepositoryF("git-builtin-fn")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -1814,11 +1814,11 @@ func (t *PorchSuite) TestBuiltinFunctionEvaluator() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get package resources
 	var resources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resources)
@@ -1842,7 +1842,7 @@ func (t *PorchSuite) TestBuiltinFunctionEvaluator() {
 
 func (t *PorchSuite) TestExecFunctionEvaluator() {
 	// Register the repository as 'git-fn'
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-fn")
+	t.RegisterMainGitRepositoryF("git-fn")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -1891,11 +1891,11 @@ for resource in ctx.resource_list["items"]:
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get package resources
 	var resources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resources)
@@ -1922,7 +1922,7 @@ func (t *PorchSuite) TestPodFunctionEvaluatorWithDistrolessImage() {
 		t.Skipf("Skipping due to not having pod evaluator in local mode")
 	}
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-fn-distroless")
+	t.RegisterMainGitRepositoryF("git-fn-distroless")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -1976,11 +1976,11 @@ data:
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get package resources
 	var resources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resources)
@@ -2009,7 +2009,7 @@ func (t *PorchSuite) TestPodEvaluator() {
 	)
 
 	// Register the repository as 'git-fn'
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-fn-pod")
+	t.RegisterMainGitRepositoryF("git-fn-pod")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -2054,11 +2054,11 @@ func (t *PorchSuite) TestPodEvaluator() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	// Get package resources
 	var resources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &resources)
@@ -2082,11 +2082,11 @@ func (t *PorchSuite) TestPodEvaluator() {
 
 	// Get the fn runner pods and delete them.
 	podList := &corev1.PodList{}
-	t.ListF(t.GetContext(), podList, client.InNamespace("porch-fn-system"))
+	t.ListF(podList, client.InNamespace("porch-fn-system"))
 	for _, pod := range podList.Items {
 		img := pod.Spec.Containers[0].Image
 		if img == generateFolderImage || img == setAnnotationsImage {
-			t.DeleteF(t.GetContext(), &pod)
+			t.DeleteF(&pod)
 		}
 	}
 
@@ -2133,10 +2133,10 @@ func (t *PorchSuite) TestPodEvaluator() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), pr2)
+	t.CreateF(pr2)
 
 	// Get package resources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr2.Name,
 	}, &resources)
@@ -2164,7 +2164,7 @@ func (t *PorchSuite) TestPodEvaluatorWithFailure() {
 		t.Skipf("Skipping due to not having pod evaluator in local mode")
 	}
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-fn-pod-failure")
+	t.RegisterMainGitRepositoryF("git-fn-pod-failure")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -2212,7 +2212,7 @@ func (t *PorchSuite) TestLargePackageRevision() {
 		testDataSize        = 5 * 1024 * 1024
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), "git-fn-pod-large")
+	t.RegisterMainGitRepositoryF("git-fn-pod-large")
 
 	// Create Package Revision
 	pr := &porchapi.PackageRevision{
@@ -2238,10 +2238,10 @@ func (t *PorchSuite) TestLargePackageRevision() {
 		},
 	}
 
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	var prr porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKeyFromObject(pr), &prr)
+	t.GetF(client.ObjectKeyFromObject(pr), &prr)
 
 	if !t.TestRunnerIsLocal {
 		// pod evaluator is not available in local test mode, skip testing it
@@ -2267,7 +2267,7 @@ data:
   value: "` + strings.Repeat("a", testDataSize) + `"
 `
 
-	t.UpdateF(t.GetContext(), &prr)
+	t.UpdateF(&prr)
 
 	rs := prr.Status.RenderStatus
 	if rs.Err != "" || rs.Result.ExitCode != 0 {
@@ -2275,7 +2275,7 @@ data:
 	}
 
 	// Get package resources
-	t.GetF(t.GetContext(), client.ObjectKeyFromObject(pr), &prr)
+	t.GetF(client.ObjectKeyFromObject(pr), &prr)
 
 	for name, obj := range prr.Spec.Resources {
 		if !strings.HasSuffix(name, ".yaml") {
@@ -2308,7 +2308,7 @@ func (t *PorchSuite) TestRepositoryError() {
 	const (
 		repositoryName = "repo-with-error"
 	)
-	t.CreateF(t.GetContext(), &configapi.Repository{
+	t.CreateF(&configapi.Repository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       configapi.TypeRepository.Kind,
 			APIVersion: configapi.TypeRepository.APIVersion(),
@@ -2327,7 +2327,7 @@ func (t *PorchSuite) TestRepositoryError() {
 		},
 	})
 	t.Cleanup(func() {
-		t.DeleteL(t.GetContext(), &configapi.Repository{
+		t.DeleteL(&configapi.Repository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      repositoryName,
 				Namespace: t.Namespace,
@@ -2346,7 +2346,7 @@ func (t *PorchSuite) TestRepositoryError() {
 		time.Sleep(5 * time.Second)
 
 		var repository configapi.Repository
-		t.GetF(t.GetContext(), client.ObjectKey{
+		t.GetF(client.ObjectKey{
 			Namespace: t.Namespace,
 			Name:      repositoryName,
 		}, &repository)
@@ -2381,7 +2381,7 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 		annoVal2   = "bar"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a package with labels and annotations.
 	pr := porchapi.PackageRevision{
@@ -2413,8 +2413,8 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), &pr)
-	t.ValidateLabelsAndAnnos(t.GetContext(), pr.Name,
+	t.CreateF(&pr)
+	t.ValidateLabelsAndAnnos(pr.Name,
 		map[string]string{
 			labelKey1: labelVal1,
 		},
@@ -2426,15 +2426,15 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 
 	// Propose the package.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), &pr)
+	t.UpdateF(&pr)
 
 	// retrieve the updated object
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: pr.Namespace,
 		Name:      pr.Name,
 	}, &pr)
 
-	t.ValidateLabelsAndAnnos(t.GetContext(), pr.Name,
+	t.ValidateLabelsAndAnnos(pr.Name,
 		map[string]string{
 			labelKey1: labelVal1,
 		},
@@ -2446,8 +2446,8 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 
 	// Approve the package
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	_ = t.UpdateApprovalF(t.GetContext(), &pr, metav1.UpdateOptions{})
-	t.ValidateLabelsAndAnnos(t.GetContext(), pr.Name,
+	_ = t.UpdateApprovalF(&pr, metav1.UpdateOptions{})
+	t.ValidateLabelsAndAnnos(pr.Name,
 		map[string]string{
 			labelKey1:                         labelVal1,
 			porchapi.LatestPackageRevisionKey: porchapi.LatestPackageRevisionValue,
@@ -2459,7 +2459,7 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 	)
 
 	// retrieve the updated object
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: pr.Namespace,
 		Name:      pr.Name,
 	}, &pr)
@@ -2469,8 +2469,8 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 	pr.ObjectMeta.Labels[labelKey2] = labelVal2
 	delete(pr.ObjectMeta.Annotations, annoKey2)
 	pr.Spec.Revision = "v1"
-	t.UpdateF(t.GetContext(), &pr)
-	t.ValidateLabelsAndAnnos(t.GetContext(), pr.Name,
+	t.UpdateF(&pr)
+	t.ValidateLabelsAndAnnos(pr.Name,
 		map[string]string{
 			labelKey2:                         labelVal2,
 			porchapi.LatestPackageRevisionKey: porchapi.LatestPackageRevisionValue,
@@ -2508,8 +2508,8 @@ func (t *PorchSuite) TestNewPackageRevisionLabels() {
 			},
 		},
 	}
-	t.CreateF(t.GetContext(), &clonedPr)
-	t.ValidateLabelsAndAnnos(t.GetContext(), clonedPr.Name,
+	t.CreateF(&clonedPr)
+	t.ValidateLabelsAndAnnos(clonedPr.Name,
 		map[string]string{},
 		map[string]string{},
 	)
@@ -2523,10 +2523,10 @@ func (t *PorchSuite) TestRegisteredPackageRevisionLabels() {
 		annoVal  = "foo"
 	)
 
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	basens := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v1"})
 	if basens.ObjectMeta.Labels == nil {
@@ -2537,9 +2537,9 @@ func (t *PorchSuite) TestRegisteredPackageRevisionLabels() {
 		basens.ObjectMeta.Annotations = make(map[string]string)
 	}
 	basens.ObjectMeta.Annotations[annoKey] = annoVal
-	t.UpdateF(t.GetContext(), basens)
+	t.UpdateF(basens)
 
-	t.ValidateLabelsAndAnnos(t.GetContext(), basens.Name,
+	t.ValidateLabelsAndAnnos(basens.Name,
 		map[string]string{
 			labelKey: labelVal,
 		},
@@ -2557,7 +2557,7 @@ func (t *PorchSuite) TestPackageRevisionGCWithOwner() {
 		cmName      = "foo"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	// Create a new package (via init)
 	pr := &porchapi.PackageRevision{
@@ -2574,7 +2574,7 @@ func (t *PorchSuite) TestPackageRevisionGCWithOwner() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -2597,11 +2597,10 @@ func (t *PorchSuite) TestPackageRevisionGCWithOwner() {
 			"foo": "bar",
 		},
 	}
-	t.CreateF(t.GetContext(), cm)
+	t.CreateF(cm)
 
-	t.DeleteF(t.GetContext(), pr)
+	t.DeleteF(pr)
 	t.WaitUntilObjectDeleted(
-		t.GetContext(),
 		packageRevisionGVK,
 		types.NamespacedName{
 			Name:      pr.Name,
@@ -2610,7 +2609,6 @@ func (t *PorchSuite) TestPackageRevisionGCWithOwner() {
 		10*time.Second,
 	)
 	t.WaitUntilObjectDeleted(
-		t.GetContext(),
 		configMapGVK,
 		types.NamespacedName{
 			Name:      cm.Name,
@@ -2628,7 +2626,7 @@ func (t *PorchSuite) TestPackageRevisionGCAsOwner() {
 		cmName      = "foo"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -2643,7 +2641,7 @@ func (t *PorchSuite) TestPackageRevisionGCAsOwner() {
 			"foo": "bar",
 		},
 	}
-	t.CreateF(t.GetContext(), cm)
+	t.CreateF(cm)
 
 	pr := &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
@@ -2667,11 +2665,10 @@ func (t *PorchSuite) TestPackageRevisionGCAsOwner() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
-	t.DeleteF(t.GetContext(), cm)
+	t.DeleteF(cm)
 	t.WaitUntilObjectDeleted(
-		t.GetContext(),
 		configMapGVK,
 		types.NamespacedName{
 			Name:      cm.Name,
@@ -2680,7 +2677,6 @@ func (t *PorchSuite) TestPackageRevisionGCAsOwner() {
 		10*time.Second,
 	)
 	t.WaitUntilObjectDeleted(
-		t.GetContext(),
 		packageRevisionGVK,
 		types.NamespacedName{
 			Name:      pr.Name,
@@ -2698,7 +2694,7 @@ func (t *PorchSuite) TestPackageRevisionOwnerReferences() {
 		cmName      = "foo"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -2713,7 +2709,7 @@ func (t *PorchSuite) TestPackageRevisionOwnerReferences() {
 			"foo": "bar",
 		},
 	}
-	t.CreateF(t.GetContext(), cm)
+	t.CreateF(cm)
 
 	pr := &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
@@ -2729,8 +2725,8 @@ func (t *PorchSuite) TestPackageRevisionOwnerReferences() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
-	t.ValidateOwnerReferences(t.GetContext(), pr.Name, []metav1.OwnerReference{})
+	t.CreateF(pr)
+	t.ValidateOwnerReferences(pr.Name, []metav1.OwnerReference{})
 
 	ownerRef := metav1.OwnerReference{
 		APIVersion: "v1",
@@ -2739,12 +2735,12 @@ func (t *PorchSuite) TestPackageRevisionOwnerReferences() {
 		UID:        cm.UID,
 	}
 	pr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
-	t.UpdateF(t.GetContext(), pr)
-	t.ValidateOwnerReferences(t.GetContext(), pr.Name, []metav1.OwnerReference{ownerRef})
+	t.UpdateF(pr)
+	t.ValidateOwnerReferences(pr.Name, []metav1.OwnerReference{ownerRef})
 
 	pr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{}
-	t.UpdateF(t.GetContext(), pr)
-	t.ValidateOwnerReferences(t.GetContext(), pr.Name, []metav1.OwnerReference{})
+	t.UpdateF(pr)
+	t.ValidateOwnerReferences(pr.Name, []metav1.OwnerReference{})
 }
 
 func (t *PorchSuite) TestPackageRevisionFinalizers() {
@@ -2754,7 +2750,7 @@ func (t *PorchSuite) TestPackageRevisionFinalizers() {
 		description = "empty-package description"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repository)
+	t.RegisterMainGitRepositoryF(repository)
 
 	pr := &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
@@ -2770,19 +2766,19 @@ func (t *PorchSuite) TestPackageRevisionFinalizers() {
 			RepositoryName: repository,
 		},
 	}
-	t.CreateF(t.GetContext(), pr)
-	t.ValidateFinalizers(t.GetContext(), pr.Name, []string{})
+	t.CreateF(pr)
+	t.ValidateFinalizers(pr.Name, []string{})
 
 	pr.Finalizers = append(pr.Finalizers, "foo-finalizer")
-	t.UpdateF(t.GetContext(), pr)
-	t.ValidateFinalizers(t.GetContext(), pr.Name, []string{"foo-finalizer"})
+	t.UpdateF(pr)
+	t.ValidateFinalizers(pr.Name, []string{"foo-finalizer"})
 
-	t.DeleteF(t.GetContext(), pr)
-	t.ValidateFinalizers(t.GetContext(), pr.Name, []string{"foo-finalizer"})
+	t.DeleteF(pr)
+	t.ValidateFinalizers(pr.Name, []string{"foo-finalizer"})
 
 	pr.Finalizers = []string{}
-	t.UpdateF(t.GetContext(), pr)
-	t.WaitUntilObjectDeleted(t.GetContext(), packageRevisionGVK, types.NamespacedName{
+	t.UpdateF(pr)
+	t.WaitUntilObjectDeleted(packageRevisionGVK, types.NamespacedName{
 		Name:      pr.Name,
 		Namespace: pr.Namespace,
 	}, 10*time.Second)
@@ -2792,9 +2788,9 @@ func (t *PorchSuite) TestPackageRevisionInMultipleNamespaces() {
 
 	registerRepoAndTestRevisions := func(repoName string, ns string, oldPRs []porchapi.PackageRevision) []porchapi.PackageRevision {
 
-		t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, repoName, "", InNamespace(ns))
+		t.RegisterGitRepositoryF(testBlueprintsRepo, repoName, "", InNamespace(ns))
 		prList := porchapi.PackageRevisionList{}
-		t.ListF(t.GetContext(), &prList, client.InNamespace(ns))
+		t.ListF(&prList, client.InNamespace(ns))
 		newPRs := prList.Items
 		if len(newPRs) == 0 {
 			t.Errorf("no PackageRevisions found in repo: %s", repoName)
@@ -2842,9 +2838,9 @@ func (t *PorchSuite) TestPackageRevisionInMultipleNamespaces() {
 			Name: t.Namespace + "-2",
 		},
 	}
-	t.CreateF(t.GetContext(), ns2)
+	t.CreateF(ns2)
 	t.Cleanup(func() {
-		t.DeleteE(t.GetContext(), ns2)
+		t.DeleteE(ns2)
 	})
 
 	prs1 := registerRepoAndTestRevisions("test-blueprints", t.Namespace, nil)
@@ -2864,11 +2860,11 @@ func (t *PorchSuite) TestPackageRevisionInMultipleNamespaces() {
 
 func (t *PorchSuite) TestUniquenessOfUIDs() {
 
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-2-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-2-blueprints", "")
 
 	prList := porchapi.PackageRevisionList{}
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace))
+	t.ListE(&prList, client.InNamespace(t.Namespace))
 
 	uids := make(map[types.UID]*porchapi.PackageRevision)
 	for _, pr := range prList.Items {
@@ -2882,13 +2878,13 @@ func (t *PorchSuite) TestUniquenessOfUIDs() {
 
 func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 	repo := "test-blueprints"
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, repo, "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, repo, "")
 
 	prList := porchapi.PackageRevisionList{}
 
 	pkgName := "basens"
 	pkgSelector := client.MatchingFields(fields.Set{"spec.packageName": pkgName})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), pkgSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), pkgSelector)
 	if len(prList.Items) == 0 {
 		t.Errorf("Expected at least one PackageRevision with packageName=%q, but got none", pkgName)
 	}
@@ -2900,7 +2896,7 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 
 	revName := "v1"
 	revSelector := client.MatchingFields(fields.Set{"spec.revision": revName})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), revSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), revSelector)
 	if len(prList.Items) == 0 {
 		t.Errorf("Expected at least one PackageRevision with revision=%q, but got none", revName)
 	}
@@ -2912,7 +2908,7 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 
 	wsName := "v1"
 	wsSelector := client.MatchingFields(fields.Set{"spec.workspaceName": wsName})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), wsSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), wsSelector)
 	if len(prList.Items) == 0 {
 		t.Errorf("Expected at least one PackageRevision with workspaceName=%q, but got none", wsName)
 	}
@@ -2923,7 +2919,7 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 	}
 
 	publishedSelector := client.MatchingFields(fields.Set{"spec.lifecycle": string(porchapi.PackageRevisionLifecyclePublished)})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), publishedSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), publishedSelector)
 	if len(prList.Items) == 0 {
 		t.Errorf("Expected at least one PackageRevision with lifecycle=%q, but got none", porchapi.PackageRevisionLifecyclePublished)
 	}
@@ -2934,7 +2930,7 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 	}
 
 	draftSelector := client.MatchingFields(fields.Set{"spec.lifecycle": string(porchapi.PackageRevisionLifecycleDraft)})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), draftSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), draftSelector)
 	// TODO: add draft packages to the test repo
 	// if len(prList.Items) == 0 {
 	// 	t.Errorf("Expected at least one PackageRevision with lifecycle=%q, but got none", porchapi.PackageRevisionLifecycleDraft)
@@ -2947,7 +2943,7 @@ func (t *PorchSuite) TestPackageRevisionFieldSelectors() {
 
 	// test combined selectors
 	combinedSelector := client.MatchingFields(fields.Set{"spec.revision": revName, "spec.packageName": pkgName})
-	t.ListE(t.GetContext(), &prList, client.InNamespace(t.Namespace), combinedSelector)
+	t.ListE(&prList, client.InNamespace(t.Namespace), combinedSelector)
 	if len(prList.Items) == 0 {
 		t.Errorf("Expected at least one PackageRevision with packageName=%q and revision=%q, but got none", pkgName, revName)
 	}
@@ -2966,61 +2962,61 @@ func (t *PorchSuite) TestLatestVersionOnDelete() {
 		packageName    = "test-latest-on-delete-package"
 	)
 
-	t.RegisterMainGitRepositoryF(t.GetContext(), repositoryName)
+	t.RegisterMainGitRepositoryF(repositoryName)
 
-	pr1 := t.CreatePackageDraftF(t.GetContext(), repositoryName, packageName, workspacev1)
+	pr1 := t.CreatePackageDraftF(repositoryName, packageName, workspacev1)
 
 	pr1.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), pr1)
+	t.UpdateF(pr1)
 
 	pr1.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), pr1, metav1.UpdateOptions{})
+	t.UpdateApprovalF(pr1, metav1.UpdateOptions{})
 
 	//After approval of the first revision, the package should be labeled as latest
-	t.MustHaveLabels(t.GetContext(), pr1.Name, map[string]string{
+	t.MustHaveLabels(pr1.Name, map[string]string{
 		porchapi.LatestPackageRevisionKey: porchapi.LatestPackageRevisionValue,
 	})
 
-	pr2 := t.CreatePackageDraftF(t.GetContext(), repositoryName, packageName, workspacev2)
+	pr2 := t.CreatePackageDraftF(repositoryName, packageName, workspacev2)
 
 	pr2.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
-	t.UpdateF(t.GetContext(), pr2)
+	t.UpdateF(pr2)
 
 	pr2.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
-	t.UpdateApprovalF(t.GetContext(), pr2, metav1.UpdateOptions{})
+	t.UpdateApprovalF(pr2, metav1.UpdateOptions{})
 
 	//After approval of the second revision, the latest label should migrate to the
 	//v2 packageRevision
-	t.MustNotHaveLabels(t.GetContext(), pr1.Name, []string{
+	t.MustNotHaveLabels(pr1.Name, []string{
 		porchapi.LatestPackageRevisionKey,
 	})
 
-	t.MustHaveLabels(t.GetContext(), pr2.Name, map[string]string{
+	t.MustHaveLabels(pr2.Name, map[string]string{
 		porchapi.LatestPackageRevisionKey: porchapi.LatestPackageRevisionValue,
 	})
 
-	t.GetF(t.GetContext(), client.ObjectKeyFromObject(pr2), pr2)
+	t.GetF(client.ObjectKeyFromObject(pr2), pr2)
 
 	pr2.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateF(t.GetContext(), pr2)
+	t.UpdateF(pr2)
 
-	t.DeleteF(t.GetContext(), pr2)
+	t.DeleteF(pr2)
 	//After deletion of the v2 pacakgeRevision,
 	//the label should migrate back to the v2 packageRevision
-	t.MustHaveLabels(t.GetContext(), pr1.Name, map[string]string{
+	t.MustHaveLabels(pr1.Name, map[string]string{
 		porchapi.LatestPackageRevisionKey: porchapi.LatestPackageRevisionValue,
 	})
 
-	t.GetF(t.GetContext(), client.ObjectKeyFromObject(pr1), pr1)
+	t.GetF(client.ObjectKeyFromObject(pr1), pr1)
 
 	pr1.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
-	t.UpdateF(t.GetContext(), pr1)
+	t.UpdateF(pr1)
 
-	t.DeleteF(t.GetContext(), pr1)
+	t.DeleteF(pr1)
 	//After the removal of all versioned packageRevisions, the main branch
 	//packageRevision should still not get the latest label.
-	mainPr := t.GetPackageRevision(t.GetContext(), repositoryName, packageName, "main")
-	t.MustNotHaveLabels(t.GetContext(), mainPr.Name, []string{
+	mainPr := t.GetPackageRevision(repositoryName, packageName, "main")
+	t.MustNotHaveLabels(mainPr.Name, []string{
 		porchapi.LatestPackageRevisionKey,
 	})
 }
@@ -3032,7 +3028,7 @@ func (t *PorchSuite) TestRepositoryModify() {
 	)
 
 	// Create initial repository
-	t.CreateF(t.GetContext(), &configapi.Repository{
+	t.CreateF(&configapi.Repository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       configapi.TypeRepository.Kind,
 			APIVersion: configapi.TypeRepository.APIVersion(),
@@ -3052,7 +3048,7 @@ func (t *PorchSuite) TestRepositoryModify() {
 
 	// Clean up after test
 	t.Cleanup(func() {
-		t.DeleteL(t.GetContext(), &configapi.Repository{
+		t.DeleteL(&configapi.Repository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      repositoryName,
 				Namespace: t.Namespace,
@@ -3062,14 +3058,14 @@ func (t *PorchSuite) TestRepositoryModify() {
 
 	// Get the repository to modify
 	var repository configapi.Repository
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      repositoryName,
 	}, &repository)
 
 	// Modify the repository
 	repository.Spec.Description = newDescription
-	t.UpdateF(t.GetContext(), &repository)
+	t.UpdateF(&repository)
 
 	// Wait and verify the repository condition
 	giveUp := time.Now().Add(60 * time.Second)
@@ -3082,7 +3078,7 @@ func (t *PorchSuite) TestRepositoryModify() {
 		time.Sleep(5 * time.Second)
 
 		var updatedRepo configapi.Repository
-		t.GetF(t.GetContext(), client.ObjectKey{
+		t.GetF(client.ObjectKey{
 			Namespace: t.Namespace,
 			Name:      repositoryName,
 		}, &updatedRepo)

--- a/test/e2e/suite_logs.go
+++ b/test/e2e/suite_logs.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"bytes"
-	"context"
 	"io"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (t *TestSuite) DumpLogsForDeploymentE(ctx context.Context, deploymentKey client.ObjectKey) {
+func (t *TestSuite) DumpLogsForDeploymentE(deploymentKey client.ObjectKey) {
 	t.T().Helper()
-	t.dumpLogsForDeployment(ctx, deploymentKey, t.Errorf)
+	t.dumpLogsForDeployment(deploymentKey, t.Errorf)
 }
 
 func (t *TestSuite) hasOwner(child, parent runtime.Object) bool {
@@ -54,14 +53,14 @@ func (t *TestSuite) hasOwner(child, parent runtime.Object) bool {
 	return false
 }
 
-func (t *TestSuite) dumpLogsForDeployment(ctx context.Context, deploymentKey client.ObjectKey, eh ErrorHandler) {
+func (t *TestSuite) dumpLogsForDeployment(deploymentKey client.ObjectKey, eh ErrorHandler) {
 	t.T().Helper()
-	deployment, err := t.KubeClient.AppsV1().Deployments(deploymentKey.Namespace).Get(ctx, deploymentKey.Name, metav1.GetOptions{})
+	deployment, err := t.KubeClient.AppsV1().Deployments(deploymentKey.Namespace).Get(t.GetContext(), deploymentKey.Name, metav1.GetOptions{})
 	if err != nil {
 		eh("failed to get deployemnt %v: %v", deploymentKey, err)
 	}
 
-	replicaSets, err := t.KubeClient.AppsV1().ReplicaSets(deployment.Namespace).List(ctx, metav1.ListOptions{})
+	replicaSets, err := t.KubeClient.AppsV1().ReplicaSets(deployment.Namespace).List(t.GetContext(), metav1.ListOptions{})
 	if err != nil {
 		eh("failed to list replicasets: %v", err)
 	}
@@ -71,13 +70,13 @@ func (t *TestSuite) dumpLogsForDeployment(ctx context.Context, deploymentKey cli
 		if !t.hasOwner(replicaSet, deployment) {
 			continue
 		}
-		t.dumpLogsForReplicaSet(ctx, replicaSet, eh)
+		t.dumpLogsForReplicaSet(replicaSet, eh)
 	}
 }
 
-func (t *TestSuite) dumpLogsForReplicaSet(ctx context.Context, replicaSet *appsv1.ReplicaSet, eh ErrorHandler) {
+func (t *TestSuite) dumpLogsForReplicaSet(replicaSet *appsv1.ReplicaSet, eh ErrorHandler) {
 	t.T().Helper()
-	pods, err := t.KubeClient.CoreV1().Pods(replicaSet.Namespace).List(ctx, metav1.ListOptions{})
+	pods, err := t.KubeClient.CoreV1().Pods(replicaSet.Namespace).List(t.GetContext(), metav1.ListOptions{})
 	if err != nil {
 		eh("failed to list pods: %v", err)
 	}
@@ -87,25 +86,25 @@ func (t *TestSuite) dumpLogsForReplicaSet(ctx context.Context, replicaSet *appsv
 		if !t.hasOwner(pod, replicaSet) {
 			continue
 		}
-		t.dumpLogsForPod(ctx, pod, eh)
+		t.dumpLogsForPod(pod, eh)
 	}
 }
 
-func (t *TestSuite) dumpLogsForPod(ctx context.Context, pod *corev1.Pod, eh ErrorHandler) {
+func (t *TestSuite) dumpLogsForPod(pod *corev1.Pod, eh ErrorHandler) {
 	t.T().Helper()
 	for _, container := range pod.Spec.Containers {
 		podKey := client.ObjectKey{
 			Namespace: pod.Namespace,
 			Name:      pod.Name,
 		}
-		t.dumpLogsForPodContainer(ctx, podKey, container.Name, eh)
+		t.dumpLogsForPodContainer(podKey, container.Name, eh)
 	}
 }
 
-func (t *TestSuite) dumpLogsForPodContainer(ctx context.Context, podKey client.ObjectKey, containerName string, eh ErrorHandler) {
+func (t *TestSuite) dumpLogsForPodContainer(podKey client.ObjectKey, containerName string, eh ErrorHandler) {
 	t.T().Helper()
 	req := t.KubeClient.CoreV1().Pods(podKey.Namespace).GetLogs(podKey.Name, &corev1.PodLogOptions{Container: containerName})
-	podLogs, err := req.Stream(ctx)
+	podLogs, err := req.Stream(t.GetContext())
 	if err != nil {
 		eh("failed to open pod logs %v %s: %v", podKey, containerName, err)
 	}

--- a/test/e2e/suite_logs.go
+++ b/test/e2e/suite_logs.go
@@ -28,12 +28,12 @@ import (
 )
 
 func (t *TestSuite) DumpLogsForDeploymentE(ctx context.Context, deploymentKey client.ObjectKey) {
-	t.Helper()
+	t.T().Helper()
 	t.dumpLogsForDeployment(ctx, deploymentKey, t.Errorf)
 }
 
 func (t *TestSuite) hasOwner(child, parent runtime.Object) bool {
-	t.Helper()
+	t.T().Helper()
 	childAccessor, err := meta.Accessor(child)
 	if err != nil {
 		t.Fatalf("could not get accessor for %T: %v", child, err)
@@ -55,7 +55,7 @@ func (t *TestSuite) hasOwner(child, parent runtime.Object) bool {
 }
 
 func (t *TestSuite) dumpLogsForDeployment(ctx context.Context, deploymentKey client.ObjectKey, eh ErrorHandler) {
-	t.Helper()
+	t.T().Helper()
 	deployment, err := t.KubeClient.AppsV1().Deployments(deploymentKey.Namespace).Get(ctx, deploymentKey.Name, metav1.GetOptions{})
 	if err != nil {
 		eh("failed to get deployemnt %v: %v", deploymentKey, err)
@@ -76,7 +76,7 @@ func (t *TestSuite) dumpLogsForDeployment(ctx context.Context, deploymentKey cli
 }
 
 func (t *TestSuite) dumpLogsForReplicaSet(ctx context.Context, replicaSet *appsv1.ReplicaSet, eh ErrorHandler) {
-	t.Helper()
+	t.T().Helper()
 	pods, err := t.KubeClient.CoreV1().Pods(replicaSet.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		eh("failed to list pods: %v", err)
@@ -92,7 +92,7 @@ func (t *TestSuite) dumpLogsForReplicaSet(ctx context.Context, replicaSet *appsv
 }
 
 func (t *TestSuite) dumpLogsForPod(ctx context.Context, pod *corev1.Pod, eh ErrorHandler) {
-	t.Helper()
+	t.T().Helper()
 	for _, container := range pod.Spec.Containers {
 		podKey := client.ObjectKey{
 			Namespace: pod.Namespace,
@@ -103,7 +103,7 @@ func (t *TestSuite) dumpLogsForPod(ctx context.Context, pod *corev1.Pod, eh Erro
 }
 
 func (t *TestSuite) dumpLogsForPodContainer(ctx context.Context, podKey client.ObjectKey, containerName string, eh ErrorHandler) {
-	t.Helper()
+	t.T().Helper()
 	req := t.KubeClient.CoreV1().Pods(podKey.Namespace).GetLogs(podKey.Name, &corev1.PodLogOptions{Container: containerName})
 	podLogs, err := req.Stream(ctx)
 	if err != nil {

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -52,23 +52,23 @@ func (t *TestSuiteWithGit) GitConfig(name string) GitConfig {
 	return config
 }
 
-func (t *TestSuiteWithGit) RegisterMainGitRepositoryF(ctx context.Context, name string, opts ...RepositoryOption) {
+func (t *TestSuiteWithGit) RegisterMainGitRepositoryF(name string, opts ...RepositoryOption) {
 	t.T().Helper()
 	config := t.GitConfig(name)
-	t.registerGitRepositoryFromConfigF(ctx, name, config, opts...)
+	t.registerGitRepositoryFromConfigF(name, config, opts...)
 }
 
-func (t *TestSuiteWithGit) RegisterGitRepositoryWithDirectoryF(ctx context.Context, name string, directory string, opts ...RepositoryOption) {
+func (t *TestSuiteWithGit) RegisterGitRepositoryWithDirectoryF(name string, directory string, opts ...RepositoryOption) {
 	t.T().Helper()
 	config := t.GitConfig(name)
 	config.Directory = directory
-	t.registerGitRepositoryFromConfigF(ctx, name, config, opts...)
+	t.registerGitRepositoryFromConfigF(name, config, opts...)
 }
 
-func (t *TestSuite) ValidateFinalizers(ctx context.Context, name string, finalizers []string) {
+func (t *TestSuite) ValidateFinalizers(name string, finalizers []string) {
 	t.T().Helper()
 	var pr porchapi.PackageRevision
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      name,
 	}, &pr)
@@ -91,10 +91,10 @@ func (t *TestSuite) ValidateFinalizers(ctx context.Context, name string, finaliz
 	}
 }
 
-func (t *TestSuite) ValidateOwnerReferences(ctx context.Context, name string, ownerRefs []metav1.OwnerReference) {
+func (t *TestSuite) ValidateOwnerReferences(name string, ownerRefs []metav1.OwnerReference) {
 	t.T().Helper()
 	var pr porchapi.PackageRevision
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      name,
 	}, &pr)
@@ -117,10 +117,10 @@ func (t *TestSuite) ValidateOwnerReferences(ctx context.Context, name string, ow
 	}
 }
 
-func (t *TestSuite) ValidateLabelsAndAnnos(ctx context.Context, name string, labels, annos map[string]string) {
+func (t *TestSuite) ValidateLabelsAndAnnos(name string, labels, annos map[string]string) {
 	t.T().Helper()
 	var pr porchapi.PackageRevision
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      name,
 	}, &pr)
@@ -142,10 +142,10 @@ func (t *TestSuite) ValidateLabelsAndAnnos(ctx context.Context, name string, lab
 	}
 }
 
-func (t *TestSuite) MustHaveLabels(ctx context.Context, name string, labels map[string]string) {
+func (t *TestSuite) MustHaveLabels(name string, labels map[string]string) {
 	t.T().Helper()
 	var pr porchapi.PackageRevision
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      name,
 	}, &pr)
@@ -161,10 +161,10 @@ func (t *TestSuite) MustHaveLabels(ctx context.Context, name string, labels map[
 	}
 }
 
-func (t *TestSuite) MustNotHaveLabels(ctx context.Context, name string, labels []string) {
+func (t *TestSuite) MustNotHaveLabels(name string, labels []string) {
 	t.T().Helper()
 	var pr porchapi.PackageRevision
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      name,
 	}, &pr)
@@ -177,24 +177,24 @@ func (t *TestSuite) MustNotHaveLabels(ctx context.Context, name string, labels [
 	}
 }
 
-func (t *TestSuite) RegisterGitRepositoryF(ctx context.Context, repo, name, directory string, opts ...RepositoryOption) {
+func (t *TestSuite) RegisterGitRepositoryF(repo, name, directory string, opts ...RepositoryOption) {
 	t.T().Helper()
 	config := GitConfig{
 		Repo:      repo,
 		Branch:    "main",
 		Directory: directory,
 	}
-	t.registerGitRepositoryFromConfigF(ctx, name, config, opts...)
+	t.registerGitRepositoryFromConfigF(name, config, opts...)
 }
 
-func (t *TestSuite) registerGitRepositoryFromConfigF(ctx context.Context, name string, config GitConfig, opts ...RepositoryOption) {
+func (t *TestSuite) registerGitRepositoryFromConfigF(name string, config GitConfig, opts ...RepositoryOption) {
 	t.T().Helper()
 	var secret string
 	// Create auth secret if necessary
 	if config.Username != "" || config.Password != "" {
 		secret = fmt.Sprintf("%s-auth", name)
 		immutable := true
-		t.CreateF(ctx, &corev1.Secret{
+		t.CreateF(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secret,
 				Namespace: t.Namespace,
@@ -208,7 +208,7 @@ func (t *TestSuite) registerGitRepositoryFromConfigF(ctx context.Context, name s
 		})
 		t.Cleanup(func() {
 			t.T().Helper()
-			t.DeleteE(ctx, &corev1.Secret{
+			t.DeleteE(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secret,
 					Namespace: t.Namespace,
@@ -246,17 +246,17 @@ func (t *TestSuite) registerGitRepositoryFromConfigF(ctx context.Context, name s
 	}
 
 	// Register repository
-	t.CreateF(ctx, repository)
+	t.CreateF(repository)
 
 	t.Cleanup(func() {
-		t.DeleteE(ctx, repository)
-		t.WaitUntilRepositoryDeleted(ctx, name, t.Namespace)
-		t.WaitUntilAllPackagesDeleted(ctx, name, t.Namespace)
+		t.DeleteE(repository)
+		t.WaitUntilRepositoryDeleted(name, t.Namespace)
+		t.WaitUntilAllPackagesDeleted(name, t.Namespace)
 	})
 
 	// Make sure the repository is ready before we test to (hopefully)
 	// avoid flakiness.
-	t.WaitUntilRepositoryReady(ctx, repository.Name, repository.Namespace)
+	t.WaitUntilRepositoryReady(repository.Name, repository.Namespace)
 	t.Logf("Repository %s/%s is ready", repository.Namespace, repository.Name)
 }
 
@@ -281,7 +281,7 @@ func InNamespace(ns string) RepositoryOption {
 }
 
 // Creates an empty package draft by initializing an empty package
-func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, packageName, workspace string) *porchapi.PackageRevision {
+func (t *TestSuite) CreatePackageDraftF(repository, packageName, workspace string) *porchapi.PackageRevision {
 	t.T().Helper()
 	pr := t.CreatePackageSkeleton(repository, packageName, workspace)
 	pr.Spec.Tasks = []porchapi.Task{
@@ -290,7 +290,7 @@ func (t *TestSuite) CreatePackageDraftF(ctx context.Context, repository, package
 			Init: &porchapi.PackageInitTaskSpec{},
 		},
 	}
-	t.CreateF(ctx, pr)
+	t.CreateF(pr)
 	return pr
 }
 
@@ -313,10 +313,10 @@ func (t *TestSuite) CreatePackageSkeleton(repoName, packageName, workspace strin
 	}
 }
 
-func (t *TestSuite) MustExist(ctx context.Context, key client.ObjectKey, obj client.Object) {
+func (t *TestSuite) MustExist(key client.ObjectKey, obj client.Object) {
 	t.T().Helper()
 	t.Logf("Checking existence of %q...", key)
-	t.GetF(ctx, key, obj)
+	t.GetF(key, obj)
 	if got, want := obj.GetName(), key.Name; got != want {
 		t.Errorf("%T.Name: got %q, want %q", obj, got, want)
 	}
@@ -325,9 +325,9 @@ func (t *TestSuite) MustExist(ctx context.Context, key client.ObjectKey, obj cli
 	}
 }
 
-func (t *TestSuite) MustNotExist(ctx context.Context, obj client.Object) {
+func (t *TestSuite) MustNotExist(obj client.Object) {
 	t.T().Helper()
-	switch err := t.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); {
+	switch err := t.Client.Get(t.GetContext(), client.ObjectKeyFromObject(obj), obj); {
 	case err == nil:
 		t.Errorf("No error returned getting a deleted package; expected error")
 	case !apierrors.IsNotFound(err):
@@ -340,14 +340,14 @@ func (t *TestSuite) MustNotExist(ctx context.Context, obj client.Object) {
 // It also queries for Functions and PackageRevisions, to ensure these are also
 // ready - this is an artifact of the way we've implemented the aggregated apiserver,
 // where the first fetch can sometimes be synchronous.
-func (t *TestSuite) WaitUntilRepositoryReady(ctx context.Context, name, namespace string) {
+func (t *TestSuite) WaitUntilRepositoryReady(name, namespace string) {
 	t.T().Helper()
 	nn := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
 	}
 	var innerErr error
-	err := wait.PollUntilContextTimeout(ctx, time.Second, 120*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 120*time.Second, true, func(ctx context.Context) (bool, error) {
 		var repo configapi.Repository
 		if err := t.Client.Get(ctx, nn, &repo); err != nil {
 			innerErr = err
@@ -370,7 +370,7 @@ func (t *TestSuite) WaitUntilRepositoryReady(ctx context.Context, name, namespac
 	}
 
 	// While we're using an aggregated apiserver, make sure we can query the generated objects
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		var revisions porchapi.PackageRevisionList
 		if err := t.Client.List(ctx, &revisions, client.InNamespace(nn.Namespace)); err != nil {
 			innerErr = err
@@ -382,9 +382,9 @@ func (t *TestSuite) WaitUntilRepositoryReady(ctx context.Context, name, namespac
 	}
 }
 
-func (t *TestSuite) WaitUntilRepositoryDeleted(ctx context.Context, name, namespace string) {
+func (t *TestSuite) WaitUntilRepositoryDeleted(name, namespace string) {
 	t.T().Helper()
-	err := wait.PollUntilContextTimeout(ctx, time.Second, 20*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 20*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		var repo configapi.Repository
 		nn := types.NamespacedName{
 			Name:      name,
@@ -403,9 +403,9 @@ func (t *TestSuite) WaitUntilRepositoryDeleted(ctx context.Context, name, namesp
 	}
 }
 
-func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName string, namespace string) {
+func (t *TestSuite) WaitUntilAllPackagesDeleted(repoName string, namespace string) {
 	t.T().Helper()
-	err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		t.T().Helper()
 		var pkgRevList porchapi.PackageRevisionList
 		if err := t.Client.List(ctx, &pkgRevList); err != nil {
@@ -436,10 +436,10 @@ func (t *TestSuite) WaitUntilAllPackagesDeleted(ctx context.Context, repoName st
 	}
 }
 
-func (t *TestSuite) WaitUntilObjectDeleted(ctx context.Context, gvk schema.GroupVersionKind, namespacedName types.NamespacedName, d time.Duration) {
+func (t *TestSuite) WaitUntilObjectDeleted(gvk schema.GroupVersionKind, namespacedName types.NamespacedName, d time.Duration) {
 	t.T().Helper()
 	var innerErr error
-	err := wait.PollUntilContextTimeout(ctx, time.Second, d, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, d, true, func(ctx context.Context) (bool, error) {
 		var u unstructured.Unstructured
 		u.SetGroupVersionKind(gvk)
 		if err := t.Client.Get(ctx, namespacedName, &u); err != nil {
@@ -457,14 +457,13 @@ func (t *TestSuite) WaitUntilObjectDeleted(ctx context.Context, gvk schema.Group
 }
 
 func (t *TestSuite) WaitUntilPackageRevisionFulfillingConditionExists(
-	ctx context.Context,
 	timeout time.Duration,
 	condition func(porchapi.PackageRevision) bool,
 ) (*porchapi.PackageRevision, error) {
 
 	t.T().Helper()
 	var foundPkgRev *porchapi.PackageRevision
-	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
 		var pkgRevList porchapi.PackageRevisionList
 		if err := t.Client.List(ctx, &pkgRevList); err != nil {
 			t.Logf("error listing packages: %v", err)
@@ -481,11 +480,11 @@ func (t *TestSuite) WaitUntilPackageRevisionFulfillingConditionExists(
 	return foundPkgRev, err
 }
 
-func (t *TestSuite) WaitUntilPackageRevisionExists(ctx context.Context, repository string, pkgName string, revision string) *porchapi.PackageRevision {
+func (t *TestSuite) WaitUntilPackageRevisionExists(repository string, pkgName string, revision string) *porchapi.PackageRevision {
 	t.T().Helper()
 	t.Logf("Waiting for package revision (%v/%v/%v) to exist", repository, pkgName, revision)
 	timeout := 120 * time.Second
-	foundPkgRev, err := t.WaitUntilPackageRevisionFulfillingConditionExists(ctx, timeout, func(pkgRev porchapi.PackageRevision) bool {
+	foundPkgRev, err := t.WaitUntilPackageRevisionFulfillingConditionExists(timeout, func(pkgRev porchapi.PackageRevision) bool {
 		return pkgRev.Spec.RepositoryName == repository &&
 			pkgRev.Spec.PackageName == pkgName &&
 			pkgRev.Spec.Revision == revision
@@ -496,11 +495,11 @@ func (t *TestSuite) WaitUntilPackageRevisionExists(ctx context.Context, reposito
 	return foundPkgRev
 }
 
-func (t *TestSuite) WaitUntilDraftPackageRevisionExists(ctx context.Context, repository string, pkgName string) *porchapi.PackageRevision {
+func (t *TestSuite) WaitUntilDraftPackageRevisionExists(repository string, pkgName string) *porchapi.PackageRevision {
 	t.T().Helper()
 	t.Logf("Waiting for a draft revision for package %v/%v to exist", repository, pkgName)
 	timeout := 120 * time.Second
-	foundPkgRev, err := t.WaitUntilPackageRevisionFulfillingConditionExists(ctx, timeout, func(pkgRev porchapi.PackageRevision) bool {
+	foundPkgRev, err := t.WaitUntilPackageRevisionFulfillingConditionExists(timeout, func(pkgRev porchapi.PackageRevision) bool {
 		return pkgRev.Spec.RepositoryName == repository &&
 			pkgRev.Spec.PackageName == pkgName &&
 			pkgRev.Spec.Lifecycle == porchapi.PackageRevisionLifecycleDraft
@@ -540,7 +539,7 @@ func (t *TestSuite) WaitUntilPackageRevisionResourcesExists(
 	return foundPrr
 }
 
-func (t *TestSuite) GetPackageRevision(ctx context.Context, repository string, pkgName string, revision string) *porchapi.PackageRevision {
+func (t *TestSuite) GetPackageRevision(repository string, pkgName string, revision string) *porchapi.PackageRevision {
 	t.T().Helper()
 	var prList porchapi.PackageRevisionList
 	selector := client.MatchingFields(fields.Set{
@@ -548,7 +547,7 @@ func (t *TestSuite) GetPackageRevision(ctx context.Context, repository string, p
 		"spec.packageName": pkgName,
 		"spec.revision":    revision,
 	})
-	t.ListF(ctx, &prList, selector, client.InNamespace(t.Namespace))
+	t.ListF(&prList, selector, client.InNamespace(t.Namespace))
 
 	if len(prList.Items) == 0 {
 		t.Fatalf("PackageRevision object wasn't found for package revision %v/%v/%v", repository, pkgName, revision)
@@ -568,7 +567,7 @@ func (t *TestSuite) GetContentsOfPackageRevision(ctx context.Context, repository
 		"spec.packageName": pkgName,
 		"spec.revision":    revision,
 	})
-	t.ListF(ctx, &prrList, selector, client.InNamespace(t.Namespace))
+	t.ListF(&prrList, selector, client.InNamespace(t.Namespace))
 
 	if len(prrList.Items) == 0 {
 		t.Fatalf("PackageRevisionResources object wasn't found for package revision %v/%v/%v", repository, pkgName, revision)

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -26,16 +26,16 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 		gitRepository = "package-update"
 	)
 
-	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
+	t.ListE(&list, client.InNamespace(t.Namespace))
 
 	basensV2 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
 	t.Logf("basensV2 = %v", basensV2)
 
 	// Register the repository as 'downstream'
-	t.RegisterMainGitRepositoryF(t.GetContext(), gitRepository)
+	t.RegisterMainGitRepositoryF(gitRepository)
 
 	// Create PackageRevision from upstream repo
 	pr := &porchapi.PackageRevision{
@@ -67,9 +67,9 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 		},
 	}
 
-	t.CreateF(t.GetContext(), pr)
+	t.CreateF(pr)
 
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, pr)
@@ -85,15 +85,15 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 		},
 	}
 
-	t.UpdateF(t.GetContext(), pr)
+	t.UpdateF(pr)
 
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, pr)
 
 	var revisionResources porchapi.PackageRevisionResources
-	t.GetF(t.GetContext(), client.ObjectKey{
+	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &revisionResources)

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -15,29 +15,27 @@
 package e2e
 
 import (
-	"context"
-
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
+func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 	const (
 		gitRepository = "package-update"
 	)
 
-	t.RegisterGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints", "")
+	t.RegisterGitRepositoryF(t.GetContext(), testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(ctx, &list, client.InNamespace(t.Namespace))
+	t.ListE(t.GetContext(), &list, client.InNamespace(t.Namespace))
 
-	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
+	basensV2 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
 	t.Logf("basensV2 = %v", basensV2)
 
 	// Register the repository as 'downstream'
-	t.RegisterMainGitRepositoryF(ctx, gitRepository)
+	t.RegisterMainGitRepositoryF(t.GetContext(), gitRepository)
 
 	// Create PackageRevision from upstream repo
 	pr := &porchapi.PackageRevision{
@@ -69,9 +67,9 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 		},
 	}
 
-	t.CreateF(ctx, pr)
+	t.CreateF(t.GetContext(), pr)
 
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(t.GetContext(), client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, pr)
@@ -87,15 +85,15 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 		},
 	}
 
-	t.UpdateF(ctx, pr)
+	t.UpdateF(t.GetContext(), pr)
 
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(t.GetContext(), client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, pr)
 
 	var revisionResources porchapi.PackageRevisionResources
-	t.GetF(ctx, client.ObjectKey{
+	t.GetF(t.GetContext(), client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      pr.Name,
 	}, &revisionResources)

--- a/test/ociserver/pkg/oci/responses.go
+++ b/test/ociserver/pkg/oci/responses.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:errcheck
 package oci
 
 import (


### PR DESCRIPTION
The main E2E test suite was a wrapper around `testing.T` and mostly mimicking testify's functionality. In this PR I "ported" the suite over to testify, making it more IDE friendly in my experience.

I also removed a lot of redundant context passing, pushing it down to the helper functions instead. Furthermore, I fixed the lint issues in the tests and removed the exclusion in the github action.