### PR TITLE
Improve revision handing, keying, and indexing of PackageRevision and Repo entities in Porch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
     "sonarlint.connectedMode.project": {
         "connectionId": "nephio-project",
         "projectKey": "nephio-project_porch"
-    }
+    },
+    "go.testEnvVars": {
+      "RUN_E2E_LOCALLY": "false"
+    },
 }

--- a/api/porch/types.go
+++ b/api/porch/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/porch/types.go
+++ b/api/porch/types.go
@@ -49,8 +49,6 @@ const (
 	PackageRevisionLifecycleDeletionProposed PackageRevisionLifecycle = "DeletionProposed"
 )
 
-type WorkspaceName string
-
 // PackageRevisionSpec defines the desired state of PackageRevision
 type PackageRevisionSpec struct {
 	// PackageName identifies the package in the repository.
@@ -60,7 +58,7 @@ type PackageRevisionSpec struct {
 	RepositoryName string `json:"repository,omitempty"`
 
 	// WorkspaceName is a short, unique description of the changes contained in this package revision.
-	WorkspaceName WorkspaceName `json:"workspaceName,omitempty"`
+	WorkspaceName string `json:"workspaceName,omitempty"`
 
 	// Revision identifies the version of the package.
 	Revision int `json:"revision,omitempty"`
@@ -475,7 +473,7 @@ type PackageRevisionResourcesSpec struct {
 	PackageName string `json:"packageName,omitempty"`
 
 	// WorkspaceName identifies the workspace of the package.
-	WorkspaceName WorkspaceName `json:"workspaceName,omitempty"`
+	WorkspaceName string `json:"workspaceName,omitempty"`
 
 	// Revision identifies the version of the package.
 	Revision int `json:"revision,omitempty"`

--- a/api/porch/v1alpha1/types.go
+++ b/api/porch/v1alpha1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/porch/v1alpha1/zz_generated.conversion.go
+++ b/api/porch/v1alpha1/zz_generated.conversion.go
@@ -875,7 +875,7 @@ func Convert_porch_PackageRevisionResourcesList_To_v1alpha1_PackageRevisionResou
 
 func autoConvert_v1alpha1_PackageRevisionResourcesSpec_To_porch_PackageRevisionResourcesSpec(in *PackageRevisionResourcesSpec, out *porch.PackageRevisionResourcesSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
-	out.WorkspaceName = porch.WorkspaceName(in.WorkspaceName)
+	out.WorkspaceName = in.WorkspaceName
 	out.Revision = in.Revision
 	out.RepositoryName = in.RepositoryName
 	out.Resources = *(*map[string]string)(unsafe.Pointer(&in.Resources))
@@ -889,7 +889,7 @@ func Convert_v1alpha1_PackageRevisionResourcesSpec_To_porch_PackageRevisionResou
 
 func autoConvert_porch_PackageRevisionResourcesSpec_To_v1alpha1_PackageRevisionResourcesSpec(in *porch.PackageRevisionResourcesSpec, out *PackageRevisionResourcesSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
-	out.WorkspaceName = string(in.WorkspaceName)
+	out.WorkspaceName = in.WorkspaceName
 	out.Revision = in.Revision
 	out.RepositoryName = in.RepositoryName
 	out.Resources = *(*map[string]string)(unsafe.Pointer(&in.Resources))
@@ -928,7 +928,7 @@ func Convert_porch_PackageRevisionResourcesStatus_To_v1alpha1_PackageRevisionRes
 func autoConvert_v1alpha1_PackageRevisionSpec_To_porch_PackageRevisionSpec(in *PackageRevisionSpec, out *porch.PackageRevisionSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
 	out.RepositoryName = in.RepositoryName
-	out.WorkspaceName = porch.WorkspaceName(in.WorkspaceName)
+	out.WorkspaceName = in.WorkspaceName
 	out.Revision = in.Revision
 	out.Parent = (*porch.ParentReference)(unsafe.Pointer(in.Parent))
 	out.Lifecycle = porch.PackageRevisionLifecycle(in.Lifecycle)
@@ -945,7 +945,7 @@ func Convert_v1alpha1_PackageRevisionSpec_To_porch_PackageRevisionSpec(in *Packa
 func autoConvert_porch_PackageRevisionSpec_To_v1alpha1_PackageRevisionSpec(in *porch.PackageRevisionSpec, out *PackageRevisionSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
 	out.RepositoryName = in.RepositoryName
-	out.WorkspaceName = string(in.WorkspaceName)
+	out.WorkspaceName = in.WorkspaceName
 	out.Revision = in.Revision
 	out.Parent = (*ParentReference)(unsafe.Pointer(in.Parent))
 	out.Lifecycle = PackageRevisionLifecycle(in.Lifecycle)

--- a/controllers/packagevariants/api/v1alpha1/packagevariant_types.go
+++ b/controllers/packagevariants/api/v1alpha1/packagevariant_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection_test.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2023, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The kpt and Nephio Authors
+// Copyright 2023-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller_test.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/fake_client.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/fake_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2023, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/render_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/render_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2023, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2023, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt and Nephio Authors
+// Copyright 2023, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cache/crcache/cache_test.go
+++ b/pkg/cache/crcache/cache_test.go
@@ -89,8 +89,12 @@ func TestPublishedLatest(t *testing.T) {
 	cachedRepo := openRepositoryFromArchive(t, ctx, testPath, "nested")
 
 	revisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package:       "catalog/gcp/bucket",
-		WorkspaceName: "v2",
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: "catalog/gcp/bucket",
+			},
+			WorkspaceName: "v2",
+		},
 	})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
@@ -135,8 +139,12 @@ func TestDeletePublishedMain(t *testing.T) {
 	cachedRepo := openRepositoryFromArchive(t, ctx, testPath, "nested")
 
 	revisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package:       "catalog/gcp/bucket",
-		WorkspaceName: "v2",
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: "catalog/gcp/bucket",
+			},
+			WorkspaceName: "v2",
+		},
 	})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
@@ -170,10 +178,14 @@ func TestDeletePublishedMain(t *testing.T) {
 	}
 
 	publishedRevisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package:       "catalog/gcp/bucket",
-		WorkspaceName: "v2",
-		Lifecycle:     api.PackageRevisionLifecyclePublished,
-		Revision:      -1,
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: "catalog/gcp/bucket",
+			},
+			WorkspaceName: "v2",
+			Revision:      -1,
+		},
+		Lifecycle: api.PackageRevisionLifecyclePublished,
 	})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
@@ -200,10 +212,14 @@ func TestDeletePublishedMain(t *testing.T) {
 	}
 
 	postDeletePublishedRevisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package:       "catalog/gcp/bucket",
-		WorkspaceName: "v2",
-		Lifecycle:     api.PackageRevisionLifecyclePublished,
-		Revision:      -1,
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: "catalog/gcp/bucket",
+			},
+			WorkspaceName: "v2",
+			Revision:      -1,
+		},
+		Lifecycle: api.PackageRevisionLifecyclePublished,
 	})
 
 	if err != nil {

--- a/pkg/cache/crcache/cache_test.go
+++ b/pkg/cache/crcache/cache_test.go
@@ -91,7 +91,8 @@ func TestPublishedLatest(t *testing.T) {
 	revisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 		Key: repository.PackageRevisionKey{
 			PkgKey: repository.PackageKey{
-				Package: "catalog/gcp/bucket",
+				Path:    "catalog/gcp",
+				Package: "bucket",
 			},
 			WorkspaceName: "v2",
 		},
@@ -141,7 +142,8 @@ func TestDeletePublishedMain(t *testing.T) {
 	revisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 		Key: repository.PackageRevisionKey{
 			PkgKey: repository.PackageKey{
-				Package: "catalog/gcp/bucket",
+				Path:    "catalog/gcp",
+				Package: "bucket",
 			},
 			WorkspaceName: "v2",
 		},
@@ -180,7 +182,8 @@ func TestDeletePublishedMain(t *testing.T) {
 	publishedRevisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 		Key: repository.PackageRevisionKey{
 			PkgKey: repository.PackageKey{
-				Package: "catalog/gcp/bucket",
+				Path:    "catalog/gcp",
+				Package: "bucket",
 			},
 			WorkspaceName: "v2",
 			Revision:      -1,
@@ -214,7 +217,8 @@ func TestDeletePublishedMain(t *testing.T) {
 	postDeletePublishedRevisions, err := cachedRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 		Key: repository.PackageRevisionKey{
 			PkgKey: repository.PackageKey{
-				Package: "catalog/gcp/bucket",
+				Path:    "catalog/gcp",
+				Package: "bucket",
 			},
 			WorkspaceName: "v2",
 			Revision:      -1,

--- a/pkg/cache/crcache/package.go
+++ b/pkg/cache/crcache/package.go
@@ -28,11 +28,11 @@ var _ repository.Package = &cachedPackage{}
 
 type cachedPackage struct {
 	repository.Package
-	latestPackageRevision string
+	latestPackageRevision int
 }
 
-func (c *cachedPackage) GetLatestRevision() string {
-	if c.latestPackageRevision != "" {
+func (c *cachedPackage) GetLatestRevision() int {
+	if c.latestPackageRevision > 0 {
 		return c.latestPackageRevision
 	}
 	return c.Package.GetLatestRevision()

--- a/pkg/cache/crcache/packagerevision.go
+++ b/pkg/cache/crcache/packagerevision.go
@@ -19,7 +19,9 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/nephio-project/porch/pkg/util"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // We take advantage of the cache having a global view of all the packages
@@ -33,6 +35,18 @@ var _ repository.PackageRevision = &cachedPackageRevision{}
 type cachedPackageRevision struct {
 	repository.PackageRevision
 	isLatestRevision bool
+}
+
+func (c *cachedPackageRevision) KubeObjectName() string {
+	return repository.ComposePkgRevObjName(c.Key())
+}
+
+func (c *cachedPackageRevision) KubeObjectNamespace() string {
+	return c.Key().Namespace
+}
+
+func (c *cachedPackageRevision) UID() types.UID {
+	return util.GenerateUid("packagerevision:", c.KubeObjectNamespace(), c.KubeObjectName())
 }
 
 func (c *cachedPackageRevision) GetPackageRevision(ctx context.Context) (*api.PackageRevision, error) {

--- a/pkg/cache/crcache/packagerevision.go
+++ b/pkg/cache/crcache/packagerevision.go
@@ -42,7 +42,7 @@ func (c *cachedPackageRevision) KubeObjectName() string {
 }
 
 func (c *cachedPackageRevision) KubeObjectNamespace() string {
-	return c.Key().Namespace
+	return c.Key().PkgKey.RepoKey.Namespace
 }
 
 func (c *cachedPackageRevision) UID() types.UID {

--- a/pkg/cache/crcache/repository.go
+++ b/pkg/cache/crcache/repository.go
@@ -179,7 +179,12 @@ func (r *cachedRepository) ClosePackageRevisionDraft(ctx context.Context, prd re
 	}
 
 	revisions, err := r.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package: prd.GetName(),
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Path:    prd.Key().PkgKey.Path,
+				Package: prd.Key().PkgKey.Package,
+			},
+		},
 	})
 	if err != nil {
 		return nil, err
@@ -250,7 +255,7 @@ func (r *cachedRepository) update(ctx context.Context, updated repository.Packag
 func (r *cachedRepository) createMainPackageRevision(ctx context.Context, updatedMain repository.PackageRevision) error {
 	//Search and delete any old main pkgRev of an older workspace in the cache
 	for pkgRevKey := range r.cachedPackageRevisions {
-		if pkgRevKey.Revision == -1 && pkgRevKey.PackageKey() == updatedMain.Key().PackageKey() {
+		if pkgRevKey.Revision == -1 && pkgRevKey.PkgKey == updatedMain.Key().PkgKey {
 			delete(r.cachedPackageRevisions, pkgRevKey)
 		}
 	}

--- a/pkg/cache/crcache/util.go
+++ b/pkg/cache/crcache/util.go
@@ -45,7 +45,7 @@ func identifyLatestRevisions(ctx context.Context, result map[repository.PackageR
 				// currentKey.Revision > previousKey.Revision; update latest
 				latest[currentKey.Package] = current
 			}
-		} else {
+		} else if currentKey.Revision != -1 { // The working repository PR (usually main) can never be the latest PR
 			// First revision of the specific package; candidate for the latest.
 			latest[currentKey.Package] = current
 		}

--- a/pkg/cache/crcache/util.go
+++ b/pkg/cache/crcache/util.go
@@ -45,7 +45,7 @@ func identifyLatestRevisions(ctx context.Context, result map[repository.PackageR
 				// currentKey.Revision > previousKey.Revision; update latest
 				latest[currentKey.Package] = current
 			}
-		} else if currentKey.Revision != -1 { // The working repository PR (usually main) can never be the latest PR
+		} else {
 			// First revision of the specific package; candidate for the latest.
 			latest[currentKey.Package] = current
 		}

--- a/pkg/cache/crcache/util.go
+++ b/pkg/cache/crcache/util.go
@@ -39,15 +39,15 @@ func identifyLatestRevisions(ctx context.Context, result map[repository.PackageR
 		}
 
 		currentKey := current.Key()
-		if previous, ok := latest[currentKey.Package]; ok {
+		if previous, ok := latest[currentKey.PkgKey.Package]; ok {
 			previousKey := previous.Key()
 			if currentKey.Revision > previousKey.Revision {
 				// currentKey.Revision > previousKey.Revision; update latest
-				latest[currentKey.Package] = current
+				latest[currentKey.PkgKey.Package] = current
 			}
 		} else if currentKey.Revision != -1 { // The working repository PR (usually main) can never be the latest PR
 			// First revision of the specific package; candidate for the latest.
-			latest[currentKey.Package] = current
+			latest[currentKey.PkgKey.Package] = current
 		}
 	}
 
@@ -67,7 +67,7 @@ func toPackageRevisionSlice(
 	}
 	sort.Slice(result, func(i, j int) bool {
 		ki, kl := result[i].Key(), result[j].Key()
-		switch res := strings.Compare(ki.Package, kl.Package); {
+		switch res := strings.Compare(ki.PkgKey.Package, kl.PkgKey.Package); {
 		case res < 0:
 			return true
 		case res > 0:

--- a/pkg/cli/commands/rpkg/get/command.go
+++ b/pkg/cli/commands/rpkg/get/command.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/commands/rpkg/get/command_test.go
+++ b/pkg/cli/commands/rpkg/get/command_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetters(t *testing.T) {
+	cells := make([]any, 1)
+	cells[0] = int64(1234)
+
+	_, retVal1 := getInt64Cell(cells, -1)
+	assert.False(t, retVal1)
+
+	val, retVal2 := getInt64Cell(cells, 0)
+	assert.True(t, retVal2)
+	assert.Equal(t, int64(1234), val)
+}

--- a/pkg/cli/commands/rpkg/update/command.go
+++ b/pkg/cli/commands/rpkg/update/command.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cli/commands/rpkg/update/discover.go
+++ b/pkg/cli/commands/rpkg/update/discover.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -162,7 +162,12 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	}
 
 	revs, err := repo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
-		Package: obj.Spec.PackageName})
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: obj.Spec.PackageName,
+			},
+		},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error listing package revisions: %w", err)
 	}

--- a/pkg/externalrepo/fake/packagerevision.go
+++ b/pkg/externalrepo/fake/packagerevision.go
@@ -40,7 +40,7 @@ func (c *FakePackageRevision) KubeObjectName() string {
 }
 
 func (c *FakePackageRevision) KubeObjectNamespace() string {
-	return c.Key().Namespace
+	return c.Key().PkgKey.RepoKey.Namespace
 }
 
 func (c *FakePackageRevision) UID() types.UID {

--- a/pkg/externalrepo/fake/packagerevision.go
+++ b/pkg/externalrepo/fake/packagerevision.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/fake/packagerevision.go
+++ b/pkg/externalrepo/fake/packagerevision.go
@@ -20,24 +20,31 @@ import (
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/nephio-project/porch/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // Implementation of the repository.PackageRevision interface for testing.
 type FakePackageRevision struct {
-	Name               string
-	Namespace          string
-	Uid                types.UID
-	PackageRevisionKey repository.PackageRevisionKey
-	PackageLifecycle   v1alpha1.PackageRevisionLifecycle
-	PackageRevision    *v1alpha1.PackageRevision
-	Resources          *v1alpha1.PackageRevisionResources
-	Kptfile            kptfile.KptFile
+	PrKey            repository.PackageRevisionKey
+	Uid              types.UID
+	PackageLifecycle v1alpha1.PackageRevisionLifecycle
+	PackageRevision  *v1alpha1.PackageRevision
+	Resources        *v1alpha1.PackageRevisionResources
+	Kptfile          kptfile.KptFile
 }
 
-func (pr *FakePackageRevision) KubeObjectName() string {
-	return pr.Name
+func (c *FakePackageRevision) KubeObjectName() string {
+	return repository.ComposePkgRevObjName(c.Key())
+}
+
+func (c *FakePackageRevision) KubeObjectNamespace() string {
+	return c.Key().Namespace
+}
+
+func (c *FakePackageRevision) UID() types.UID {
+	return util.GenerateUid("packagerevision:", c.KubeObjectNamespace(), c.KubeObjectName())
 }
 
 var _ repository.PackageRevision = &FakePackageRevision{}
@@ -47,20 +54,12 @@ func (f *FakePackageRevision) ToMainPackageRevision() repository.PackageRevision
 	panic("unimplemented")
 }
 
-func (pr *FakePackageRevision) KubeObjectNamespace() string {
-	return pr.Namespace
-}
-
-func (pr *FakePackageRevision) UID() types.UID {
-	return pr.Uid
-}
-
 func (pr *FakePackageRevision) ResourceVersion() string {
 	return pr.PackageRevision.ResourceVersion
 }
 
 func (pr *FakePackageRevision) Key() repository.PackageRevisionKey {
-	return pr.PackageRevisionKey
+	return pr.PrKey
 }
 
 func (pr *FakePackageRevision) Lifecycle(ctx context.Context) v1alpha1.PackageRevisionLifecycle {

--- a/pkg/externalrepo/fake/packagerevision.go
+++ b/pkg/externalrepo/fake/packagerevision.go
@@ -35,6 +35,8 @@ type FakePackageRevision struct {
 	Kptfile          kptfile.KptFile
 }
 
+var _ repository.PackageRevision = &FakePackageRevision{}
+
 func (c *FakePackageRevision) KubeObjectName() string {
 	return repository.ComposePkgRevObjName(c.Key())
 }

--- a/pkg/externalrepo/fake/packagerevision_test.go
+++ b/pkg/externalrepo/fake/packagerevision_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"testing"
+
+	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestPackageGetters(t *testing.T) {
+	fakePr := FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name:      "my-repo",
+					Namespace: "my-namespace",
+				},
+				Package: "my-package",
+			},
+			WorkspaceName: "my-workspace",
+		},
+	}
+
+	assert.Equal(t, "my-repo.my-package.my-workspace", fakePr.KubeObjectName())
+	assert.Equal(t, "my-namespace", fakePr.KubeObjectNamespace())
+	assert.Equal(t, types.UID("7007e8aa-0928-50f9-b980-92a44942f055"), fakePr.UID())
+}

--- a/pkg/externalrepo/fake/repository.go
+++ b/pkg/externalrepo/fake/repository.go
@@ -41,16 +41,7 @@ func (r *Repository) Version(ctx context.Context) (string, error) {
 func (r *Repository) ListPackageRevisions(_ context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
 	var revs []repository.PackageRevision
 	for _, rev := range r.PackageRevisions {
-		if filter.KubeObjectName != "" && filter.KubeObjectName == rev.KubeObjectName() {
-			revs = append(revs, rev)
-		}
-		if filter.Package != "" && filter.Package == rev.Key().Package {
-			revs = append(revs, rev)
-		}
-		if filter.Revision != 0 && filter.Revision == rev.Key().Revision {
-			revs = append(revs, rev)
-		}
-		if filter.WorkspaceName != "" && filter.WorkspaceName == rev.Key().WorkspaceName {
+		if filter.Key.Matches(rev.Key()) {
 			revs = append(revs, rev)
 		}
 	}

--- a/pkg/externalrepo/git/draft.go
+++ b/pkg/externalrepo/git/draft.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/draft.go
+++ b/pkg/externalrepo/git/draft.go
@@ -64,7 +64,7 @@ func (d *gitPackageRevisionDraft) UpdateLifecycle(ctx context.Context, new v1alp
 }
 
 func (d *gitPackageRevisionDraft) GetName() string {
-	packageDirectory := d.parent.directory
+	packageDirectory := d.parent.Key().Path
 	packageName := strings.TrimPrefix(d.path, packageDirectory+"/")
 	return packageName
 }

--- a/pkg/externalrepo/git/draft.go
+++ b/pkg/externalrepo/git/draft.go
@@ -16,7 +16,6 @@ package git
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -26,12 +25,10 @@ import (
 )
 
 type gitPackageRevisionDraft struct {
-	parent        *gitRepository // repo is repo containing the package
-	path          string         // the path to the package from the repo root
-	revision      int
-	workspaceName v1alpha1.WorkspaceName
-	updated       time.Time
-	tasks         []v1alpha1.Task
+	prKey   repository.PackageRevisionKey
+	repo    *gitRepository // repo is repo containing the package
+	updated time.Time
+	tasks   []v1alpha1.Task
 
 	// New value of the package revision lifecycle
 	lifecycle v1alpha1.PackageRevisionLifecycle
@@ -51,20 +48,18 @@ type gitPackageRevisionDraft struct {
 
 var _ repository.PackageRevisionDraft = &gitPackageRevisionDraft{}
 
+func (d *gitPackageRevisionDraft) Key() repository.PackageRevisionKey {
+	return d.prKey
+}
+
 func (d *gitPackageRevisionDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
 	ctx, span := tracer.Start(ctx, "gitPackageDraft::UpdateResources", trace.WithAttributes())
 	defer span.End()
 
-	return d.parent.UpdateDraftResources(ctx, d, new, change)
+	return d.repo.UpdateDraftResources(ctx, d, new, change)
 }
 
 func (d *gitPackageRevisionDraft) UpdateLifecycle(ctx context.Context, new v1alpha1.PackageRevisionLifecycle) error {
 	d.lifecycle = new
 	return nil
-}
-
-func (d *gitPackageRevisionDraft) GetName() string {
-	packageDirectory := d.parent.Key().Path
-	packageName := strings.TrimPrefix(d.path, packageDirectory+"/")
-	return packageName
 }

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -41,6 +41,7 @@ import (
 	kptfilev1 "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
 	"github.com/nephio-project/porch/pkg/util"
+	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
@@ -870,15 +871,7 @@ func (r *gitRepository) loadTaggedPackage(ctx context.Context, tag *plumbing.Ref
 		klog.Warningf("Error building git package revision %q: %s", path, err)
 	}
 
-	packageRevision, err := krmPackage.buildGitPackageRevision(ctx, revisionStr, workspaceName, tag)
-	if err != nil {
-		return nil, err
-	}
-
-	return []*gitPackageRevision{
-		packageRevision,
-	}, nil
-
+	return packageRevision, nil
 }
 
 func (r *gitRepository) dumpAllRefs() {

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -228,6 +228,7 @@ type gitRepository struct {
 }
 
 var _ GitRepository = &gitRepository{}
+var _ repository.Repository = &gitRepository{}
 
 func (r *gitRepository) Key() repository.RepositoryKey {
 	return r.key

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -862,7 +862,14 @@ func (r *gitRepository) loadTaggedPackage(ctx context.Context, tag *plumbing.Ref
 		klog.Warningf("Error building git package revision %q: %s", path, err)
 	}
 
-	return packageRevision, nil
+	packageRevision, err := krmPackage.buildGitPackageRevision(ctx, revisionStr, workspaceName, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*gitPackageRevision{
+		packageRevision,
+	}, nil
 
 }
 

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -139,12 +139,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 		branch = BranchName(spec.Branch)
 	}
 
-	placeholderName := string(branch)
-	if slashPos := strings.Index(placeholderName, "/"); slashPos > 0 {
-		placeholderName = placeholderName[slashPos+1:]
-	}
-
-	if err := util.ValidateK8SName(placeholderName); err != nil {
+	if err := util.ValidateDirectoryName(string(branch)); err != nil {
 		return nil, fmt.Errorf("branch name %s invalid: %v", branch, err)
 	}
 
@@ -153,7 +148,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 			Name:              name,
 			Namespace:         namespace,
 			Path:              strings.Trim(spec.Directory, "/"),
-			PlaceholderWSname: v1alpha1.WorkspaceName(placeholderName),
+			PlaceholderWSname: v1alpha1.WorkspaceName(string(branch)),
 		},
 		repo:               repo,
 		branch:             branch,
@@ -418,23 +413,28 @@ func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 		return nil, fmt.Errorf("failed to create packagerevision: %w", err)
 	}
 
-	packagePath := filepath.Join(r.Key().Path, obj.Spec.PackageName)
+	draftKey := repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			RepoKey: r.Key(),
+			Package: obj.Spec.PackageName,
+		},
+		WorkspaceName: obj.Spec.WorkspaceName,
+	}
 
 	// TODO use git branches to leverage uniqueness
-	draft := createDraftName(packagePath, obj.Spec.WorkspaceName)
+	draftBranchName := createDraftName(draftKey)
 
 	// TODO: This should also create a new 'Package' resource if one does not already exist
 
 	return &gitPackageRevisionDraft{
-		parent:        r,
-		path:          packagePath,
-		workspaceName: obj.Spec.WorkspaceName,
-		lifecycle:     v1alpha1.PackageRevisionLifecycleDraft,
-		updated:       time.Now(),
-		base:          nil, // Creating a new package
-		tasks:         nil, // Creating a new package
-		branch:        draft,
-		commit:        base,
+		prKey:     draftKey,
+		repo:      r,
+		lifecycle: v1alpha1.PackageRevisionLifecycleDraft,
+		updated:   time.Now(),
+		base:      nil, // Creating a new package
+		tasks:     nil, // Creating a new package
+		branch:    draftBranchName,
+		commit:    base,
 	}, nil
 }
 
@@ -472,16 +472,14 @@ func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repositor
 	lifecycle := r.getLifecycle(oldGitPackage)
 
 	return &gitPackageRevisionDraft{
-		parent:        r,
-		path:          oldGitPackage.path,
-		revision:      oldGitPackage.revision,
-		workspaceName: oldGitPackage.workspaceName,
-		lifecycle:     lifecycle,
-		updated:       rev.updated,
-		base:          rev.ref,
-		tree:          rev.tree,
-		commit:        rev.commit,
-		tasks:         rev.tasks,
+		prKey:     oldGitPackage.prKey,
+		repo:      r,
+		lifecycle: lifecycle,
+		updated:   rev.updated,
+		base:      rev.ref,
+		tree:      rev.tree,
+		commit:    rev.commit,
+		tasks:     rev.tasks,
 	}, nil
 }
 
@@ -500,7 +498,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 	if ref == nil {
 		// This is an internal error. In some rare cases (see GetPackageRevision below) we create
 		// package revisions without refs. They should never be returned via the API though.
-		return fmt.Errorf("cannot delete package with no ref: %s", oldGit.path)
+		return fmt.Errorf("cannot delete package with no ref: %s", oldGit.Key().PkgKey.ToFullPathname())
 	}
 
 	// We can only delete packages which have their own ref. Refs that are shared with other packages
@@ -511,7 +509,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 	switch rn := ref.Name(); {
 	case rn.IsTag():
 		// Delete tag only if it is package-specific.
-		name := createFinalTagNameInLocal(oldGit.path, oldGit.revision)
+		name := createFinalTagNameInLocal(oldGit.Key())
 		if rn != name {
 			return fmt.Errorf("cannot delete package tagged with a tag that is not specific to the package: %s", rn)
 		}
@@ -520,7 +518,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 		refSpecs.AddRefToDelete(ref)
 
 		// If this revision was proposed for deletion, we need to delete the associated branch.
-		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision); err != nil {
+		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.Key()); err != nil {
 			return err
 		}
 
@@ -537,7 +535,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 
 		// Remove the proposed for deletion branch. We end up here when users
 		// try to delete the main branch version of a packagerevision.
-		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision); err != nil {
+		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.Key()); err != nil {
 			return err
 		}
 
@@ -556,9 +554,9 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 	return nil
 }
 
-func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context, path string, revision int) error {
+func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context, key repository.PackageRevisionKey) error {
 	refSpecsForDeletionProposed := newPushRefSpecBuilder()
-	deletionProposedBranch := createDeletionProposedName(path, revision)
+	deletionProposedBranch := createDeletionProposedName(key)
 	refSpecsForDeletionProposed.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
 	if err := r.pushAndCleanup(ctx, refSpecsForDeletionProposed); err != nil {
 		if pkgerrors.Is(err, git.NoErrAlreadyUpToDate) {
@@ -1111,30 +1109,28 @@ func (r *gitRepository) createPackageDeleteCommit(ctx context.Context, branch pl
 		return zero, fmt.Errorf("failed to find commit tree for %s: %w", ref, err)
 	}
 
-	packagePath := pkg.path
-
 	// Find the package in the tree
-	switch _, err := root.FindEntry(packagePath); err {
+	switch _, err := root.FindEntry(pkg.Key().PkgKey.ToFullPathname()); err {
 	case object.ErrEntryNotFound:
 		// Package doesn't exist; no need to delete it
 		return zero, nil
 	case nil:
 		// found
 	default:
-		return zero, fmt.Errorf("failed to find package %q in the repositrory ref %q: %w,", packagePath, ref, err)
+		return zero, fmt.Errorf("failed to find package %q in the repositrory ref %q: %w,", pkg.Key().PkgKey.ToFullPathname(), ref, err)
 	}
 
 	// Create commit helper. Use zero hash for the initial package tree. Commit helper will initialize trees
 	// without TreeEntry for this package present - the package is deleted.
-	ch, err := newCommitHelper(r, r.userInfoProvider, commit.Hash, packagePath, zero)
+	ch, err := newCommitHelper(r, r.userInfoProvider, commit.Hash, pkg.Key().PkgKey.ToFullPathname(), zero)
 	if err != nil {
-		return zero, fmt.Errorf("failed to initialize commit of package %q to %q: %w", packagePath, ref, err)
+		return zero, fmt.Errorf("failed to initialize commit of package %q to %q: %w", pkg.Key().PkgKey.ToFullPathname(), ref, err)
 	}
 
-	message := fmt.Sprintf("Delete %s", packagePath)
-	commitHash, _, err := ch.commit(ctx, message, packagePath)
+	message := fmt.Sprintf("Delete %s", pkg.Key().PkgKey.ToFullPathname())
+	commitHash, _, err := ch.commit(ctx, message, pkg.Key().PkgKey.ToFullPathname())
 	if err != nil {
-		return zero, fmt.Errorf("failed to commit package %q to %q: %w", packagePath, ref, err)
+		return zero, fmt.Errorf("failed to commit package %q to %q: %w", pkg.Key().PkgKey.ToFullPathname(), ref, err)
 	}
 	return commitHash, nil
 }
@@ -1176,8 +1172,7 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 	return nil
 }
 
-func (r *gitRepository) loadTasks(_ context.Context, startCommit *object.Commit, packagePath,
-	workspaceName string) ([]v1alpha1.Task, error) {
+func (r *gitRepository) loadTasks(_ context.Context, startCommit *object.Commit, key repository.PackageRevisionKey) ([]v1alpha1.Task, error) {
 
 	var logOptions = git.LogOptions{
 		From:  startCommit.Hash,
@@ -1217,10 +1212,10 @@ func (r *gitRepository) loadTasks(_ context.Context, startCommit *object.Commit,
 		}
 
 		for _, gitAnnotation := range gitAnnotations {
-			packageMatches := gitAnnotation.PackagePath == packagePath
-			workspaceNameMatches := gitAnnotation.WorkspaceName == workspaceName ||
+			packageMatches := gitAnnotation.PackagePath == key.PkgKey.ToFullPathname()
+			workspaceNameMatches := gitAnnotation.WorkspaceName == key.WorkspaceName ||
 				// this is needed for porch package revisions created before the workspaceName field existed
-				(gitAnnotation.Revision == string(workspaceName) && gitAnnotation.WorkspaceName == "")
+				(gitAnnotation.Revision == string(key.WorkspaceName) && gitAnnotation.WorkspaceName == "")
 
 			if packageMatches && workspaceNameMatches {
 				// We are iterating through the commits in reverse order.
@@ -1304,8 +1299,45 @@ func (r *gitRepository) GetResources(hash plumbing.Hash) (map[string]string, err
 }
 
 // findLatestPackageCommit returns the latest commit from the history that pertains
-// to the package given by the packagePath. If no commit is found, it will return nil and an error.
-func (r *gitRepository) findLatestPackageCommit(startCommit *object.Commit, packagePath string) (*object.Commit, error) {
+// to the package given by the packagePath. If no commit is found, it will return nil.
+func (r *gitRepository) findLatestPackageCommit(startCommit *object.Commit, key repository.PackageKey) (*object.Commit, error) {
+	var commit *object.Commit
+	err := r.packageHistoryIterator(startCommit, key, func(c *object.Commit) error {
+		commit = c
+		return storer.ErrStop
+	})
+	return commit, err
+}
+
+// commitCallback is the function type that needs to be provided to the history iterator functions.
+type commitCallback func(*object.Commit) error
+
+// packageHistoryIterator traverses the git history from the provided commit and invokes
+// the callback function for every commit pertaining to the provided package.
+func (r *gitRepository) packageHistoryIterator(startCommit *object.Commit, key repository.PackageKey, cb commitCallback) error {
+	return r.traverseHistory(startCommit, func(commit *object.Commit) error {
+		gitAnnotations, err := ExtractGitAnnotations(commit)
+		if err != nil {
+			return err
+		}
+
+		for _, gitAnnotation := range gitAnnotations {
+			if gitAnnotation.PackagePath == key.ToFullPathname() {
+
+				if err := cb(commit); err != nil {
+					return err
+				}
+
+				if gitAnnotation.Task != nil && (gitAnnotation.Task.Type == v1alpha1.TaskTypeClone || gitAnnotation.Task.Type == v1alpha1.TaskTypeInit) {
+					break
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (r *gitRepository) traverseHistory(startCommit *object.Commit, cb commitCallback) error {
 	var logOptions = git.LogOptions{
 		From:  startCommit.Hash,
 		Order: git.LogOrderCommitterTime,
@@ -1410,7 +1442,7 @@ func (r *gitRepository) checkPublishedLifecycle(pkgRev *gitPackageRevision) v1al
 		}
 	}
 
-	branchName := createDeletionProposedName(pkgRev.path, pkgRev.revision)
+	branchName := createDeletionProposedName(pkgRev.Key())
 	if _, found := r.deletionProposedCache[branchName]; found {
 		return v1alpha1.PackageRevisionLifecycleDeletionProposed
 	}
@@ -1430,7 +1462,7 @@ func (r *gitRepository) UpdateLifecycle(ctx context.Context, pkgRev *gitPackageR
 		return fmt.Errorf("cannot update lifecycle for draft package revision")
 	}
 	refSpecs := newPushRefSpecBuilder()
-	deletionProposedBranch := createDeletionProposedName(pkgRev.path, pkgRev.revision)
+	deletionProposedBranch := createDeletionProposedName(pkgRev.Key())
 
 	if old == v1alpha1.PackageRevisionLifecyclePublished {
 		if newLifecycle != v1alpha1.PackageRevisionLifecycleDeletionProposed {
@@ -1466,20 +1498,20 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	ch, err := newCommitHelper(r, r.userInfoProvider, draft.commit, draft.path, plumbing.ZeroHash)
+	ch, err := newCommitHelper(r, r.userInfoProvider, draft.commit, draft.Key().PkgKey.ToFullPathname(), plumbing.ZeroHash)
 	if err != nil {
 		return pkgerrors.Wrap(err, "failed to commit package:")
 	}
 
 	for k, v := range new.Spec.Resources {
-		if err := ch.storeFile(filepath.Join(draft.path, k), v); err != nil {
+		if err := ch.storeFile(path.Join(draft.Key().PkgKey.ToFullPathname(), k), v); err != nil {
 			return err
 		}
 	}
 
 	// Because we can't read the package back without a Kptfile, make sure one is present
 	{
-		p := filepath.Join(draft.path, "Kptfile")
+		p := path.Join(draft.Key().PkgKey.ToFullPathname(), "Kptfile")
 		_, err := ch.readFile(p)
 		if os.IsNotExist(err) {
 			// We could write the file here; currently we return an error
@@ -1488,9 +1520,9 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 	}
 
 	annotation := &gitAnnotation{
-		PackagePath:   draft.path,
-		WorkspaceName: draft.workspaceName,
-		Revision:      repository.Revision2Str(draft.revision),
+		PackagePath:   draft.Key().PkgKey.ToFullPathname(),
+		WorkspaceName: draft.Key().WorkspaceName,
+		Revision:      repository.Revision2Str(draft.Key().Revision),
 		Task:          change,
 	}
 	message := "Intermediate commit"
@@ -1505,7 +1537,7 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 		return err
 	}
 
-	commitHash, packageTree, err := ch.commit(ctx, message, draft.path)
+	commitHash, packageTree, err := ch.commit(ctx, message, draft.Key().PkgKey.ToFullPathname())
 	if err != nil {
 		return pkgerrors.Wrap(err, "failed to commit package: %w")
 	}
@@ -1525,8 +1557,8 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 	d := prd.(*gitPackageRevisionDraft)
 
 	refSpecs := newPushRefSpecBuilder()
-	draftBranch := createDraftName(d.path, d.workspaceName)
-	proposedBranch := createProposedName(d.path, d.workspaceName)
+	draftBranch := createDraftName(d.Key())
+	proposedBranch := createProposedName(d.Key())
 
 	var newRef *plumbing.Reference
 
@@ -1536,7 +1568,7 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 		if version == 0 {
 			return nil, errors.New("Version cannot be empty for the next package revision")
 		}
-		d.revision = version
+		d.prKey.Revision = version
 
 		// Finalize the package revision. Commit it to main branch.
 		commitHash, newTreeHash, commitBase, err := r.commitPackageToMain(ctx, d)
@@ -1544,7 +1576,7 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 			return nil, err
 		}
 
-		tag := createFinalTagNameInLocal(d.path, d.revision)
+		tag := createFinalTagNameInLocal(d.Key())
 		refSpecs.AddRefToPush(commitHash, r.branch.RefInLocal()) // Push new main branch
 		refSpecs.AddRefToPush(commitHash, tag)                   // Push the tag
 		refSpecs.RequireRef(commitBase)                          // Make sure main didn't advance
@@ -1592,7 +1624,7 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 		return nil, fmt.Errorf("package has unrecognized lifecycle: %q", d.lifecycle)
 	}
 
-	if err := d.parent.pushAndCleanup(ctx, refSpecs); err != nil {
+	if err := d.repo.pushAndCleanup(ctx, refSpecs); err != nil {
 		// No changes is fine. No need to return an error.
 		if !pkgerrors.Is(err, git.NoErrAlreadyUpToDate) {
 			return nil, err
@@ -1601,20 +1633,18 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 
 	// for backwards compatibility with packages that existed before porch supported
 	// descriptions, we populate the workspaceName as the revision number if it is empty
-	if d.workspaceName == "" {
-		d.workspaceName = "v" + v1alpha1.WorkspaceName(repository.Revision2Str(d.revision))
+	if len(strings.TrimSpace(string(d.Key().WorkspaceName))) == 0 {
+		d.prKey.WorkspaceName = "v" + v1alpha1.WorkspaceName(repository.Revision2Str(d.Key().Revision))
 	}
 
 	return &gitPackageRevision{
-		repo:          d.parent,
-		path:          d.path,
-		revision:      d.revision,
-		workspaceName: d.workspaceName,
-		updated:       d.updated,
-		ref:           newRef,
-		tree:          d.tree,
-		commit:        newRef.Hash(),
-		tasks:         d.tasks,
+		prKey:   d.prKey,
+		repo:    d.repo,
+		updated: d.updated,
+		ref:     newRef,
+		tree:    d.tree,
+		commit:  newRef.Hash(),
+		tasks:   d.tasks,
 	}, nil
 }
 
@@ -1674,28 +1704,27 @@ func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageRe
 	if err != nil {
 		return zero, zero, nil, fmt.Errorf("failed to resolve main branch to commit: %w", err)
 	}
-	packagePath := d.path
 
 	// TODO: Check for out-of-band update of the package in main branch
 	// (compare package tree in target branch and common base)
-	ch, err := newCommitHelper(r, r.userInfoProvider, headCommit.Hash, packagePath, d.tree)
+	ch, err := newCommitHelper(r, r.userInfoProvider, headCommit.Hash, d.Key().PkgKey.ToFullPathname(), d.tree)
 	if err != nil {
-		return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", packagePath, localRef)
+		return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", d.Key().PkgKey.ToFullPathname(), localRef)
 	}
 
 	// Add a commit without changes to mark that the package revision is approved. The gitAnnotation is
 	// included so that we can later associate the commit with the correct packagerevision.
-	message, err := AnnotateCommitMessage(fmt.Sprintf("Approve %s/%d", packagePath, d.revision), &gitAnnotation{
-		PackagePath:   packagePath,
-		WorkspaceName: d.workspaceName,
-		Revision:      repository.Revision2Str(d.revision),
+	message, err := AnnotateCommitMessage(fmt.Sprintf("Approve %s/%d", d.Key().PkgKey.ToFullPathname(), d.Key().Revision), &gitAnnotation{
+		PackagePath:   d.Key().PkgKey.ToFullPathname(),
+		WorkspaceName: d.Key().WorkspaceName,
+		Revision:      repository.Revision2Str(d.Key().Revision),
 	})
 	if err != nil {
-		return zero, zero, nil, fmt.Errorf("failed annotation commit message for package %s: %v", packagePath, err)
+		return zero, zero, nil, fmt.Errorf("failed annotation commit message for package %s: %v", d.Key().PkgKey.ToFullPathname(), err)
 	}
-	commitHash, newPackageTreeHash, err = ch.commit(ctx, message, packagePath, d.commit)
+	commitHash, newPackageTreeHash, err = ch.commit(ctx, message, d.Key().PkgKey.ToFullPathname(), d.commit)
 	if err != nil {
-		return zero, zero, nil, fmt.Errorf("failed to commit package %s to %s", packagePath, localRef)
+		return zero, zero, nil, fmt.Errorf("failed to commit package %s to %s", d.Key().PkgKey.ToFullPathname(), localRef)
 	}
 
 	return commitHash, newPackageTreeHash, localTarget, nil
@@ -1741,7 +1770,7 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 		rootTree = tree
 	}
 
-	if err := t.discoverPackages(rootTree, opt.FilterPrefix, opt.Recurse); err != nil {
+	if err := t.discoverPackages(r.Key(), rootTree, opt.FilterPrefix, opt.Recurse); err != nil {
 		return nil, err
 	}
 
@@ -1764,12 +1793,12 @@ func (r *gitRepository) Kezy() string {
 func getPkgWorkspace(commit *object.Commit, p *packageListEntry, ref *plumbing.Reference) string {
 	if ref == nil || (!isTagInLocalRepo(ref.Name()) && !isDraftBranchNameInLocal(ref.Name()) && !isProposedBranchNameInLocal(ref.Name())) {
 		// packages on the main branch may have unrelated commits, we need to find the latest commit relevant to this package
-		c, err := p.parent.parent.findLatestPackageCommit(p.parent.commit, p.path)
-		if c == nil {
-			if err != nil {
-				klog.Warningf("Error searching for latest commit for package %s: %s", p.path, err)
-			}
-			return ""
+		c, err := p.parent.parent.findLatestPackageCommit(p.parent.commit, p.pkgKey)
+		if err != nil {
+			return "", err
+		}
+		if c != nil {
+			commit = c
 		}
 		commit = c
 	}
@@ -1778,7 +1807,7 @@ func getPkgWorkspace(commit *object.Commit, p *packageListEntry, ref *plumbing.R
 		klog.Warningf("Error extracting git annotations for package %s: %s", p.path, err)
 	}
 	for _, a := range annotations {
-		if a.PackagePath != p.path {
+		if a.PackagePath != p.pkgKey.ToFullPathname() {
 			continue
 		}
 		if a.WorkspaceName != "" {

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -887,6 +887,14 @@ func (g GitSuite) TestDeletePackages(t *testing.T) {
 			refMustExist(t, repo, rn)
 		}
 
+		gitDeleting := deleting.(*gitPackageRevision)
+		saveRef := gitDeleting.ref
+		gitDeleting.ref = nil
+		if err := git.DeletePackageRevision(ctx, deleting); err == nil {
+			t.Fatalf("DeletePackageRevision(%q) should have failed on nil reference: %v", deleting.KubeObjectName(), err)
+		}
+		gitDeleting.ref = saveRef
+
 		if err := git.DeletePackageRevision(ctx, deleting); err != nil {
 			t.Fatalf("DeletePackageRevision(%q) failed: %v", deleting.KubeObjectName(), err)
 		}

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -199,7 +199,7 @@ func (g GitSuite) TestGitPackageRoundTrip(t *testing.T) {
 			t.Fatalf("ListPackageRevisons failed: %v", err)
 		}
 
-		original := findPackageRevision(t, revisions, repository.PackageRevisionKey{
+		original := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
 			Repository:    repositoryName,
 			Package:       packageName,
 			WorkspaceName: workspace,
@@ -677,7 +677,7 @@ func (g GitSuite) TestApproveDraft(t *testing.T) {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}
 
-	bucket := findPackageRevision(t, revisions, repository.PackageRevisionKey{
+	bucket := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
 		Repository:    repositoryName,
 		Package:       "bucket",
 		WorkspaceName: "v1",
@@ -741,7 +741,7 @@ func (g GitSuite) TestApproveDraftWithHistory(t *testing.T) {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}
 
-	bucket := findPackageRevision(t, revisions, repository.PackageRevisionKey{
+	bucket := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
 		Repository:    repositoryName,
 		Package:       "pkg-with-history",
 		WorkspaceName: "v1",
@@ -919,7 +919,7 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	}
 
 	// Confirm we listed some package(s)
-	findPackageRevision(t, all, repository.PackageRevisionKey{Repository: "refresh", Package: "basens",
+	findPackageRevision(t, all, repository.ListPackageRevisionFilter{Repository: "refresh", Package: "basens",
 		Revision: 2, WorkspaceName: "v2"})
 	packageMustNotExist(t, all, newPackageName)
 
@@ -971,7 +971,7 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListPackageRevisions(Refresh) failed; %v", err)
 	}
-	findPackageRevision(t, all, newPackageName)
+	findPackageRevision(t, all, repository.PRFilterFromKey(newPackageName))
 }
 
 // The test deletes packages on the upstream one by one and validates they were
@@ -1259,7 +1259,7 @@ func (g GitSuite) TestAuthor(t *testing.T) {
 			}
 
 			_ = revisions
-			draftPkg := findPackageRevision(t, revisions, repository.PackageRevisionKey{
+			draftPkg := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
 				Repository:    repositoryName,
 				Package:       tc.pkg,
 				WorkspaceName: tc.workspace,

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -200,9 +200,15 @@ func (g GitSuite) TestGitPackageRoundTrip(t *testing.T) {
 		}
 
 		original := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
-			Repository:    repositoryName,
-			Package:       packageName,
-			WorkspaceName: workspace,
+			Key: repository.PackageRevisionKey{
+				PkgKey: repository.PackageKey{
+					RepoKey: repository.RepositoryKey{
+						Name: repositoryName,
+					},
+					Package: packageName,
+				},
+				WorkspaceName: workspace,
+			},
 		})
 
 		update, err := repo.UpdatePackageRevision(ctx, original)
@@ -554,18 +560,18 @@ func (g GitSuite) TestListPackagesSimple(t *testing.T) {
 	}
 
 	want := map[repository.PackageRevisionKey]v1alpha1.PackageRevisionLifecycle{
-		{Repository: "simple", Package: "empty", Revision: 1, WorkspaceName: "v1"}:   v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "basens", Revision: 1, WorkspaceName: "v1"}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "basens", Revision: 2, WorkspaceName: "v2"}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "istions", Revision: 1, WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "istions", Revision: 2, WorkspaceName: "v2"}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"}:   v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"}: v1alpha1.PackageRevisionLifecyclePublished,
 
 		// TODO: may want to filter these out, for example by including only those package
 		// revisions from main branch that differ in content (their tree hash) from another
 		// taged revision of the package.
-		{Repository: "simple", Package: "empty", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:   v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "basens", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "simple", Package: "istions", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "empty"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:   v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "basens"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "simple"}, Package: "istions"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}: v1alpha1.PackageRevisionLifecyclePublished,
 	}
 
 	got := map[repository.PackageRevisionKey]v1alpha1.PackageRevisionLifecycle{}
@@ -575,8 +581,12 @@ func (g GitSuite) TestListPackagesSimple(t *testing.T) {
 			t.Errorf("didn't expect error, but got %v", err)
 		}
 		got[repository.PackageRevisionKey{
-			Repository:    rev.Spec.RepositoryName,
-			Package:       rev.Spec.PackageName,
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: rev.Spec.RepositoryName,
+				},
+				Package: rev.Spec.PackageName,
+			},
 			WorkspaceName: rev.Spec.WorkspaceName,
 			Revision:      rev.Spec.Revision,
 		}] = rev.Spec.Lifecycle
@@ -615,20 +625,20 @@ func (g GitSuite) TestListPackagesDrafts(t *testing.T) {
 	}
 
 	want := map[repository.PackageRevisionKey]v1alpha1.PackageRevisionLifecycle{
-		{Repository: "drafts", Package: "empty", Revision: 1, WorkspaceName: "v1"}:   v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "basens", Revision: 1, WorkspaceName: "v1"}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "basens", Revision: 2, WorkspaceName: "v2"}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "istions", Revision: 1, WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "istions", Revision: 2, WorkspaceName: "v2"}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"}:   v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"}: v1alpha1.PackageRevisionLifecyclePublished,
 
-		{Repository: "drafts", Package: "bucket", WorkspaceName: "v1"}:           v1alpha1.PackageRevisionLifecycleDraft,
-		{Repository: "drafts", Package: "none", WorkspaceName: "v1"}:             v1alpha1.PackageRevisionLifecycleDraft,
-		{Repository: "drafts", Package: "pkg-with-history", WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecycleDraft,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "bucket"}, WorkspaceName: "v1"}:           v1alpha1.PackageRevisionLifecycleDraft,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "none"}, WorkspaceName: "v1"}:             v1alpha1.PackageRevisionLifecycleDraft,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "pkg-with-history"}, WorkspaceName: "v1"}: v1alpha1.PackageRevisionLifecycleDraft,
 
 		// TODO: filter main branch out? see above
-		{Repository: "drafts", Package: "basens", WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}:  v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "empty", WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}:   v1alpha1.PackageRevisionLifecyclePublished,
-		{Repository: "drafts", Package: "istions", WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}: v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "basens"}, WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}:  v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "empty"}, WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}:   v1alpha1.PackageRevisionLifecyclePublished,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "drafts"}, Package: "istions"}, WorkspaceName: v1alpha1.WorkspaceName(g.branch), Revision: -1}: v1alpha1.PackageRevisionLifecyclePublished,
 	}
 
 	got := map[repository.PackageRevisionKey]v1alpha1.PackageRevisionLifecycle{}
@@ -638,8 +648,12 @@ func (g GitSuite) TestListPackagesDrafts(t *testing.T) {
 			t.Errorf("didn't expect error, but got %v", err)
 		}
 		got[repository.PackageRevisionKey{
-			Repository:    rev.Spec.RepositoryName,
-			Package:       rev.Spec.PackageName,
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: rev.Spec.RepositoryName,
+				},
+				Package: rev.Spec.PackageName,
+			},
 			Revision:      rev.Spec.Revision,
 			WorkspaceName: rev.Spec.WorkspaceName,
 		}] = rev.Spec.Lifecycle
@@ -678,9 +692,12 @@ func (g GitSuite) TestApproveDraft(t *testing.T) {
 	}
 
 	bucket := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
-		Repository:    repositoryName,
-		Package:       "bucket",
-		WorkspaceName: "v1",
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				Package: "bucket",
+			},
+			WorkspaceName: "v1",
+		},
 	})
 
 	// Before Update; Check server references. Draft must exist, final not.
@@ -742,9 +759,15 @@ func (g GitSuite) TestApproveDraftWithHistory(t *testing.T) {
 	}
 
 	bucket := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
-		Repository:    repositoryName,
-		Package:       "pkg-with-history",
-		WorkspaceName: "v1",
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: "pkg-with-history",
+			},
+			WorkspaceName: "v1",
+		},
 	})
 
 	// Before Update; Check server references. Draft must exist, final not.
@@ -803,13 +826,13 @@ func (g GitSuite) TestDeletePackages(t *testing.T) {
 
 	// If we delete one of these packages, we expect the reference to be deleted too
 	wantDeletedRefs := map[repository.PackageRevisionKey]plumbing.ReferenceName{
-		{Repository: "delete", Package: "bucket", Revision: 1}:  "refs/heads/drafts/bucket/v1",
-		{Repository: "delete", Package: "none", Revision: 1}:    "refs/heads/drafts/none/v1",
-		{Repository: "delete", Package: "basens", Revision: 1}:  "refs/tags/basens/v1",
-		{Repository: "delete", Package: "basens", Revision: 2}:  "refs/tags/basens/v2",
-		{Repository: "delete", Package: "empty", Revision: 1}:   "refs/tags/empty/v1",
-		{Repository: "delete", Package: "istions", Revision: 1}: "refs/tags/istions/v1",
-		{Repository: "delete", Package: "istions", Revision: 2}: "refs/tags/istions/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "bucket"}, Revision: 1}:  "refs/heads/drafts/bucket/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "none"}, Revision: 1}:    "refs/heads/drafts/none/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "basens"}, Revision: 1}:  "refs/tags/basens/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "basens"}, Revision: 2}:  "refs/tags/basens/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "empty"}, Revision: 1}:   "refs/tags/empty/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "istions"}, Revision: 1}: "refs/tags/istions/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "delete"}, Package: "istions"}, Revision: 2}: "refs/tags/istions/v2",
 	}
 
 	// Delete all packages
@@ -825,8 +848,16 @@ func (g GitSuite) TestDeletePackages(t *testing.T) {
 		if err != nil {
 			t.Fatalf("didn't expect error, but got %v", err)
 		}
-		name := repository.PackageRevisionKey{Repository: pr.Spec.RepositoryName, Package: pr.Spec.PackageName,
-			Revision: pr.Spec.Revision, WorkspaceName: pr.Spec.WorkspaceName}
+		name := repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: pr.Spec.RepositoryName,
+				},
+				Package: pr.Spec.PackageName,
+			},
+			Revision:      pr.Spec.Revision,
+			WorkspaceName: pr.Spec.WorkspaceName,
+		}
 
 		if rn, ok := wantDeletedRefs[name]; ok {
 			// Verify the reference still exists
@@ -899,8 +930,12 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	)
 
 	newPackageName := repository.PackageRevisionKey{
-		Repository:    "refresh",
-		Package:       "newpkg",
+		PkgKey: repository.PackageKey{
+			RepoKey: repository.RepositoryKey{
+				Name: "refresh",
+			},
+			Package: "newpkg",
+		},
 		Revision:      3,
 		WorkspaceName: "v3",
 	}
@@ -919,8 +954,17 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	}
 
 	// Confirm we listed some package(s)
-	findPackageRevision(t, all, repository.ListPackageRevisionFilter{Repository: "refresh", Package: "basens",
-		Revision: 2, WorkspaceName: "v2"})
+	findPackageRevision(t, all, repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: "refresh",
+				},
+				Package: "basens",
+			},
+			Revision:      2,
+			WorkspaceName: "v2",
+		}})
 	packageMustNotExist(t, all, newPackageName)
 
 	// Create package in the upstream repository
@@ -971,7 +1015,7 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListPackageRevisions(Refresh) failed; %v", err)
 	}
-	findPackageRevision(t, all, repository.PRFilterFromKey(newPackageName))
+	findPackageRevision(t, all, repository.ListPackageRevisionFilter{Key: newPackageName})
 }
 
 // The test deletes packages on the upstream one by one and validates they were
@@ -1002,31 +1046,31 @@ func (g GitSuite) TestPruneRemotes(t *testing.T) {
 	}{
 		{
 			ref: "refs/heads/drafts/bucket/v1",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "bucket", WorkspaceName: "v1"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "bucket"}, WorkspaceName: "v1"},
 		},
 		{
 			ref: "refs/heads/drafts/none/v1",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "none", WorkspaceName: "v1"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "none"}, WorkspaceName: "v1"},
 		},
 		{
 			ref: "refs/tags/basens/v1",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "basens", Revision: 1, WorkspaceName: "v1"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"},
 		},
 		{
 			ref: "refs/tags/basens/v2",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "basens", Revision: 2, WorkspaceName: "v2"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"},
 		},
 		{
 			ref: "refs/tags/empty/v1",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "empty", Revision: 1, WorkspaceName: "v1"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"},
 		},
 		{
 			ref: "refs/tags/istions/v1",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "istions", Revision: 1, WorkspaceName: "v1"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"},
 		},
 		{
 			ref: "refs/tags/istions/v2",
-			pkg: repository.PackageRevisionKey{Repository: "prune", Package: "istions", Revision: 2, WorkspaceName: "v2"},
+			pkg: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "prune"}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"},
 		},
 	} {
 		repositoryMustHavePackageRevision(t, git, pair.pkg)
@@ -1094,7 +1138,7 @@ func (g GitSuite) TestNested(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't expect error, but got %v", err)
 		}
-		if rev.Spec.Revision == repository.Revision2Int(g.branch) {
+		if rev.Spec.Revision == -1 {
 			// skip packages with the revision of the main registered branch,
 			// to match the above simplified package discovery algo.
 			continue
@@ -1116,9 +1160,9 @@ func createPackageRevisionMap(revisions []repository.PackageRevision) map[string
 	for _, pr := range revisions {
 		key := pr.Key()
 		if key.WorkspaceName != "" {
-			result[fmt.Sprintf("%s/%s", key.Package, key.WorkspaceName)] = true
+			result[fmt.Sprintf("%s/%s", key.PkgKey.Package, key.WorkspaceName)] = true
 		} else {
-			result[fmt.Sprintf("%s/%d", key.Package, key.Revision)] = true
+			result[fmt.Sprintf("%s/%d", key.PkgKey.Package, key.Revision)] = true
 		}
 	}
 	return result
@@ -1141,7 +1185,7 @@ func (g GitSuite) TestNestedDirectories(t *testing.T) {
 	}{
 		{
 			directory: "sample",
-			packages:  []string{"/v1", "/v2", "/" + g.branch},
+			packages:  []string{"sample/v1", "sample/v2", "sample/" + g.branch},
 		},
 		{
 			directory: "nonexistent",
@@ -1260,10 +1304,16 @@ func (g GitSuite) TestAuthor(t *testing.T) {
 
 			_ = revisions
 			draftPkg := findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
-				Repository:    repositoryName,
-				Package:       tc.pkg,
-				WorkspaceName: tc.workspace,
-				Revision:      tc.revision,
+				Key: repository.PackageRevisionKey{
+					PkgKey: repository.PackageKey{
+						RepoKey: repository.RepositoryKey{
+							Name: repositoryName,
+						},
+						Package: tc.pkg,
+					},
+					WorkspaceName: v1alpha1.WorkspaceName(tc.workspace),
+					Revision:      tc.revision,
+				},
 			})
 			rev, err := draftPkg.GetPackageRevision(ctx)
 			if err != nil {

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -919,7 +919,7 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	}
 
 	// Confirm we listed some package(s)
-	findPackageRevision(t, all, repository.ListPackageRevisionFilter{Repository: "refresh", Package: "basens",
+	findPackageRevision(t, all, repository.PackageRevisionKey{Repository: "refresh", Package: "basens",
 		Revision: 2, WorkspaceName: "v2"})
 	packageMustNotExist(t, all, newPackageName)
 

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -919,7 +919,7 @@ func (g GitSuite) TestRefreshRepo(t *testing.T) {
 	}
 
 	// Confirm we listed some package(s)
-	findPackageRevision(t, all, repository.PackageRevisionKey{Repository: "refresh", Package: "basens",
+	findPackageRevision(t, all, repository.ListPackageRevisionFilter{Repository: "refresh", Package: "basens",
 		Revision: 2, WorkspaceName: "v2"})
 	packageMustNotExist(t, all, newPackageName)
 

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -1362,7 +1362,7 @@ func TestDiscoverManuallyTaggedPackageWithTagMessage(t *testing.T) {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
 
-	expectedRevisions := []string{"main", "v1", "v2"}
+	expectedRevisions := []int{-1, 1, 2}
 
 	prs, err := git.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
 	if err != nil {
@@ -1394,9 +1394,9 @@ func TestDiscoverWithBadKptAnnotationFromNestedRepository(t *testing.T) {
 		deployment     = false
 	)
 
-	expectedRevisions := map[string][]string{
-		"bp1": {"main", "v1", "v2", "v3"},
-		"bp2": {"main", "v1", "v2"},
+	expectedRevisions := map[string][]int{
+		"bp1": {-1, 1, 2, 3},
+		"bp2": {-1, 1, 2},
 	}
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
@@ -1449,7 +1449,7 @@ func TestDiscoverWithBadKptAnnotationFromNestedRepositoryFromUnrelatedSubReposit
 		packageName    = "bp10"
 	)
 
-	expectedRevisions := []string{"main", "v1"}
+	expectedRevisions := []int{-1, 1}
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -115,6 +115,29 @@ func (g GitSuite) TestOpenEmptyRepository(t *testing.T) {
 	}
 }
 
+func (g GitSuite) TestOpenBadDirectoryRepository(t *testing.T) {
+	tempdir := t.TempDir()
+	tarfile := filepath.Join("testdata", "empty-repository.tar")
+	_, address := ServeGitRepositoryWithBranch(t, tarfile, tempdir, g.branch)
+
+	ctx := context.Background()
+	const (
+		name       = "empty"
+		namespace  = "default"
+		deployment = true
+	)
+
+	repository := &configapi.GitRepository{
+		Repo:      address,
+		Branch:    g.branch,
+		Directory: "/illegal$$$Characters",
+	}
+
+	if _, err := OpenRepository(ctx, name, namespace, repository, deployment, tempdir, GitRepositoryOptions{}); err == nil {
+		t.Errorf("Unexpectedly succeeded opening repository with bad directory name.")
+	}
+}
+
 // TestGitPackageRoundTrip creates a package in git and verifies we can read the contents back.
 func (g GitSuite) TestGitPackageRoundTrip(t *testing.T) {
 	tempdir := t.TempDir()

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -115,7 +115,7 @@ func (g GitSuite) TestOpenEmptyRepository(t *testing.T) {
 	}
 }
 
-func (g GitSuite) TestOpenBadDirectoryRepository(t *testing.T) {
+func (g GitSuite) TestOpenRepositoryBadBranchName(t *testing.T) {
 	tempdir := t.TempDir()
 	tarfile := filepath.Join("testdata", "empty-repository.tar")
 	_, address := ServeGitRepositoryWithBranch(t, tarfile, tempdir, g.branch)
@@ -129,12 +129,12 @@ func (g GitSuite) TestOpenBadDirectoryRepository(t *testing.T) {
 
 	repository := &configapi.GitRepository{
 		Repo:      address,
-		Branch:    g.branch,
-		Directory: "/illegal$$$Characters",
+		Branch:    "illegal$$$Characters",
+		Directory: "/",
 	}
 
 	if _, err := OpenRepository(ctx, name, namespace, repository, deployment, tempdir, GitRepositoryOptions{}); err == nil {
-		t.Errorf("Unexpectedly succeeded opening repository with bad directory name.")
+		t.Errorf("Unexpectedly succeeded opening repository with a bad branch name.")
 	}
 }
 

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -33,10 +33,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	uuidSpace = "aac71d91-5c67-456f-8fd2-902ef6da820e"
-)
-
 type gitPackageRevision struct {
 	repo          *gitRepository // repo is repo containing the package
 	path          string         // the path to the package from the repo root

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -122,7 +122,7 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 			},
 		},
 		Spec: v1alpha1.PackageRevisionSpec{
-			PackageName:    key.PkgKey.ToFullPathname(),
+			PackageName:    key.PkgKey.ToPkgPathname(),
 			RepositoryName: key.PkgKey.RepoKey.Name,
 			Lifecycle:      p.Lifecycle(ctx),
 			Tasks:          p.tasks,
@@ -156,7 +156,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			OwnerReferences: []metav1.OwnerReference{}, // TODO: should point to repository resource
 		},
 		Spec: v1alpha1.PackageRevisionResourcesSpec{
-			PackageName:    p.Key().PkgKey.ToFullPathname(),
+			PackageName:    p.Key().PkgKey.ToPkgPathname(),
 			WorkspaceName:  p.Key().WorkspaceName,
 			Revision:       p.Key().Revision,
 			RepositoryName: p.Key().PkgKey.RepoKey.Name,
@@ -240,14 +240,14 @@ func (p *gitPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, 
 			Type: kptfile.GitOrigin,
 			Git: &kptfile.Git{
 				Repo:      repo,
-				Directory: p.prKey.PkgKey.RepoKey.Path,
+				Directory: p.prKey.PkgKey.ToPkgPathname(),
 				Ref:       ref.Short(),
 			},
 		}, kptfile.UpstreamLock{
 			Type: kptfile.GitOrigin,
 			Git: &kptfile.GitLock{
 				Repo:      repo,
-				Directory: p.prKey.PkgKey.RepoKey.Path,
+				Directory: p.prKey.PkgKey.ToPkgPathname(),
 				Ref:       ref.Short(),
 				Commit:    p.commit.String(),
 			},

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -49,26 +49,8 @@ type gitPackageRevision struct {
 
 var _ repository.PackageRevision = &gitPackageRevision{}
 
-// Kubernetes resource names requirements do not allow to encode arbitrary directory
-// path: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-// Because we need a resource names that are stable over time, and avoid conflict, we
-// compute a hash of the package path and revision.
-// For implementation convenience (though this is temporary) we prepend the repository
-// name in order to aide package discovery on the server. With improvements to caching
-// layer, the prefix will be removed (this may happen without notice) so it should not
-// be relied upon by clients.
-func (p *gitPackageRevision) KubeObjectName() string {
-	// The published package revisions on the working branch will have the same workspaceName
-	// as the most recently published package revision, so we need to ensure it has a unique
-	// and unchanging name.
-	var s string
-	if p.revision == -1 {
-		s = string(p.repo.branch)
-	} else {
-		s = string(p.Key().WorkspaceName)
-	}
-
-	return util.ComposePkgRevObjName(p.repo.name, p.repo.directory, p.Key().Package, s)
+func (c *gitPackageRevision) KubeObjectName() string {
+	return repository.ComposePkgRevObjName(c.Key())
 }
 
 func (c *gitPackageRevision) KubeObjectNamespace() string {

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -68,8 +68,8 @@ func (p *gitPackageRevision) KubeObjectName() string {
 	// as the most recently published package revision, so we need to ensure it has a unique
 	// and unchanging name.
 	var s string
-	if p.Key().Revision == string(p.repo.branch) {
-		s = p.Key().Revision
+	if p.revision == -1 {
+		s = string(p.repo.branch)
 	} else {
 		s = string(p.Key().WorkspaceName)
 	}

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -49,8 +49,26 @@ type gitPackageRevision struct {
 
 var _ repository.PackageRevision = &gitPackageRevision{}
 
-func (c *gitPackageRevision) KubeObjectName() string {
-	return repository.ComposePkgRevObjName(c.Key())
+// Kubernetes resource names requirements do not allow to encode arbitrary directory
+// path: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+// Because we need a resource names that are stable over time, and avoid conflict, we
+// compute a hash of the package path and revision.
+// For implementation convenience (though this is temporary) we prepend the repository
+// name in order to aide package discovery on the server. With improvements to caching
+// layer, the prefix will be removed (this may happen without notice) so it should not
+// be relied upon by clients.
+func (p *gitPackageRevision) KubeObjectName() string {
+	// The published package revisions on the working branch will have the same workspaceName
+	// as the most recently published package revision, so we need to ensure it has a unique
+	// and unchanging name.
+	var s string
+	if p.revision == -1 {
+		s = string(p.repo.branch)
+	} else {
+		s = string(p.Key().WorkspaceName)
+	}
+
+	return util.ComposePkgRevObjName(p.repo.name, p.repo.directory, p.Key().Package, s)
 }
 
 func (c *gitPackageRevision) KubeObjectNamespace() string {

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -106,7 +106,6 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 		}
 	}
 
-	// TODO: Should we support nested packages?
 	return &v1alpha1.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -98,7 +98,7 @@ func (g GitSuite) TestLock(t *testing.T) {
 			Ref:       upstream.Git.Ref,
 		}), (gitAddress{
 			Repo:      address,
-			Directory: key.PkgKey.RepoKey.Path,
+			Directory: key.PkgKey.ToFullPathname(),
 			Ref:       wantRef,
 		}); !cmp.Equal(want, got) {
 			t.Errorf("Package upstream differs (-want,+got): %s", cmp.Diff(want, got))
@@ -111,7 +111,7 @@ func (g GitSuite) TestLock(t *testing.T) {
 			Ref:       lock.Git.Ref,
 		}), (gitAddress{
 			Repo:      address,
-			Directory: key.PkgKey.RepoKey.Path,
+			Directory: key.PkgKey.ToFullPathname(),
 			Ref:       wantRef,
 		}); !cmp.Equal(want, got) {
 			t.Errorf("Package upstream lock differs (-want,+got): %s", cmp.Diff(want, got))

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -25,6 +25,8 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	v1 "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func (g GitSuite) TestLock(t *testing.T) {
@@ -124,4 +126,23 @@ func (g GitSuite) TestLock(t *testing.T) {
 			t.Errorf("Commit: got %s, want %s", got, want)
 		}
 	}
+}
+
+func TestPackageGetters(t *testing.T) {
+	gitPr := gitPackageRevision{
+		prKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name:      "my-repo",
+					Namespace: "my-namespace",
+				},
+				Package: "my-package",
+			},
+			WorkspaceName: "my-workspace",
+		},
+	}
+
+	assert.Equal(t, "my-repo.my-package.my-workspace", gitPr.KubeObjectName())
+	assert.Equal(t, "my-namespace", gitPr.KubeObjectNamespace())
+	assert.Equal(t, types.UID("7007e8aa-0928-50f9-b980-92a44942f055"), gitPr.UID())
 }

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -54,15 +54,15 @@ func (g GitSuite) TestLock(t *testing.T) {
 	}
 
 	wantRefs := map[repository.PackageRevisionKey]string{
-		{Repository: repositoryName, Package: "empty", Revision: 1, WorkspaceName: "v1"}:   "empty/v1",
-		{Repository: repositoryName, Package: "basens", Revision: 1, WorkspaceName: "v1"}:  "basens/v1",
-		{Repository: repositoryName, Package: "basens", Revision: 2, WorkspaceName: "v2"}:  "basens/v2",
-		{Repository: repositoryName, Package: "istions", Revision: 1, WorkspaceName: "v1"}: "istions/v1",
-		{Repository: repositoryName, Package: "istions", Revision: 2, WorkspaceName: "v2"}: "istions/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"}:   "empty/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"}:  "basens/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"}:  "basens/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"}: "istions/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"}: "istions/v2",
 
-		{Repository: repositoryName, Package: "basens", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:  g.branch,
-		{Repository: repositoryName, Package: "empty", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:   g.branch,
-		{Repository: repositoryName, Package: "istions", Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}: g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:  g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "empty"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:   g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}: g.branch,
 	}
 
 	for _, rev := range revisions {
@@ -82,8 +82,6 @@ func (g GitSuite) TestLock(t *testing.T) {
 		}
 
 		key := rev.Key()
-		key.Namespace = ""
-		key.PlaceholderWSname = ""
 		wantRef, ok := wantRefs[key]
 		if !ok {
 			t.Errorf("Unexpected package found; %q", rev.Key())
@@ -100,7 +98,7 @@ func (g GitSuite) TestLock(t *testing.T) {
 			Ref:       upstream.Git.Ref,
 		}), (gitAddress{
 			Repo:      address,
-			Directory: key.Package,
+			Directory: key.PkgKey.RepoKey.Path,
 			Ref:       wantRef,
 		}); !cmp.Equal(want, got) {
 			t.Errorf("Package upstream differs (-want,+got): %s", cmp.Diff(want, got))
@@ -113,7 +111,7 @@ func (g GitSuite) TestLock(t *testing.T) {
 			Ref:       lock.Git.Ref,
 		}), (gitAddress{
 			Repo:      address,
-			Directory: key.Package,
+			Directory: key.PkgKey.RepoKey.Path,
 			Ref:       wantRef,
 		}); !cmp.Equal(want, got) {
 			t.Errorf("Package upstream lock differs (-want,+got): %s", cmp.Diff(want, got))

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -54,15 +54,15 @@ func (g GitSuite) TestLock(t *testing.T) {
 	}
 
 	wantRefs := map[repository.PackageRevisionKey]string{
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"}:   "empty/v1",
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"}:  "basens/v1",
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"}:  "basens/v2",
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"}: "istions/v1",
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"}: "istions/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "empty"}, Revision: 1, WorkspaceName: "v1"}:   "empty/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "basens"}, Revision: 1, WorkspaceName: "v1"}:  "basens/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "basens"}, Revision: 2, WorkspaceName: "v2"}:  "basens/v2",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "istions"}, Revision: 1, WorkspaceName: "v1"}: "istions/v1",
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "istions"}, Revision: 2, WorkspaceName: "v2"}: "istions/v2",
 
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "basens"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:  g.branch,
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "empty"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}:   g.branch,
-		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: v1alpha1.WorkspaceName(g.branch)}, Package: "istions"}, Revision: -1, WorkspaceName: v1alpha1.WorkspaceName(g.branch)}: g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "basens"}, Revision: -1, WorkspaceName: g.branch}:  g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "empty"}, Revision: -1, WorkspaceName: g.branch}:   g.branch,
+		{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Namespace: "default", Name: repositoryName, PlaceholderWSname: g.branch}, Package: "istions"}, Revision: -1, WorkspaceName: g.branch}: g.branch,
 	}
 
 	for _, rev := range revisions {

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -82,6 +82,8 @@ func (g GitSuite) TestLock(t *testing.T) {
 		}
 
 		key := rev.Key()
+		key.Namespace = ""
+		key.PlaceholderWSname = ""
 		wantRef, ok := wantRefs[key]
 		if !ok {
 			t.Errorf("Unexpected package found; %q", rev.Key())

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -82,8 +82,6 @@ func (g GitSuite) TestLock(t *testing.T) {
 		}
 
 		key := rev.Key()
-		key.Namespace = ""
-		key.PlaceholderWSname = ""
 		wantRef, ok := wantRefs[key]
 		if !ok {
 			t.Errorf("Unexpected package found; %q", rev.Key())

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -16,7 +16,6 @@ package git
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"time"
@@ -24,7 +23,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	"k8s.io/klog/v2"
 )
@@ -55,7 +53,7 @@ type packageListEntry struct {
 
 // buildGitPackageRevision creates a gitPackageRevision for the packageListEntry
 // TODO: Can packageListEntry just _be_ a gitPackageRevision?
-func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revisionStr string, workspace v1alpha1.WorkspaceName, ref *plumbing.Reference) (*gitPackageRevision, error) {
+func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revisionStr, workspace string, ref *plumbing.Reference) (*gitPackageRevision, error) {
 	repo := p.parent.parent
 
 	var updated time.Time
@@ -81,7 +79,7 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 			updated = commit.Author.When
 			updatedBy = commit.Author.Email
 		} else {
-			klog.Warningf("Cannot find latest package commit for package %s/%s: %s", p.path, revision, err)
+			klog.Warningf("Cannot find latest package commit for package %s/%s: %s", p.pkgKey.String(), revisionStr, err)
 		}
 		// If not commit was found with the porch commit tags, we don't really
 		// know who approved the package or when it happend. We could find this
@@ -96,9 +94,9 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 	revision := repository.Revision2Int(revisionStr)
 	if workspace == "" {
 		if revision == -1 {
-			workspace = v1alpha1.WorkspaceName(revisionStr)
+			workspace = revisionStr
 		} else {
-			workspace = "v" + v1alpha1.WorkspaceName(repository.Revision2Str(revision))
+			workspace = "v" + repository.Revision2Str(revision)
 		}
 	}
 

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/ref.go
+++ b/pkg/externalrepo/git/ref.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 )
 
@@ -121,16 +120,16 @@ func getTagNameInLocalRepo(n plumbing.ReferenceName) (string, bool) {
 	return trimOptionalPrefix(n.String(), tagsPrefixInLocalRepo)
 }
 
-func createDraftName(pkg string, wn string) BranchName {
-	return BranchName(draftsPrefix + pkg + "/" + wn)
+func createDraftName(key repository.PackageRevisionKey) BranchName {
+	return BranchName(draftsPrefix + key.PkgKey.ToFullPathname() + "/" + string(key.WorkspaceName))
 }
 
-func createProposedName(pkg string, wn string) BranchName {
-	return BranchName(proposedPrefix + pkg + "/" + wn)
+func createProposedName(key repository.PackageRevisionKey) BranchName {
+	return BranchName(proposedPrefix + key.PkgKey.ToFullPathname() + "/" + string(key.WorkspaceName))
 }
 
-func createDeletionProposedName(pkg string, revision int) BranchName {
-	return BranchName(deletionProposedPrefix + pkg + "/v" + repository.Revision2Str(revision))
+func createDeletionProposedName(key repository.PackageRevisionKey) BranchName {
+	return BranchName(deletionProposedPrefix + key.PkgKey.ToFullPathname() + "/v" + repository.Revision2Str(key.Revision))
 }
 
 func trimOptionalPrefix(s, prefix string) (string, bool) {
@@ -140,8 +139,8 @@ func trimOptionalPrefix(s, prefix string) (string, bool) {
 	return "", false
 }
 
-func createFinalTagNameInLocal(pkg string, rev int) plumbing.ReferenceName {
-	return plumbing.ReferenceName(tagsPrefixInLocalRepo + pkg + "/v" + repository.Revision2Str(rev))
+func createFinalTagNameInLocal(key repository.PackageRevisionKey) plumbing.ReferenceName {
+	return plumbing.ReferenceName(tagsPrefixInLocalRepo + key.PkgKey.ToFullPathname() + "/v" + repository.Revision2Str(key.Revision))
 }
 
 func refInLocalFromRefInRemote(n plumbing.ReferenceName) (plumbing.ReferenceName, error) {

--- a/pkg/externalrepo/git/ref.go
+++ b/pkg/externalrepo/git/ref.go
@@ -16,6 +16,7 @@ package git
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5/config"
@@ -121,15 +122,15 @@ func getTagNameInLocalRepo(n plumbing.ReferenceName) (string, bool) {
 }
 
 func createDraftName(key repository.PackageRevisionKey) BranchName {
-	return BranchName(draftsPrefix + key.PkgKey.ToFullPathname() + "/" + string(key.WorkspaceName))
+	return BranchName(draftsPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
 }
 
 func createProposedName(key repository.PackageRevisionKey) BranchName {
-	return BranchName(proposedPrefix + key.PkgKey.ToFullPathname() + "/" + string(key.WorkspaceName))
+	return BranchName(proposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
 }
 
 func createDeletionProposedName(key repository.PackageRevisionKey) BranchName {
-	return BranchName(deletionProposedPrefix + key.PkgKey.ToFullPathname() + "/v" + repository.Revision2Str(key.Revision))
+	return BranchName(deletionProposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), "/v"+repository.Revision2Str(key.Revision)))
 }
 
 func trimOptionalPrefix(s, prefix string) (string, bool) {
@@ -140,7 +141,7 @@ func trimOptionalPrefix(s, prefix string) (string, bool) {
 }
 
 func createFinalTagNameInLocal(key repository.PackageRevisionKey) plumbing.ReferenceName {
-	return plumbing.ReferenceName(tagsPrefixInLocalRepo + key.PkgKey.ToFullPathname() + "/v" + repository.Revision2Str(key.Revision))
+	return plumbing.ReferenceName(tagsPrefixInLocalRepo + filepath.Join(key.PkgKey.ToFullPathname(), "/v"+repository.Revision2Str(key.Revision)))
 }
 
 func refInLocalFromRefInRemote(n plumbing.ReferenceName) (plumbing.ReferenceName, error) {

--- a/pkg/externalrepo/git/ref.go
+++ b/pkg/externalrepo/git/ref.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/git/testing_repo.go
+++ b/pkg/externalrepo/git/testing_repo.go
@@ -299,7 +299,9 @@ func repositoryMustHavePackageRevision(t *testing.T, git GitRepository, prKey re
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}
 
-	findPackageRevision(t, list, repository.PRFilterFromKey(prKey))
+	findPackageRevision(t, list, repository.ListPackageRevisionFilter{
+		Key: prKey,
+	})
 }
 
 func repositoryMustNotHavePackageRevision(t *testing.T, git GitRepository, name repository.PackageRevisionKey) {

--- a/pkg/externalrepo/git/testing_repo.go
+++ b/pkg/externalrepo/git/testing_repo.go
@@ -269,15 +269,15 @@ func findFile(t *testing.T, tree *object.Tree, path string) *object.File {
 	return file
 }
 
-func findPackageRevision(t *testing.T, revisions []repository.PackageRevision, key repository.PackageRevisionKey) repository.PackageRevision {
+func findPackageRevision(t *testing.T, revisions []repository.PackageRevision, filter repository.ListPackageRevisionFilter) repository.PackageRevision {
 	t.Helper()
 
 	for _, r := range revisions {
-		if r.Key() == key {
+		if filter.Matches(context.Background(), r) {
 			return r
 		}
 	}
-	t.Fatalf("PackageRevision %q not found", key)
+	t.Fatalf("PackageRevision %q not found", filter)
 	return nil
 }
 
@@ -291,14 +291,15 @@ func packageMustNotExist(t *testing.T, revisions []repository.PackageRevision, k
 	}
 }
 
-func repositoryMustHavePackageRevision(t *testing.T, git GitRepository, name repository.PackageRevisionKey) {
+func repositoryMustHavePackageRevision(t *testing.T, git GitRepository, prKey repository.PackageRevisionKey) {
 	t.Helper()
 
 	list, err := git.ListPackageRevisions(context.Background(), repository.ListPackageRevisionFilter{})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}
-	findPackageRevision(t, list, name)
+
+	findPackageRevision(t, list, repository.PRFilterFromKey(prKey))
 }
 
 func repositoryMustNotHavePackageRevision(t *testing.T, git GitRepository, name repository.PackageRevisionKey) {

--- a/pkg/externalrepo/oci/loader.go
+++ b/pkg/externalrepo/oci/loader.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/oci/mutate.go
+++ b/pkg/externalrepo/oci/mutate.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/externalrepo/oci/mutate.go
+++ b/pkg/externalrepo/oci/mutate.go
@@ -296,7 +296,7 @@ func (r *ociRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 		return nil, fmt.Errorf("error getting config file: %w", err)
 	}
 
-	return p.parent.buildPackageRevision(ctx, digestName, p.Key().PkgKey.Package, v1alpha1.WorkspaceName(p.tag.TagStr()), revision, configFile.Created.Time)
+	return p.parent.buildPackageRevision(ctx, digestName, p.Key().PkgKey.Package, p.tag.TagStr(), revision, configFile.Created.Time)
 }
 
 func constructResourceVersion(t time.Time) string {

--- a/pkg/externalrepo/oci/mutate.go
+++ b/pkg/externalrepo/oci/mutate.go
@@ -68,8 +68,8 @@ func (r *ociRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 
 func (r *ociRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
 	oldPackage := old.(*ociPackageRevision)
-	packageName := oldPackage.packageName
-	workspace := oldPackage.workspaceName
+	packageName := oldPackage.Key().Package
+	workspace := oldPackage.Key().WorkspaceName
 	// digestName := oldPackage.digestName
 
 	ociRepo, err := name.NewRepository(path.Join(r.spec.Registry, packageName))
@@ -297,8 +297,8 @@ func constructUID(ref string) types.UID {
 
 func (r *ociRepository) DeletePackageRevision(ctx context.Context, old repository.PackageRevision) error {
 	oldPackage := old.(*ociPackageRevision)
-	packageName := oldPackage.packageName
-	workspace := oldPackage.workspaceName
+	packageName := oldPackage.Key().Package
+	workspace := oldPackage.Key().WorkspaceName
 
 	ociRepo, err := name.NewRepository(path.Join(r.spec.Registry, packageName))
 	if err != nil {

--- a/pkg/externalrepo/oci/mutate_test.go
+++ b/pkg/externalrepo/oci/mutate_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/pkg/oci"
+	"github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateUpdatePackageRevision(t *testing.T) {
+	ociRepo := ociRepository{}
+	ociRepo.storage = &oci.Storage{}
+
+	ociRepo.spec.Registry = "my-registry"
+
+	apiPr := &v1alpha1.PackageRevision{
+		Spec: v1alpha1.PackageRevisionSpec{
+			PackageName:   "my-package-name",
+			WorkspaceName: "my-wprkspace",
+		},
+	}
+
+	_, err := ociRepo.CreatePackageRevision(context.TODO(), apiPr)
+	assert.True(t, err != nil)
+
+	ociRepo.name = "my-repo"
+	_, err = ociRepo.CreatePackageRevision(context.TODO(), apiPr)
+	assert.False(t, err != nil)
+
+	oldPr := ociPackageRevision{}
+
+	_, err = ociRepo.UpdatePackageRevision(context.TODO(), &oldPr)
+	assert.True(t, err != nil)
+}

--- a/pkg/externalrepo/oci/mutate_test.go
+++ b/pkg/externalrepo/oci/mutate_test.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/pkg/oci"
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/nephio-project/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateUpdatePackageRevision(t *testing.T) {
+func TestCreateUpdateDeletePackageRevision(t *testing.T) {
 	ociRepo := ociRepository{}
 	ociRepo.storage = &oci.Storage{}
 
@@ -40,11 +41,21 @@ func TestCreateUpdatePackageRevision(t *testing.T) {
 	assert.True(t, err != nil)
 
 	ociRepo.name = "my-repo"
-	_, err = ociRepo.CreatePackageRevision(context.TODO(), apiPr)
+	draftPr, err := ociRepo.CreatePackageRevision(context.TODO(), apiPr)
 	assert.False(t, err != nil)
+
+	draftPrKey := repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			Package: "my-package-name",
+		},
+	}
+	assert.Equal(t, draftPrKey, draftPr.Key())
 
 	oldPr := ociPackageRevision{}
 
 	_, err = ociRepo.UpdatePackageRevision(context.TODO(), &oldPr)
+	assert.True(t, err != nil)
+
+	err = ociRepo.DeletePackageRevision(context.TODO(), &oldPr)
 	assert.True(t, err != nil)
 }

--- a/pkg/externalrepo/oci/oci.go
+++ b/pkg/externalrepo/oci/oci.go
@@ -254,9 +254,6 @@ func (p *ociPackageRevision) ToMainPackageRevision() repository.PackageRevision 
 type ociPackageRevision struct {
 	prKey           repository.PackageRevisionKey
 	digestName      oci.ImageDigestName
-	packageName     string
-	revision        int
-	workspaceName   v1alpha1.WorkspaceName
 	created         time.Time
 	resourceVersion string
 	uid             types.UID

--- a/pkg/externalrepo/oci/oci.go
+++ b/pkg/externalrepo/oci/oci.go
@@ -161,7 +161,7 @@ func (r *ociRepository) ListPackageRevisions(ctx context.Context, filter reposit
 							Package: childName,
 						},
 
-						WorkspaceName: v1alpha1.WorkspaceName(tag),
+						WorkspaceName: tag,
 					},
 					created:         created,
 					parent:          r,
@@ -201,8 +201,8 @@ func (r *ociRepository) ListPackages(ctx context.Context, filter repository.List
 	return nil, fmt.Errorf("ListPackages not supported for OCI packages")
 }
 
-func (r *ociRepository) buildPackageRevision(ctx context.Context, name oci.ImageDigestName, packageName string,
-	workspace v1alpha1.WorkspaceName, revision int, created time.Time) (repository.PackageRevision, error) {
+func (r *ociRepository) buildPackageRevision(ctx context.Context, name oci.ImageDigestName, packageName, workspace string,
+	revision int, created time.Time) (repository.PackageRevision, error) {
 
 	ctx, span := tracer.Start(ctx, "ociRepository::buildPackageRevision")
 	defer span.End()
@@ -210,7 +210,7 @@ func (r *ociRepository) buildPackageRevision(ctx context.Context, name oci.Image
 	// for backwards compatibility with packages that existed before porch supported
 	// workspaces, we populate the workspaceName as the revision number if it is empty
 	if workspace == "" {
-		workspace = v1alpha1.WorkspaceName(repository.Revision2Str(revision))
+		workspace = repository.Revision2Str(revision)
 	}
 
 	p := &ociPackageRevision{

--- a/pkg/externalrepo/oci/oci.go
+++ b/pkg/externalrepo/oci/oci.go
@@ -254,6 +254,9 @@ func (p *ociPackageRevision) ToMainPackageRevision() repository.PackageRevision 
 type ociPackageRevision struct {
 	prKey           repository.PackageRevisionKey
 	digestName      oci.ImageDigestName
+	packageName     string
+	revision        int
+	workspaceName   v1alpha1.WorkspaceName
 	created         time.Time
 	resourceVersion string
 	uid             types.UID

--- a/pkg/externalrepo/oci/oci_test.go
+++ b/pkg/externalrepo/oci/oci_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/kpt/pkg/oci"
+	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestBuildPackageRevision(t *testing.T) {
+	ociRepo := ociRepository{}
+	ociRepo.storage = &oci.Storage{}
+
+	digestName := oci.ImageDigestName{
+		Image:  "",
+		Digest: "my-digest",
+	}
+	_, err := ociRepo.buildPackageRevision(context.TODO(), digestName, "package-name", "workspace_name", 1, time.Now())
+	assert.True(t, err != nil)
+}
+
+func TestPackageGetters(t *testing.T) {
+	fakePr := ociPackageRevision{
+		prKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name:      "my-repo",
+					Namespace: "my-namespace",
+				},
+				Package: "my-package",
+			},
+			WorkspaceName: "my-workspace",
+		},
+	}
+
+	assert.Equal(t, "my-repo.my-package.my-workspace", fakePr.KubeObjectName())
+	assert.Equal(t, "my-namespace", fakePr.KubeObjectNamespace())
+	assert.Equal(t, types.UID("7007e8aa-0928-50f9-b980-92a44942f055"), fakePr.UID())
+}

--- a/pkg/externalrepo/oci/oci_test.go
+++ b/pkg/externalrepo/oci/oci_test.go
@@ -35,6 +35,9 @@ func TestBuildPackageRevision(t *testing.T) {
 	}
 	_, err := ociRepo.buildPackageRevision(context.TODO(), digestName, "package-name", "workspace_name", 1, time.Now())
 	assert.True(t, err != nil)
+
+	_, err = ociRepo.buildPackageRevision(context.TODO(), digestName, "package-name", "", 1, time.Now())
+	assert.True(t, err != nil)
 }
 
 func TestPackageGetters(t *testing.T) {

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -135,60 +135,11 @@ loop:
 
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
-	case watch.Added:
-		klog.Infof("adding repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		if err := b.cacheRepository(ctx, repository); err == nil {
-			klog.Infof("added repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-	case watch.Modified:
-		klog.Infof("modifying repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			return fmt.Errorf("modifying repository failed, dots are not allowed in repo names: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-		}
-
-		// First verify repositories can be listed (core client is alive)
-		var repoList configapi.RepositoryList
-		if err := b.coreClient.List(ctx, &repoList); err != nil {
-			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		// Update the cache with modified repository
-		if err := b.cacheRepository(ctx, repository); err == nil {
-			klog.Infof("modified repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
+	case watch.Added, watch.Modified:
+		return b.repositoryChange(ctx, repository)
 
 	case watch.Deleted:
-		klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		}
-
-		var repoList configapi.RepositoryList
-		if err := b.coreClient.List(ctx, &repoList); err != nil {
-			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		if err := b.cache.CloseRepository(ctx, repository, repoList.Items); err == nil {
-			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
+		return b.repositoryDelete(ctx, repository)
 
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)
@@ -222,7 +173,28 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 		klog.Infof("%s, handling completed", msgPreamble)
 		return nil
 	} else {
-		return fmt.Errorf("%s, handling failed, cache could not process repo event :%q", msgPreamble, err)
+		return fmt.Errorf("changing repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+	}
+}
+
+func (b *background) repositoryDelete(ctx context.Context, repository *configapi.Repository) error {
+	klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+	if err := validateRepository(repository); err != nil {
+		klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+		return nil
+	}
+
+	var repoList configapi.RepositoryList
+	if err := b.coreClient.List(ctx, &repoList); err != nil {
+		return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+	}
+
+	if err := b.cache.CloseRepository(ctx, repository, repoList.Items); err == nil {
+		klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+		return nil
+	} else {
+		return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
 	}
 }
 

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -191,7 +191,7 @@ func (b *background) repositoryDelete(ctx context.Context, repository *configapi
 	// Verify repositories can be listed (core client is alive)
 	var repoList configapi.RepositoryList
 	if err := b.coreClient.List(ctx, &repoList); err != nil {
-		return fmt.Errorf("%s :%q", msgErr, err)
+		return fmt.Errorf("%s, handling failed, could not list repos using core client :%q", msgPreamble, err)
 	}
 
 	var err error
@@ -205,7 +205,7 @@ func (b *background) repositoryDelete(ctx context.Context, repository *configapi
 		klog.Infof("%s, handling completed", msgPreamble)
 		return nil
 	} else {
-		return fmt.Errorf("%s :%q", msgErr, err)
+		return fmt.Errorf("%s, handling failed, cache could not process repo event :%q", msgPreamble, err)
 	}
 }
 

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,7 +17,6 @@ package porch
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -25,7 +24,6 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -259,29 +257,4 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
-}
-
-func validateRepository(repository *configapi.Repository) error {
-	// The repo name must follow the rules for RFC 1123 DNS labels
-	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
-
-	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
-	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
-	var dirErrs []string
-	if len(dirNoSlash) > 0 {
-		dirErrs = validation.IsDNS1123Label(dirNoSlash)
-	} else {
-		// The directory is "/"
-		dirErrs = nil
-	}
-
-	if nameErrs == nil && dirErrs == nil {
-		return nil
-	}
-
-	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
-		repository.ObjectMeta.Name,
-		repository.Spec.Git.Directory,
-		strings.Join(nameErrs, ","),
-		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -174,36 +174,7 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 		klog.Infof("%s, handling completed", msgPreamble)
 		return nil
 	} else {
-		return fmt.Errorf("changing repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-	}
-}
-
-func (b *background) repositoryDelete(ctx context.Context, repository *configapi.Repository) error {
-	klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-	if err := validateRepository(repository); err != nil {
-		klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-		return nil
-	}
-
-	// Verify repositories can be listed (core client is alive)
-	var repoList configapi.RepositoryList
-	if err := b.coreClient.List(ctx, &repoList); err != nil {
-		return fmt.Errorf("%s, handling failed, could not list repos using core client :%q", msgPreamble, err)
-	}
-
-	var err error
-	if eventType == watch.Deleted {
-		err = b.cache.CloseRepository(ctx, repository, repoList.Items)
-	} else {
-		err = b.cacheRepository(ctx, repo)
-	}
-
-	if err == nil {
-		klog.Infof("%s, handling completed", msgPreamble)
-		return nil
-	} else {
-		return fmt.Errorf("%s, handling failed, cache could not process repo event :%q", msgPreamble, err)
+		return fmt.Errorf("changing repository failed: %s:%s:%q", repo.ObjectMeta.Namespace, repo.ObjectMeta.Name, err)
 	}
 }
 

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,7 +17,6 @@ package porch
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -25,7 +24,6 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -288,29 +286,4 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
-}
-
-func validateRepository(repository *configapi.Repository) error {
-	// The repo name must follow the rules for RFC 1123 DNS labels
-	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
-
-	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
-	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
-	var dirErrs []string
-	if len(dirNoSlash) > 0 {
-		dirErrs = validation.IsDNS1123Label(dirNoSlash)
-	} else {
-		// The directory is "/"
-		dirErrs = nil
-	}
-
-	if nameErrs == nil && dirErrs == nil {
-		return nil
-	}
-
-	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
-		repository.ObjectMeta.Name,
-		repository.Spec.Git.Directory,
-		strings.Join(nameErrs, ","),
-		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -133,60 +133,11 @@ loop:
 
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
-	case watch.Added:
-		klog.Infof("adding repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		if err := b.cacheRepository(ctx, repository); err == nil {
-			klog.Infof("added repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-	case watch.Modified:
-		klog.Infof("modifying repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			return fmt.Errorf("modifying repository failed, dots are not allowed in repo names: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-		}
-
-		// First verify repositories can be listed (core client is alive)
-		var repoList configapi.RepositoryList
-		if err := b.coreClient.List(ctx, &repoList); err != nil {
-			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		// Update the cache with modified repository
-		if err := b.cacheRepository(ctx, repository); err == nil {
-			klog.Infof("modified repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
+	case watch.Added, watch.Modified:
+		return b.repositoryChange(ctx, repository)
 
 	case watch.Deleted:
-		klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-
-		if err := validateRepository(repository); err != nil {
-			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		}
-
-		var repoList configapi.RepositoryList
-		if err := b.coreClient.List(ctx, &repoList); err != nil {
-			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
-
-		if err := b.cache.CloseRepository(ctx, repository, repoList.Items); err == nil {
-			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
-			return nil
-		} else {
-			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
-		}
+		return b.repositoryDelete(ctx, repository)
 
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,6 +17,7 @@ package porch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -24,6 +25,7 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -286,4 +288,29 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
+}
+
+func validateRepository(repository *configapi.Repository) error {
+	// The repo name must follow the rules for RFC 1123 DNS labels
+	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
+
+	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
+	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
+	var dirErrs []string
+	if len(dirNoSlash) > 0 {
+		dirErrs = validation.IsDNS1123Label(dirNoSlash)
+	} else {
+		// The directory is "/"
+		dirErrs = nil
+	}
+
+	if nameErrs == nil && dirErrs == nil {
+		return nil
+	}
+
+	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
+		repository.ObjectMeta.Name,
+		repository.Spec.Git.Directory,
+		strings.Join(nameErrs, ","),
+		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,6 +17,7 @@ package porch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -24,6 +25,7 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -257,4 +259,29 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
+}
+
+func validateRepository(repository *configapi.Repository) error {
+	// The repo name must follow the rules for RFC 1123 DNS labels
+	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
+
+	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
+	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
+	var dirErrs []string
+	if len(dirNoSlash) > 0 {
+		dirErrs = validation.IsDNS1123Label(dirNoSlash)
+	} else {
+		// The directory is "/"
+		dirErrs = nil
+	}
+
+	if nameErrs == nil && dirErrs == nil {
+		return nil
+	}
+
+	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
+		repository.ObjectMeta.Name,
+		repository.Spec.Git.Directory,
+		strings.Join(nameErrs, ","),
+		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,6 +17,7 @@ package porch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -24,6 +25,7 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -254,4 +256,29 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
+}
+
+func validateRepository(repository *configapi.Repository) error {
+	// The repo name must follow the rules for RFC 1123 DNS labels
+	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
+
+	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
+	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
+	var dirErrs []string
+	if len(dirNoSlash) > 0 {
+		dirErrs = validation.IsDNS1123Label(dirNoSlash)
+	} else {
+		// The directory is "/"
+		dirErrs = nil
+	}
+
+	if nameErrs == nil && dirErrs == nil {
+		return nil
+	}
+
+	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
+		repository.ObjectMeta.Name,
+		repository.Spec.Git.Directory,
+		strings.Join(nameErrs, ","),
+		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -191,7 +191,7 @@ func (b *background) repositoryDelete(ctx context.Context, repository *configapi
 	// Verify repositories can be listed (core client is alive)
 	var repoList configapi.RepositoryList
 	if err := b.coreClient.List(ctx, &repoList); err != nil {
-		return fmt.Errorf("%s, handling failed :%q", msgPreamble, err)
+		return fmt.Errorf("%s :%q", msgErr, err)
 	}
 
 	var err error
@@ -205,7 +205,7 @@ func (b *background) repositoryDelete(ctx context.Context, repository *configapi
 		klog.Infof("%s, handling completed", msgPreamble)
 		return nil
 	} else {
-		return fmt.Errorf("%s, handling failed :%q", msgPreamble, err)
+		return fmt.Errorf("%s :%q", msgErr, err)
 	}
 }
 

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -134,13 +134,59 @@ loop:
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
 	case watch.Added:
-		return b.handleRepositoryEvent(ctx, repository, watch.Added)
+		klog.Infof("adding repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		if err := b.cacheRepository(ctx, repository); err == nil {
+			klog.Infof("added repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	case watch.Modified:
-		return b.handleRepositoryEvent(ctx, repository, watch.Modified)
+		klog.Infof("modifying repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			return fmt.Errorf("modifying repository failed, dots are not allowed in repo names: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+		}
+
+		// First verify repositories can be listed (core client is alive)
+		var repoList configapi.RepositoryList
+		if err := b.coreClient.List(ctx, &repoList); err != nil {
+			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		// Update the cache with modified repository
+		if err := b.cacheRepository(ctx, repository); err == nil {
+			klog.Infof("modified repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	case watch.Deleted:
-		return b.handleRepositoryEvent(ctx, repository, watch.Deleted)
+		klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		}
+
+		var repoList configapi.RepositoryList
+		if err := b.coreClient.List(ctx, &repoList); err != nil {
+			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		if err := b.cache.CloseRepository(ctx, repository, repoList.Items); err == nil {
+			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -135,11 +135,14 @@ loop:
 
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
-	case watch.Added, watch.Modified:
-		return b.repositoryChange(ctx, repository)
+	case watch.Added:
+		return b.handleRepositoryEvent(ctx, repository, watch.Added)
+
+	case watch.Modified:
+		return b.handleRepositoryEvent(ctx, repository, watch.Modified)
 
 	case watch.Deleted:
-		return b.repositoryDelete(ctx, repository)
+		return b.handleRepositoryEvent(ctx, repository, watch.Deleted)
 
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -136,13 +136,59 @@ loop:
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
 	case watch.Added:
-		return b.handleRepositoryEvent(ctx, repository, watch.Added)
+		klog.Infof("adding repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		if err := b.cacheRepository(ctx, repository); err == nil {
+			klog.Infof("added repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("adding repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	case watch.Modified:
-		return b.handleRepositoryEvent(ctx, repository, watch.Modified)
+		klog.Infof("modifying repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			return fmt.Errorf("modifying repository failed, dots are not allowed in repo names: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+		}
+
+		// First verify repositories can be listed (core client is alive)
+		var repoList configapi.RepositoryList
+		if err := b.coreClient.List(ctx, &repoList); err != nil {
+			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		// Update the cache with modified repository
+		if err := b.cacheRepository(ctx, repository); err == nil {
+			klog.Infof("modified repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("modifying repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	case watch.Deleted:
-		return b.handleRepositoryEvent(ctx, repository, watch.Deleted)
+		klog.Infof("deleting repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+
+		if err := validateRepository(repository); err != nil {
+			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		}
+
+		var repoList configapi.RepositoryList
+		if err := b.coreClient.List(ctx, &repoList); err != nil {
+			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
+
+		if err := b.cache.CloseRepository(ctx, repository, repoList.Items); err == nil {
+			klog.Infof("deleted repository: %s:%s", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name)
+			return nil
+		} else {
+			return fmt.Errorf("deleting repository failed: %s:%s:%q", repository.ObjectMeta.Namespace, repository.ObjectMeta.Name, err)
+		}
 
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,7 +17,6 @@ package porch
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -25,7 +24,6 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -198,7 +196,7 @@ func (b *background) repositoryDelete(ctx context.Context, repository *configapi
 	if eventType == watch.Deleted {
 		err = b.cache.CloseRepository(ctx, repository, repoList.Items)
 	} else {
-		err = b.cacheRepository(ctx, repository)
+		err = b.cacheRepository(ctx, repo)
 	}
 
 	if err == nil {
@@ -288,29 +286,4 @@ func (t *backoffTimer) backoff() bool {
 	}
 	t.curr = curr
 	return t.timer.Reset(curr)
-}
-
-func validateRepository(repository *configapi.Repository) error {
-	// The repo name must follow the rules for RFC 1123 DNS labels
-	nameErrs := validation.IsDNS1123Label(repository.ObjectMeta.Name)
-
-	// The repo name must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
-	dirNoSlash := strings.ReplaceAll(repository.Spec.Git.Directory, "/", "")
-	var dirErrs []string
-	if len(dirNoSlash) > 0 {
-		dirErrs = validation.IsDNS1123Label(dirNoSlash)
-	} else {
-		// The directory is "/"
-		dirErrs = nil
-	}
-
-	if nameErrs == nil && dirErrs == nil {
-		return nil
-	}
-
-	return fmt.Errorf("repository name %q and/or directory %q is invalid: %s, %s",
-		repository.ObjectMeta.Name,
-		repository.Spec.Git.Directory,
-		strings.Join(nameErrs, ","),
-		strings.Join(dirErrs, ","))
 }

--- a/pkg/registry/porch/fieldselector.go
+++ b/pkg/registry/porch/fieldselector.go
@@ -144,13 +144,13 @@ func parsePackageRevisionFieldSelector(fieldSelector fields.Selector) (packageRe
 			filter.Namespace = requirement.Value
 
 		case "spec.revision":
-			filter.Revision = repository.Revision2Int(requirement.Value)
+			filter.Key.Revision = repository.Revision2Int(requirement.Value)
 		case "spec.packageName":
-			filter.Package = requirement.Value
+			filter.Key.PkgKey.Package = requirement.Value
 		case "spec.repository":
 			filter.Repository = requirement.Value
 		case "spec.workspaceName":
-			filter.WorkspaceName = requirement.Value
+			filter.Key.WorkspaceName = v1alpha1.WorkspaceName(requirement.Value)
 		case "spec.lifecycle":
 			v := v1alpha1.PackageRevisionLifecycle(requirement.Value)
 			switch v {

--- a/pkg/registry/porch/fieldselector.go
+++ b/pkg/registry/porch/fieldselector.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/registry/porch/fieldselector.go
+++ b/pkg/registry/porch/fieldselector.go
@@ -150,7 +150,7 @@ func parsePackageRevisionFieldSelector(fieldSelector fields.Selector) (packageRe
 		case "spec.repository":
 			filter.Repository = requirement.Value
 		case "spec.workspaceName":
-			filter.Key.WorkspaceName = v1alpha1.WorkspaceName(requirement.Value)
+			filter.Key.WorkspaceName = requirement.Value
 		case "spec.lifecycle":
 			v := v1alpha1.PackageRevisionLifecycle(requirement.Value)
 			switch v {

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -295,6 +295,7 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 	if err != nil {
 		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("invalid name %q", name))
 	}
+	repositoryName := parsedRevName[0]
 	if isCreate {
 		repoName = newApiPkgRev.Spec.RepositoryName
 		if repoName == "" {

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -295,7 +295,6 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 	if err != nil {
 		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("invalid name %q", name))
 	}
-	repositoryName := parsedRevName[0]
 	if isCreate {
 		repoName = newApiPkgRev.Spec.RepositoryName
 		if repoName == "" {

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/registry/porch/strategy.go
+++ b/pkg/registry/porch/strategy.go
@@ -128,7 +128,8 @@ func (s packageRevisionStrategy) Validate(ctx context.Context, runtimeObj runtim
 
 	obj := runtimeObj.(*api.PackageRevision)
 
-	if pkgNameErr := util.ValidateK8SName(obj.Spec.PackageName); pkgNameErr != nil {
+	// A package name can have a path
+	if pkgNameErr := util.ValidateDirectoryName(obj.Spec.PackageName, true); pkgNameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "packageName"), obj.Spec.PackageName, pkgNameErr.Error()))
 	}
 

--- a/pkg/registry/porch/table.go
+++ b/pkg/registry/porch/table.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -244,6 +244,19 @@ func (f *ListPackageRevisionFilter) Matches(ctx context.Context, p PackageRevisi
 	return true
 }
 
+// Return a filter composed from a PackageRevision key
+func PRFilterFromKey(key PackageRevisionKey) ListPackageRevisionFilter {
+	return ListPackageRevisionFilter{
+		Namespace:         key.Namespace,
+		Repository:        key.Repository,
+		Path:              key.Path,
+		Package:           key.Package,
+		Revision:          key.Revision,
+		WorkspaceName:     key.WorkspaceName,
+		PlaceholderWSname: key.PlaceholderWSname,
+	}
+}
+
 // ListPackageFilter is a predicate for filtering Package objects;
 // only matching Package objects will be returned.
 type ListPackageFilter struct {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -71,23 +71,28 @@ func (k PackageKey) String() string {
 	return fmt.Sprintf("%s:%s:%s", k.RepoKey.String(), k.Path, k.Package)
 }
 
-func (k PackageKey) ToFullPathname() string {
+func (k PackageKey) ToPkgPathname() string {
 	return filepath.Join(k.Path, k.Package)
 }
 
+func (k PackageKey) ToFullPathname() string {
+	return filepath.Join(k.RepoKey.Path, k.Path, k.Package)
+}
+
 func FromFullPathname(repoKey RepositoryKey, fullpath string) PackageKey {
-	slashIndex := strings.LastIndex(fullpath, "/")
+	pkgPath := strings.Trim(strings.TrimPrefix(fullpath, repoKey.Path), "/")
+	slashIndex := strings.LastIndex(pkgPath, "/")
 
 	if slashIndex >= 0 {
 		return PackageKey{
 			RepoKey: repoKey,
-			Path:    fullpath[:slashIndex],
-			Package: fullpath[slashIndex+1:],
+			Path:    pkgPath[:slashIndex],
+			Package: pkgPath[slashIndex+1:],
 		}
 	} else {
 		return PackageKey{
 			RepoKey: repoKey,
-			Package: fullpath,
+			Package: pkgPath,
 		}
 	}
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -35,7 +35,7 @@ type PackageResources struct {
 type PackageRevisionKey struct {
 	PkgKey        PackageKey
 	Revision      int
-	WorkspaceName v1alpha1.WorkspaceName
+	WorkspaceName string
 }
 
 func (k PackageRevisionKey) String() string {
@@ -114,8 +114,7 @@ func (k PackageKey) Matches(other PackageKey) bool {
 }
 
 type RepositoryKey struct {
-	Namespace, Name, Path string
-	PlaceholderWSname     v1alpha1.WorkspaceName
+	Namespace, Name, Path, PlaceholderWSname string
 }
 
 func (k RepositoryKey) String() string {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -31,17 +31,13 @@ type PackageResources struct {
 }
 
 type PackageRevisionKey struct {
-	Namespace, Repository, Package string
-	Revision                       int
-	WorkspaceName                  v1alpha1.WorkspaceName
+	Namespace, Repository, Path, Package string
+	Revision                             int
+	WorkspaceName, PlaceholderWSname     v1alpha1.WorkspaceName
 }
 
 func (n PackageRevisionKey) String() string {
-	return fmt.Sprintf("%s.%s.%s.%d.%s", n.Namespace, n.Repository, n.Package, n.Revision, string(n.WorkspaceName))
-}
-
-func (n PackageRevisionKey) NonNSString() string {
-	return fmt.Sprintf("%s.%s.%d.%s", n.Repository, n.Package, n.Revision, string(n.WorkspaceName))
+	return fmt.Sprintf("%s:%s:%s:%s:%d:%s:%s", n.Namespace, n.Repository, n.Path, n.Package, n.Revision, string(n.WorkspaceName), string(n.PlaceholderWSname))
 }
 
 func (n PackageRevisionKey) PackageKey() PackageKey {
@@ -192,6 +188,8 @@ type ListPackageRevisionFilter struct {
 
 	// Revision matches the revision of the package (spec.revision)
 	Revision int
+
+	PlaceholderWSname v1alpha1.WorkspaceName
 
 	// Lifecycle matches the spec.lifecycle of the package
 	Lifecycle v1alpha1.PackageRevisionLifecycle

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -31,13 +31,17 @@ type PackageResources struct {
 }
 
 type PackageRevisionKey struct {
-	Namespace, Repository, Path, Package string
-	Revision                             int
-	WorkspaceName, PlaceholderWSname     v1alpha1.WorkspaceName
+	Namespace, Repository, Package string
+	Revision                       int
+	WorkspaceName                  v1alpha1.WorkspaceName
 }
 
 func (n PackageRevisionKey) String() string {
-	return fmt.Sprintf("%s:%s:%s:%s:%d:%s:%s", n.Namespace, n.Repository, n.Path, n.Package, n.Revision, string(n.WorkspaceName), string(n.PlaceholderWSname))
+	return fmt.Sprintf("%s.%s.%s.%d.%s", n.Namespace, n.Repository, n.Package, n.Revision, string(n.WorkspaceName))
+}
+
+func (n PackageRevisionKey) NonNSString() string {
+	return fmt.Sprintf("%s.%s.%d.%s", n.Repository, n.Package, n.Revision, string(n.WorkspaceName))
 }
 
 func (n PackageRevisionKey) PackageKey() PackageKey {
@@ -188,8 +192,6 @@ type ListPackageRevisionFilter struct {
 
 	// Revision matches the revision of the package (spec.revision)
 	Revision int
-
-	PlaceholderWSname v1alpha1.WorkspaceName
 
 	// Lifecycle matches the spec.lifecycle of the package
 	Lifecycle v1alpha1.PackageRevisionLifecycle

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -244,19 +244,6 @@ func (f *ListPackageRevisionFilter) Matches(ctx context.Context, p PackageRevisi
 	return true
 }
 
-// Return a filter composed from a PackageRevision key
-func PRFilterFromKey(key PackageRevisionKey) ListPackageRevisionFilter {
-	return ListPackageRevisionFilter{
-		Namespace:         key.Namespace,
-		Repository:        key.Repository,
-		Path:              key.Path,
-		Package:           key.Package,
-		Revision:          key.Revision,
-		WorkspaceName:     key.WorkspaceName,
-		PlaceholderWSname: key.PlaceholderWSname,
-	}
-}
-
 // ListPackageFilter is a predicate for filtering Package objects;
 // only matching Package objects will be returned.
 type ListPackageFilter struct {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -162,7 +162,7 @@ type Package interface {
 
 	// GetLatestRevision returns the name of the package revision that is the "latest" package
 	// revision belonging to this package
-	GetLatestRevision() string
+	GetLatestRevision() int
 }
 
 type PackageRevisionDraft interface {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -46,7 +46,7 @@ func (k PackageRevisionKey) GetPackageKey() PackageKey {
 	return k.PkgKey
 }
 
-func (k PackageRevisionKey) RepositoryKey() RepositoryKey {
+func (k PackageRevisionKey) GetRepositoryKey() RepositoryKey {
 	return k.PkgKey.RepoKey
 }
 
@@ -97,7 +97,7 @@ func FromFullPathname(repoKey RepositoryKey, fullpath string) PackageKey {
 	}
 }
 
-func (k PackageKey) GetRepoKey() RepositoryKey {
+func (k PackageKey) GetRepositoryKey() RepositoryKey {
 	return k.RepoKey
 }
 

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepositoryKey(t *testing.T) {
+	repoKey := RepositoryKey{
+		Namespace:         "my-ns",
+		Name:              "my-repo",
+		Path:              "my/dir/path",
+		PlaceholderWSname: "my-ws-name",
+	}
+
+	assert.Equal(t, "my-ns:my-repo:my/dir/path:my-ws-name", repoKey.String())
+	assert.Equal(t, repoKey, repoKey)
+
+	otherRepoKey := RepositoryKey{}
+	assert.True(t, otherRepoKey.Matches(repoKey))
+
+	otherRepoKey.Namespace = "other-ns"
+	otherRepoKey.Name = "other-repo"
+	otherRepoKey.Path = "other/dir/path"
+	otherRepoKey.PlaceholderWSname = "other-ws-name"
+	assert.False(t, otherRepoKey.Matches(repoKey))
+
+	otherRepoKey.Namespace = "my-ns"
+	assert.False(t, otherRepoKey.Matches(repoKey))
+
+	otherRepoKey.Name = "my-repo"
+	assert.False(t, otherRepoKey.Matches(repoKey))
+
+	otherRepoKey.Path = "my/dir/path"
+	assert.False(t, otherRepoKey.Matches(repoKey))
+
+	otherRepoKey.Path = "my/dir/path"
+	otherRepoKey.PlaceholderWSname = "my-ws-name"
+	assert.True(t, otherRepoKey.Matches(repoKey))
+}
+
+func TestPackageKey(t *testing.T) {
+	pkgKey := PackageKey{
+		Path:    "my/pkg/path",
+		Package: "my-package-name",
+	}
+
+	assert.Equal(t, "::::my/pkg/path:my-package-name", pkgKey.String())
+	assert.Equal(t, pkgKey, pkgKey)
+
+	otherPkgKey := PackageKey{}
+	assert.True(t, otherPkgKey.Matches(pkgKey))
+
+	otherPkgKey.Path = "other/pkg/path"
+	otherPkgKey.Package = "other-ws-name"
+	assert.False(t, otherPkgKey.Matches(pkgKey))
+
+	otherPkgKey.Path = "my/pkg/path"
+	assert.False(t, otherPkgKey.Matches(pkgKey))
+
+	otherPkgKey.Package = "my-package-name"
+	assert.True(t, otherPkgKey.Matches(pkgKey))
+
+	assert.Equal(t, "my/pkg/path/my-package-name", pkgKey.ToPkgPathname())
+	assert.Equal(t, "my/pkg/path/my-package-name", pkgKey.ToFullPathname())
+
+	pkgKey.RepoKey.Path = "dir/path"
+	assert.Equal(t, "dir/path/my/pkg/path/my-package-name", pkgKey.ToFullPathname())
+
+	testRepoKey := RepositoryKey{
+		Namespace:         "ns",
+		Name:              "repo",
+		Path:              "dir/path",
+		PlaceholderWSname: "ws-name",
+	}
+	pkgKey.RepoKey = testRepoKey
+	assert.Equal(t, pkgKey, FromFullPathname(testRepoKey, pkgKey.ToPkgPathname()))
+	assert.Equal(t, pkgKey, FromFullPathname(pkgKey.GetRepositoryKey(), pkgKey.ToPkgPathname()))
+
+	pkgKey.RepoKey = RepositoryKey{}
+	assert.Equal(t, pkgKey, FromFullPathname(pkgKey.GetRepositoryKey(), pkgKey.ToPkgPathname()))
+
+	pkgKey.Path = ""
+	assert.Equal(t, pkgKey, FromFullPathname(pkgKey.GetRepositoryKey(), pkgKey.ToPkgPathname()))
+}
+
+func TestPackageRevisionKey(t *testing.T) {
+	pkgRevKey := PackageRevisionKey{
+		Revision:      1,
+		WorkspaceName: "my-ws-name",
+	}
+
+	assert.Equal(t, "::::::1:my-ws-name", pkgRevKey.String())
+	assert.Equal(t, pkgRevKey, pkgRevKey)
+
+	otherPkgRevKey := PackageRevisionKey{}
+	assert.True(t, otherPkgRevKey.Matches(pkgRevKey))
+
+	otherPkgRevKey.Revision = 2
+	otherPkgRevKey.WorkspaceName = "other-ws-name"
+	assert.False(t, otherPkgRevKey.Matches(pkgRevKey))
+
+	otherPkgRevKey.Revision = 1
+	assert.False(t, otherPkgRevKey.Matches(pkgRevKey))
+
+	otherPkgRevKey.WorkspaceName = "my-ws-name"
+	assert.True(t, otherPkgRevKey.Matches(pkgRevKey))
+
+	testPkgKey := PackageKey{
+		Path:    "pkg/path",
+		Package: "package-name",
+	}
+	pkgRevKey.PkgKey = testPkgKey
+	assert.Equal(t, testPkgKey, pkgRevKey.GetPackageKey())
+
+	testRepoKey := RepositoryKey{
+		Namespace:         "ns",
+		Name:              "repo",
+		Path:              "dir/path",
+		PlaceholderWSname: "ws-name",
+	}
+	pkgRevKey.PkgKey.RepoKey = testRepoKey
+	assert.Equal(t, testRepoKey, pkgRevKey.GetRepositoryKey())
+}

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -16,9 +16,7 @@ package repository
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
-	"strings"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -20,6 +20,7 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
+	"go.opentelemetry.io/otel"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -63,44 +64,31 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 	}
 }
 
-func NextRevisionNumber(ctx context.Context, revs []string) (string, error) {
-	_, span := tracer.Start(ctx, "util.go::NextRevisionNumber", trace.WithAttributes())
-	defer span.End()
-
-	// Computes the next revision number as the latest revision number + 1.
-	// This function only understands strict versioning format, e.g. v1, v2, etc. It will
-	// ignore all revision numbers it finds that do not adhere to this format.
-	// If there are no published revisions (in the recognized format), the revision
-	// number returned here will be "v1".
-	latestRev := "v0"
-	for _, currentRev := range revs {
-		if !semver.IsValid(currentRev) {
-			// ignore this revision
-			continue
-		}
-		// collect the major version. i.e. if we find that the latest published
-		// version is v3.1.1, we will end up returning v4
-		currentRev = semver.Major(currentRev)
-
-		switch cmp := semver.Compare(currentRev, latestRev); {
-		case cmp == 0:
-			// Same revision.
-		case cmp < 0:
-			// current < latest; no change
-		case cmp > 0:
-			// current > latest; update latest
-			latestRev = currentRev
-		}
-
+// ValidateWorkspaceName validates WorkspaceName. It must:
+//   - be at least 1 and at most 63 characters long
+//   - contain only lowercase alphanumeric characters or '-'
+//   - start and end with an alphanumeric character.
+//
+// '/ ' should never be allowed, because we use '/' to
+// delimit branch names (e.g. the 'drafts/' prefix).
+func ValidateWorkspaceName(workspace api.WorkspaceName) error {
+	wn := string(workspace)
+	if len(wn) > 63 || len(wn) == 0 {
+		return fmt.Errorf("workspaceName %q must be at least 1 and at most 63 characters long", wn)
+	}
+	if strings.HasPrefix(wn, "-") || strings.HasSuffix(wn, "-") {
+		return fmt.Errorf("workspaceName %q must start and end with an alphanumeric character", wn)
 	}
 
-	i, err := strconv.Atoi(latestRev[1:])
+	match, err := regexp.MatchString(`^[a-z0-9-]+$`, wn)
 	if err != nil {
-		return "", err
+		return err
 	}
-	i++
-	next := "v" + strconv.Itoa(i)
-	return next, nil
+	if !match {
+		return fmt.Errorf("workspaceName %q must be comprised only of lowercase alphanumeric characters and '-'", wn)
+	}
+
+	return nil
 }
 
 // AnyBlockOwnerDeletionSet checks whether there are any ownerReferences in the Object

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -120,8 +120,8 @@ func Revision2Str(revision int) string {
 
 func ComposePkgRevObjName(key PackageRevisionKey) string {
 	if key.Revision != -1 { // Then it's a regular PackageRevision
-		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.WorkspaceName))
+		return util.ComposePkgRevObjName(key.PkgKey.RepoKey.Name, key.PkgKey.Path, key.PkgKey.Package, string(key.WorkspaceName))
 	} else { // Then it's the placeholder PackageRevision
-		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.PlaceholderWSname))
+		return util.ComposePkgRevObjName(key.PkgKey.RepoKey.Name, key.PkgKey.Path, key.PkgKey.Package, string(key.PkgKey.RepoKey.PlaceholderWSname))
 	}
 }

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -16,7 +16,6 @@ package repository
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -64,33 +63,6 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 	default:
 		panic(fmt.Errorf("unknown condition status: %v", s))
 	}
-}
-
-// ValidateWorkspaceName validates WorkspaceName. It must:
-//   - be at least 1 and at most 63 characters long
-//   - contain only lowercase alphanumeric characters or '-'
-//   - start and end with an alphanumeric character.
-//
-// '/ ' should never be allowed, because we use '/' to
-// delimit branch names (e.g. the 'drafts/' prefix).
-func ValidateWorkspaceName(workspace api.WorkspaceName) error {
-	wn := string(workspace)
-	if len(wn) > 63 || len(wn) == 0 {
-		return fmt.Errorf("workspaceName %q must be at least 1 and at most 63 characters long", wn)
-	}
-	if strings.HasPrefix(wn, "-") || strings.HasSuffix(wn, "-") {
-		return fmt.Errorf("workspaceName %q must start and end with an alphanumeric character", wn)
-	}
-
-	match, err := regexp.MatchString(`^[a-z0-9-]+$`, wn)
-	if err != nil {
-		return err
-	}
-	if !match {
-		return fmt.Errorf("workspaceName %q must be comprised only of lowercase alphanumeric characters and '-'", wn)
-	}
-
-	return nil
 }
 
 // AnyBlockOwnerDeletionSet checks whether there are any ownerReferences in the Object

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -20,7 +20,6 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
-	"go.opentelemetry.io/otel"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -22,7 +22,7 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
-	"github.com/nephio-project/porch/pkg/util"
+	"go.opentelemetry.io/otel"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -116,12 +116,4 @@ func Revision2Int(revisionStr string) int {
 
 func Revision2Str(revision int) string {
 	return strconv.Itoa(revision)
-}
-
-func ComposePkgRevObjName(key PackageRevisionKey) string {
-	if key.Revision != -1 { // Then it's a regular PackageRevision
-		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.WorkspaceName))
-	} else { // Then it's the placeholder PackageRevision
-		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.PlaceholderWSname))
-	}
 }

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -16,7 +16,9 @@ package repository
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -22,7 +22,6 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
-	"go.opentelemetry.io/otel"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -22,6 +22,7 @@ import (
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
+	"github.com/nephio-project/porch/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -115,4 +116,12 @@ func Revision2Int(revisionStr string) int {
 
 func Revision2Str(revision int) string {
 	return strconv.Itoa(revision)
+}
+
+func ComposePkgRevObjName(key PackageRevisionKey) string {
+	if key.Revision != -1 { // Then it's a regular PackageRevision
+		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.WorkspaceName))
+	} else { // Then it's the placeholder PackageRevision
+		return util.ComposePkgRevObjName(key.Repository, key.Path, key.Package, string(key.PlaceholderWSname))
+	}
 }

--- a/pkg/repository/util_test.go
+++ b/pkg/repository/util_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRevision2Int(t *testing.T) {
+	assert.Equal(t, 123, Revision2Int("123"))
+	assert.Equal(t, 123, Revision2Int("v123"))
+	assert.Equal(t, -1, Revision2Int("V123"))
+	assert.Equal(t, -1, Revision2Int("v123v"))
+	assert.Equal(t, -1, Revision2Int("-1"))
+	assert.Equal(t, 0, Revision2Int("v0"))
+	assert.Equal(t, 0, Revision2Int("0"))
+}
+
+func TestRevision2Str(t *testing.T) {
+	assert.Equal(t, "123", Revision2Str(123))
+	assert.Equal(t, "-1", Revision2Str(-1))
+}
+
+func TestComposePkgRevObjName(t *testing.T) {
+	pkgRevKey := PackageRevisionKey{
+		PkgKey: PackageKey{
+			RepoKey: RepositoryKey{
+				Namespace:         "the-ns",
+				Name:              "the-repo",
+				Path:              "the/dir/path",
+				PlaceholderWSname: "the-placeholder-ws-name",
+			},
+			Path:    "the/pkg/path",
+			Package: "the-package-name",
+		},
+		Revision:      123,
+		WorkspaceName: "the-ws-name",
+	}
+
+	assert.Equal(t, "the-repo.the.pkg.path.the-package-name.the-ws-name", ComposePkgRevObjName(pkgRevKey))
+
+	pkgRevKey.Revision = -1
+	assert.Equal(t, "the-repo.the.pkg.path.the-package-name.the-placeholder-ws-name", ComposePkgRevObjName(pkgRevKey))
+}

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -49,8 +49,8 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	}
 
 	// We only allow edit to create new revision from the same package.
-	if revision.Key().Package != m.packageName ||
-		revision.Key().Repository != m.repositoryName {
+	if revision.Key().PkgKey.Package != m.packageName ||
+		revision.Key().PkgKey.RepoKey.Name != m.repositoryName {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be from same package %s/%s", m.repositoryName, m.packageName)
 	}
 

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -49,7 +49,7 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	}
 
 	// We only allow edit to create new revision from the same package.
-	if revision.Key().PkgKey.Package != m.packageName ||
+	if revision.Key().PkgKey.ToPkgPathname() != m.packageName ||
 		revision.Key().PkgKey.RepoKey.Name != m.repositoryName {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be from same package %s/%s", m.repositoryName, m.packageName)
 	}

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -29,7 +29,10 @@ import (
 
 func TestEdit(t *testing.T) {
 	repositoryName := "repo"
+	pkg := "1234567890"
 	revision := 1
+	workspace := "ws"
+	packageName := "repo.1234567890.ws"
 	packageRevision := &fake.FakePackageRevision{
 		PrKey: repository.PackageRevisionKey{
 			Package:       pkg,

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -28,16 +28,17 @@ import (
 )
 
 func TestEdit(t *testing.T) {
-	pkg := "pkg"
-	packageName := "repo.1234567890.ws"
 	repositoryName := "repo"
+	pkg := "1234567890"
 	revision := 1
+	workspace := "ws"
+	packageName := "repo.1234567890.ws"
 	packageRevision := &fake.FakePackageRevision{
-		Name: packageName,
-		PackageRevisionKey: repository.PackageRevisionKey{
-			Package:    pkg,
-			Repository: repositoryName,
-			Revision:   revision,
+		PrKey: repository.PackageRevisionKey{
+			Package:       pkg,
+			Repository:    repositoryName,
+			Revision:      revision,
+			WorkspaceName: v1alpha1.WorkspaceName(workspace),
 		},
 		PackageLifecycle: v1alpha1.PackageRevisionLifecyclePublished,
 		Resources: &v1alpha1.PackageRevisionResources{

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -35,8 +35,12 @@ func TestEdit(t *testing.T) {
 	packageName := "repo.1234567890.ws"
 	packageRevision := &fake.FakePackageRevision{
 		PrKey: repository.PackageRevisionKey{
-			Package:       pkg,
-			Repository:    repositoryName,
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
 			Revision:      revision,
 			WorkspaceName: v1alpha1.WorkspaceName(workspace),
 		},

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -42,7 +42,7 @@ func TestEdit(t *testing.T) {
 				Package: pkg,
 			},
 			Revision:      revision,
-			WorkspaceName: v1alpha1.WorkspaceName(workspace),
+			WorkspaceName: workspace,
 		},
 		PackageLifecycle: v1alpha1.PackageRevisionLifecyclePublished,
 		Resources: &v1alpha1.PackageRevisionResources{

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -29,10 +29,7 @@ import (
 
 func TestEdit(t *testing.T) {
 	repositoryName := "repo"
-	pkg := "1234567890"
 	revision := 1
-	workspace := "ws"
-	packageName := "repo.1234567890.ws"
 	packageRevision := &fake.FakePackageRevision{
 		PrKey: repository.PackageRevisionKey{
 			Package:       pkg,

--- a/pkg/util/testdata/pkg-rev-name.yaml
+++ b/pkg/util/testdata/pkg-rev-name.yaml
@@ -106,7 +106,7 @@ has repeated slashes:
   prerrstring: ""
   repoerrstring: must consist of lower case alphanumeric characters
   direrrstring: consecutive '/' characters are not allowed
-  pkgerrstring: must consist of lower case alphanumeric characters
+  pkgerrstring: consecutive '/' characters are not allowed
   wserrstring: must consist of lower case alphanumeric characters
 has slashes:
   repo: he/lo
@@ -117,7 +117,7 @@ has slashes:
   prerrstring: ""
   repoerrstring: must consist of lower case alphanumeric characters
   direrrstring: ""
-  pkgerrstring: must consist of lower case alphanumeric characters
+  pkgerrstring: ""
   wserrstring: must consist of lower case alphanumeric characters
 has uppercase alphanumeric characters:
   repo: hElLo

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,6 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
+const (
+	invalidConst string = " invalid "
+)
+
 func GetInClusterNamespace() (string, error) {
 	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
@@ -114,12 +118,12 @@ func ValidateRepository(repoName, directory string) error {
 	repoErrString := ""
 
 	if nameErrs != nil {
-		repoErrString = "repository name " + repoName + " invalid: " + strings.Join(nameErrs, ",") + "\n"
+		repoErrString = "repository name " + repoName + invalidConst + strings.Join(nameErrs, ",") + "\n"
 	}
 
 	dirErrString := ""
 	if dirErrs != nil {
-		dirErrString = "directory name " + directory + " invalid: " + strings.Join(dirErrs, ",") + "\n"
+		dirErrString = "directory name " + directory + invalidConst + strings.Join(dirErrs, ",") + "\n"
 	}
 
 	return errors.New(repoErrString + dirErrString)
@@ -139,18 +143,18 @@ func ValidPkgRevObjName(repoName, directory, packageName, workspace string) erro
 	}
 
 	if err := ValidateK8SName(packageName); err != nil {
-		errSlice = append(errSlice, "package name "+packageName+" invalid: "+err.Error()+"\n")
+		errSlice = append(errSlice, "package name "+packageName+invalidConst+err.Error()+"\n")
 	}
 
 	if err := ValidateK8SName(string(workspace)); err != nil {
-		errSlice = append(errSlice, "workspace name "+workspace+" invalid: "+err.Error())
+		errSlice = append(errSlice, "workspace name "+workspace+invalidConst+err.Error())
 	}
 
 	if len(errSlice) == 0 {
 		objName := ComposePkgRevObjName(repoName, directory, packageName, workspace)
 
 		if objNameErrs := validation.IsDNS1123Subdomain(objName); objNameErrs != nil {
-			errSlice = append(errSlice, "complete object name "+objName+" invalid: "+strings.Join(objNameErrs, "")+"\n")
+			errSlice = append(errSlice, "complete object name "+objName+invalidConst+strings.Join(objNameErrs, "")+"\n")
 		}
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	invalidConst string = " invalid "
+	invalidConst string = " invalid:"
 )
 
 func GetInClusterNamespace() (string, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -225,3 +225,10 @@ func GenerateUid(prefix string, kubeNs string, kubeName string) types.UID {
 	buff.WriteString(strings.ToLower(kubeName))
 	return types.UID(uuid.NewSHA1(space, buff.Bytes()).String())
 }
+
+func SafeReverse[S ~[]E, E any](s S) {
+	if s == nil {
+		return
+	}
+	slices.Reverse(s)
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -175,16 +175,16 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	if firstDot >= lastDot {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	parsedName := make([]string, 3)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -185,16 +185,16 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	if firstDot >= lastDot {
-		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+		return nil, fmt.Errorf(twoDotErrMsg, name)
 	}
 
 	parsedName := make([]string, 3)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -175,23 +175,19 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
-	}
-
-	if firstDot >= lastDot {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
 	}
 
 	parsedName := make([]string, 3)
 
 	parsedName[0] = name[:firstDot]
-	parsedName[1] = name[firstDot+1 : lastDot]
-	parsedName[2] = name[lastDot+1:]
+	parsedName[1] = name[firstDot:lastDot]
+	parsedName[2] = name[lastDot:]
 
 	return parsedName, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -185,19 +185,23 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+	}
+
+	if firstDot >= lastDot {
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
 	}
 
 	parsedName := make([]string, 3)
 
 	parsedName[0] = name[:firstDot]
-	parsedName[1] = name[firstDot:lastDot]
-	parsedName[2] = name[lastDot:]
+	parsedName[1] = name[firstDot+1 : lastDot]
+	parsedName[2] = name[lastDot+1:]
 
 	return parsedName, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -185,23 +185,19 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
-	}
-
-	if firstDot >= lastDot {
-		return nil, fmt.Errorf(twoDotErrMsg, name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
 	}
 
 	parsedName := make([]string, 3)
 
 	parsedName[0] = name[:firstDot]
-	parsedName[1] = name[firstDot+1 : lastDot]
-	parsedName[2] = name[lastDot+1:]
+	parsedName[1] = name[firstDot:lastDot]
+	parsedName[2] = name[lastDot:]
 
 	return parsedName, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -175,19 +175,23 @@ func ParsePkgRevObjName(name string) ([]string, error) {
 
 	firstDot := strings.Index(name, ".")
 	if firstDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
 	}
 
 	lastDot := strings.LastIndex(name, ".")
 	if lastDot < 0 {
-		return nil, fmt.Errorf("malformed package revision name; expected at least one dot: %q", name)
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
+	}
+
+	if firstDot >= lastDot {
+		return nil, fmt.Errorf("malformed package revision name; expected at least two dots: %q", name)
 	}
 
 	parsedName := make([]string, 3)
 
 	parsedName[0] = name[:firstDot]
-	parsedName[1] = name[firstDot:lastDot]
-	parsedName[2] = name[lastDot:]
+	parsedName[1] = name[firstDot+1 : lastDot]
+	parsedName[2] = name[lastDot+1:]
 
 	return parsedName, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -99,14 +99,14 @@ func ValidateK8SName(k8sName string) error {
 	return nil
 }
 
-func ValidateDirectoryName(directory string) error {
+func ValidateDirectoryName(directory string, mandatory bool) error {
 	// A directory must follow the rules for RFC 1123 DNS labels except that we allow '/' characters
 	var dirErrs []string
 	if strings.Contains(directory, "//") {
 		dirErrs = append(dirErrs, "consecutive '/' characters are not allowed")
 	}
 	dirNoSlash := strings.ReplaceAll(directory, "/", "")
-	if len(dirNoSlash) > 0 {
+	if mandatory || len(dirNoSlash) > 0 {
 		dirErrs = append(dirErrs, validation.IsDNS1123Label(dirNoSlash)...)
 	} else {
 		// The directory is "/"
@@ -124,7 +124,7 @@ func ValidateRepository(repoName, directory string) error {
 	// The repo name must follow the rules for RFC 1123 DNS labels
 	nameErrs := validation.IsDNS1123Label(repoName)
 
-	dirErr := ValidateDirectoryName(directory)
+	dirErr := ValidateDirectoryName(directory, false)
 
 	if nameErrs == nil && dirErr == nil {
 		return nil
@@ -157,7 +157,7 @@ func ValidPkgRevObjName(repoName, path, packageName, workspace string) error {
 		errSlice = append(errSlice, err.Error())
 	}
 
-	if err := ValidateK8SName(packageName); err != nil {
+	if err := ValidateDirectoryName(packageName, true); err != nil {
 		errSlice = append(errSlice, "package name "+packageName+invalidConst+err.Error()+"\n")
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-// Copyright 2023, 2024 The kpt and Nephio Authors
+// Copyright 2023-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,8 +30,8 @@ func TestParseRepositoryNameOK(t *testing.T) {
 
 	testCases := map[string]struct {
 		pkgRevId string
-		expected string
-		err      error
+		expected []string
+		err      bool
 	}{
 		"three-dots": {
 			pkgRevId: "my-repo.my-package-name.my-workspace",

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
-	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestParseRepositoryNameOK(t *testing.T) {
@@ -167,6 +168,10 @@ func TestValidatePkgRevName(t *testing.T) {
 				tc.Ws)
 		})
 	}
+}
+
+func TestGenerateUid(t *testing.T) {
+	assert.Equal(t, types.UID("272983f7-a30d-58e0-a809-c38e8638666d"), GenerateUid("my-prefix", "my-namespace", "my.kube.name.of-something"))
 }
 
 func assertExpectedPartErrExists(t *testing.T, errorSlice []string, errString, prefix, part string) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,8 +30,7 @@ func TestParseRepositoryNameOK(t *testing.T) {
 
 	testCases := map[string]struct {
 		pkgRevId string
-		expected []string
-		err      bool
+		expected string
 	}{
 		"three-dots": {
 			pkgRevId: "my-repo.my-package-name.my-workspace",

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -31,6 +31,7 @@ func TestParseRepositoryNameOK(t *testing.T) {
 	testCases := map[string]struct {
 		pkgRevId string
 		expected string
+		err      error
 	}{
 		"three-dots": {
 			pkgRevId: "my-repo.my-package-name.my-workspace",

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,8 +30,8 @@ func TestParseRepositoryNameOK(t *testing.T) {
 
 	testCases := map[string]struct {
 		pkgRevId string
-		expected []string
-		err      bool
+		expected string
+		err      error
 	}{
 		"three-dots": {
 			pkgRevId: "my-repo.my-package-name.my-workspace",

--- a/test/e2e/cli/testdata/rpkg-clone/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-clone/config.yaml
@@ -74,7 +74,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.basens-clone.clone-2
           namespace: rpkg-clone
-          uid: 488cf229-e634-5842-a337-cf02a78ea35d
+          uid: 710e4f9b-b21f-5786-bf04-1d1d9b32d57c
       - apiVersion: kpt.dev/v1
         info:
           description: sample description
@@ -131,7 +131,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.empty-clone.clone-1
           namespace: rpkg-clone
-          uid: 08181701-9b48-5dc5-879b-78b73de4c482
+          uid: e8317a47-90ce-5c75-b548-26e7de2e2508
       - apiVersion: kpt.dev/v1
         info:
           description: Empty Blueprint

--- a/test/e2e/cli/testdata/rpkg-copy/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-copy/config.yaml
@@ -63,7 +63,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.basens-edit.copy-2
           namespace: rpkg-copy
-          uid: 5fd90b6d-e093-5b5f-b651-16413ac590ac
+          uid: dc403caa-3f59-5a61-8a79-adcdf40bc52a
       - apiVersion: kpt.dev/v1
         info:
           description: sample description

--- a/test/e2e/cli/testdata/rpkg-get/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-get/config.yaml
@@ -15,12 +15,12 @@ commands:
       - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.revision
     stdout: |
       NAME                          PKG      REPO              REV
-      test-blueprints.basens.main   basens   test-blueprints   main
-      test-blueprints.basens.v1     basens   test-blueprints   v1
-      test-blueprints.basens.v2     basens   test-blueprints   v2
-      test-blueprints.basens.v3     basens   test-blueprints   v3
-      test-blueprints.empty.main    empty    test-blueprints   main
-      test-blueprints.empty.v1      empty    test-blueprints   v1
+      test-blueprints.basens.main   basens   test-blueprints   -1
+      test-blueprints.basens.v1     basens   test-blueprints   1
+      test-blueprints.basens.v2     basens   test-blueprints   2
+      test-blueprints.basens.v3     basens   test-blueprints   3
+      test-blueprints.empty.main    empty    test-blueprints   -1
+      test-blueprints.empty.v1      empty    test-blueprints   1
   - args:
       - porchctl
       - rpkg
@@ -29,7 +29,7 @@ commands:
       - test-blueprints.basens.v1
     stdout: |
       NAME                        PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      test-blueprints.basens.v1   basens    v1              v1         false    Published   test-blueprints
+      test-blueprints.basens.v1   basens    v1              1          false    Published   test-blueprints
   - args:
       - porchctl
       - rpkg
@@ -38,7 +38,7 @@ commands:
       - --name=basens
     stdout: |
       NAME                          PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      test-blueprints.basens.main   basens    main            main       false    Published   test-blueprints
-      test-blueprints.basens.v1     basens    v1              v1         false    Published   test-blueprints
-      test-blueprints.basens.v2     basens    v2              v2         false    Published   test-blueprints
-      test-blueprints.basens.v3     basens    v3              v3         true     Published   test-blueprints
+      test-blueprints.basens.main   basens    main            -1         false    Published   test-blueprints
+      test-blueprints.basens.v1     basens    v1              1          false    Published   test-blueprints
+      test-blueprints.basens.v2     basens    v2              2          false    Published   test-blueprints
+      test-blueprints.basens.v3     basens    v3              3          true     Published   test-blueprints

--- a/test/e2e/cli/testdata/rpkg-init-deploy/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-init-deploy/config.yaml
@@ -50,7 +50,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.deploy-package.deploy
           namespace: rpkg-init-deploy
-          uid: 8d6b1b08-9029-5e3e-a673-09aa6ff71e91
+          uid: d9f80c5c-8e7a-5dfa-a546-bad5196de8e0
       - apiVersion: kpt.dev/v1
         info:
           description: Test Package Description

--- a/test/e2e/cli/testdata/rpkg-init/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-init/config.yaml
@@ -50,7 +50,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.init-package.init-1
           namespace: rpkg-init
-          uid: 3da4afa2-0d0a-5268-861f-fcfdefea17bb
+          uid: 45ee0692-730a-51b2-9a1d-ad4f4ad55dc8
       - apiVersion: kpt.dev/v1
         info:
           description: Test Package Description

--- a/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
@@ -58,7 +58,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle                  false    Draft       git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       0          false    Draft       git
   - args:
       - porchctl
       - rpkg
@@ -83,7 +83,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle                  false    Proposed    git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       0          false    Proposed    git
   - args:
       - porchctl
       - rpkg
@@ -100,7 +100,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       v1         true     Published   git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       1          true     Published   git
   - args:
       - porchctl
       - rpkg
@@ -133,7 +133,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE          REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       v1         true     DeletionProposed   git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       1          true     DeletionProposed   git
   - args:
       - porchctl
       - rpkg
@@ -158,7 +158,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       v1         true     Published   git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       1          true     Published   git
   - args:
       - porchctl
       - rpkg
@@ -175,7 +175,7 @@ commands:
       - --namespace=rpkg-lifecycle
     stdout: |
       NAME                              PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE          REPOSITORY
-      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       v1         true     DeletionProposed   git
+      git.lifecycle-package.lifecycle   lifecycle-package   lifecycle       1          true     DeletionProposed   git
   - args:
       - porchctl
       - rpkg

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -35,7 +35,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.test-package.push
           namespace: rpkg-push
-          uid: 50d077b1-c3cc-5232-b0b6-7e0772d18514
+          uid: 0e7dd104-514e-5455-b077-6f196b04165c
       - apiVersion: kpt.dev/v1
         info:
           description: sample description
@@ -161,7 +161,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.test-package.push
           namespace: rpkg-push
-          uid: 50d077b1-c3cc-5232-b0b6-7e0772d18514
+          uid: 0e7dd104-514e-5455-b077-6f196b04165c
       - apiVersion: kpt.dev/v1
         info:
           description: Updated Test Package Description
@@ -207,7 +207,7 @@ commands:
             internal.config.kubernetes.io/path: .KptRevisionMetadata
           name: git.test-package.push
           namespace: rpkg-push
-          uid: 50d077b1-c3cc-5232-b0b6-7e0772d18514
+          uid: 0e7dd104-514e-5455-b077-6f196b04165c
           resourceVersion: "1"
       - apiVersion: kpt.dev/v1
         info:

--- a/test/e2e/cli/testdata/rpkg-update/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-update/config.yaml
@@ -60,10 +60,10 @@ commands:
       - --namespace=rpkg-update
     stdout: |
       NAME                             PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      git.basens-edit.update-1         basens-edit         update-1                   false    Draft       git
-      git.basens-edit.main             basens-edit         update-3        main       false    Published   git
-      git.basens-edit.update-3         basens-edit         update-3        v1         true     Published   git
-      git.basens-edit-clone.update-2   basens-edit-clone   update-2                   false    Draft       git
+      git.basens-edit.main             basens-edit         update-3        -1         false    Published   git
+      git.basens-edit.update-1         basens-edit         update-1        0          false    Draft       git
+      git.basens-edit.update-3         basens-edit         update-3        1          true     Published   git
+      git.basens-edit-clone.update-2   basens-edit-clone   update-2        0          false    Draft       git
   - args:
       - porchctl
       - rpkg
@@ -73,7 +73,7 @@ commands:
       - git.basens-edit-clone.update-2
     stdout: |
       PACKAGE REVISION                 UPSTREAM REPOSITORY   UPSTREAM UPDATES
-      git.basens-edit-clone.update-2   git                   v1
+      git.basens-edit-clone.update-2   git                   1
   - args:
       - porchctl
       - rpkg
@@ -82,10 +82,10 @@ commands:
       - --discover=upstream
     stdout: |
       PACKAGE REVISION                 UPSTREAM REPOSITORY   UPSTREAM UPDATES
-      git.basens-edit.update-1                               No update available
       git.basens-edit.main                                   No update available
+      git.basens-edit.update-1                               No update available
       git.basens-edit.update-3                               No update available
-      git.basens-edit-clone.update-2   git                   v1
+      git.basens-edit-clone.update-2   git                   1
   - args:
       - porchctl
       - rpkg
@@ -94,13 +94,13 @@ commands:
       - --discover=downstream
     stdout: |
       PACKAGE REVISION           DOWNSTREAM PACKAGE               DOWNSTREAM UPDATE
-      git.basens-edit.update-3   git.basens-edit-clone.update-2   (draft "update-1")->v1
+      git.basens-edit.update-3   git.basens-edit-clone.update-2   (draft "update-1")->1
   - args:
       - porchctl
       - rpkg
       - update
       - --namespace=rpkg-update
-      - --revision=v1
+      - --revision=1
       - git.basens-edit-clone.update-2
     stdout: "git.basens-edit-clone.update-2 updated\n"
   - args:
@@ -111,8 +111,8 @@ commands:
       - --discover=upstream
     stdout: |
       PACKAGE REVISION                 UPSTREAM REPOSITORY   UPSTREAM UPDATES
-      git.basens-edit.update-1                               No update available
       git.basens-edit.main                                   No update available
+      git.basens-edit.update-1                               No update available
       git.basens-edit.update-3                               No update available
       git.basens-edit-clone.update-2   git                   No update available
   - args:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -146,7 +146,7 @@ func (t *PorchSuite) TestCloneFromUpstream() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	upstreamPr := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 1})
+	upstreamPr := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 1})
 
 	// Register the repository as 'downstream'
 	t.RegisterMainGitRepositoryF("downstream")
@@ -250,9 +250,13 @@ func (t *PorchSuite) TestConcurrentClones() {
 	upstreamPr := t.MustFindPackageRevision(
 		&list,
 		repository.PackageRevisionKey{
-			Repository: upstreamRepository,
-			Package:    upstreamPackage,
-			Revision:   1})
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: upstreamRepository,
+				},
+				Package: upstreamPackage,
+			},
+			Revision: 1})
 
 	// Create PackageRevision from upstream repo
 	clonedPr := t.CreatePackageSkeleton(downstreamRepository, downstreamPackage, workspace)
@@ -437,10 +441,14 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository() {
 	t.RegisterGitRepositoryF(testBlueprintsRepo, "test-blueprints", "")
 
 	var upstreamPackages porchapi.PackageRevisionList
-	t.ListE(&upstreamPackages, client.InNamespace(t.Namespace))
-	upstreamPackage := t.MustFindPackageRevision(&upstreamPackages, repository.PackageRevisionKey{
-		Repository:    "test-blueprints",
-		Package:       "basens",
+	t.ListE(ctx, &upstreamPackages, client.InNamespace(t.Namespace))
+	upstreamPackage := MustFindPackageRevision(t.T, &upstreamPackages, repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			RepoKey: repository.RepositoryKey{
+				Name: "test-blueprints",
+			},
+			Package: "basens",
+		},
 		Revision:      1,
 		WorkspaceName: "v1",
 	})
@@ -1606,8 +1614,8 @@ func (t *PorchSuite) TestPackageUpdate() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	basensV1 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 1})
-	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 2})
+	basensV1 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 1})
+	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 2})
 
 	// Register the repository as 'downstream'
 	t.RegisterMainGitRepositoryF(gitRepository)
@@ -1703,8 +1711,8 @@ func (t *PorchSuite) TestConcurrentPackageUpdates() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	basensV1 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 1})
-	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 2})
+	basensV1 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 1})
+	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 2})
 
 	// Register the repository as 'downstream'
 	t.RegisterMainGitRepositoryF(gitRepository)
@@ -1804,7 +1812,7 @@ func (t *PorchSuite) TestBuiltinFunctionEvaluator() {
 						Image: "gcr.io/kpt-fn/starlark:v0.4.3",
 						ConfigMap: map[string]string{
 							"source": `for resource in ctx.resource_list["items"]:
-  resource["metadata"]["annotations"]["foo"] = "bar"`,
+	  resource["metadata"]["annotations"]["foo"] = "bar"`,
 						},
 					},
 				},
@@ -2536,7 +2544,7 @@ func (t *PorchSuite) TestRegisteredPackageRevisionLabels() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	basens := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 1})
+	basens := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 1})
 	if basens.ObjectMeta.Labels == nil {
 		basens.ObjectMeta.Labels = make(map[string]string)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The kpt and Nephio Authors
+// Copyright 2024-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1048,7 +1048,7 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 		subfolderRepository  = "repo-in-subfolder"
 		subfolderDirectory   = "random/repo/folder"
 		normalPackageName    = "test-package"
-		subfolderPackageName = "randompackagefolder/test-package"
+		subfolderPackageName = "randompackagefoldertest-package"
 		workspace            = "workspace"
 		workspace2           = "workspace2"
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1056,7 +1056,7 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 		subfolderRepository  = "repo-in-subfolder"
 		subfolderDirectory   = "random/repo/folder"
 		normalPackageName    = "test-package"
-		subfolderPackageName = "randompackagefoldertest-package"
+		subfolderPackageName = "randompackagefolder/test-package"
 		workspace            = "workspace"
 		workspace2           = "workspace2"
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1048,7 +1048,7 @@ func (t *PorchSuite) TestSubfolderPackageRevisionIncrementation() {
 		subfolderRepository  = "repo-in-subfolder"
 		subfolderDirectory   = "random/repo/folder"
 		normalPackageName    = "test-package"
-		subfolderPackageName = "randompackagefoldertest-package"
+		subfolderPackageName = "randompackagefolder/test-package"
 		workspace            = "workspace"
 		workspace2           = "workspace2"
 	)

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -190,6 +190,11 @@ func (t *TestSuite) IsPorchServerInCluster() bool {
 }
 
 func (t *TestSuite) IsTestRunnerInCluster() bool {
+	runLocally := os.Getenv("RUN_E2E_LOCALLY")
+	if strings.ToLower(runLocally) == "true" {
+		return false
+	}
+
 	porch := aggregatorv1.APIService{}
 	ctx := context.TODO()
 	t.GetF(client.ObjectKey{

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -812,8 +812,8 @@ func (t *TestSuite) MustFindPackageRevision(packages *porchapi.PackageRevisionLi
 	t.T().Helper()
 	for i := range packages.Items {
 		pr := &packages.Items[i]
-		if pr.Spec.RepositoryName == name.Repository &&
-			pr.Spec.PackageName == name.Package &&
+		if pr.Spec.RepositoryName == name.PkgKey.RepoKey.Name &&
+			pr.Spec.PackageName == name.PkgKey.Package &&
 			pr.Spec.Revision == name.Revision {
 			return pr
 		}

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Nephio Authors
+// Copyright 2024-2025 The Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -481,8 +481,8 @@ func (t *TestSuite) WaitUntilPackageRevisionFulfillingConditionExists(
 	return foundPkgRev, err
 }
 
-func (t *TestSuite) WaitUntilPackageRevisionExists(ctx context.Context, repository string, pkgName string, revision int) *porchapi.PackageRevision {
-	t.Helper()
+func (t *TestSuite) WaitUntilPackageRevisionExists(repository string, pkgName string, revision int) *porchapi.PackageRevision {
+	t.T().Helper()
 	t.Logf("Waiting for package revision (%v/%v/%v) to exist", repository, pkgName, revision)
 	timeout := 120 * time.Second
 	foundPkgRev, err := t.WaitUntilPackageRevisionFulfillingConditionExists(timeout, func(pkgRev porchapi.PackageRevision) bool {
@@ -512,7 +512,6 @@ func (t *TestSuite) WaitUntilDraftPackageRevisionExists(repository string, pkgNa
 }
 
 func (t *TestSuite) WaitUntilPackageRevisionResourcesExists(
-	ctx context.Context,
 	key types.NamespacedName,
 ) *porchapi.PackageRevisionResources {
 
@@ -520,7 +519,7 @@ func (t *TestSuite) WaitUntilPackageRevisionResourcesExists(
 	t.Logf("Waiting for PackageRevisionResources object %v to exist", key)
 	timeout := 120 * time.Second
 	var foundPrr *porchapi.PackageRevisionResources
-	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
 		var prrList porchapi.PackageRevisionResourcesList
 		if err := t.Client.List(ctx, &prrList); err != nil {
 			t.Logf("error listing package revision resources: %v", err)
@@ -540,8 +539,8 @@ func (t *TestSuite) WaitUntilPackageRevisionResourcesExists(
 	return foundPrr
 }
 
-func (t *TestSuite) GetPackageRevision(ctx context.Context, repo string, pkgName string, revision int) *porchapi.PackageRevision {
-	t.Helper()
+func (t *TestSuite) GetPackageRevision(repo string, pkgName string, revision int) *porchapi.PackageRevision {
+	t.T().Helper()
 	var prList porchapi.PackageRevisionList
 	selector := client.MatchingFields(fields.Set{
 		"spec.repository":  repo,
@@ -559,7 +558,7 @@ func (t *TestSuite) GetPackageRevision(ctx context.Context, repo string, pkgName
 	return &prList.Items[0]
 }
 
-func (t *TestSuite) GetContentsOfPackageRevision(ctx context.Context, repository string, pkgName string, revision string) map[string]string {
+func (t *TestSuite) GetContentsOfPackageRevision(repository string, pkgName string, revision string) map[string]string {
 
 	t.T().Helper()
 	var prrList porchapi.PackageRevisionResourcesList

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -31,7 +31,7 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: 2})
+	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 2})
 	t.Logf("basensV2 = %v", basensV2)
 
 	// Register the repository as 'downstream'

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -31,7 +31,7 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 2})
+	basensV2 := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: "test-blueprints"}, Package: "basens"}, Revision: 2})
 	t.Logf("basensV2 = %v", basensV2)
 
 	// Register the repository as 'downstream'

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR refactors the existing Porch to make it easier to introduce a database cache. It:

#### Replaces string revisions with integer revisions
- Approved Package Revisions have revision numbers 1 or greater, the highest revision number is the latest revision
- Draft Package Revisions have a revision number of 0
- Placeholder Package Revisions (such as the "main" Package Revision) have a revision number of -1
- Tags and branch names in Git continue to use <........>/v1 for branches/tags for released revisions
- All conversions between textual representations of revisions in Git and integer revisions are carried out by utility functions in "pkg/repository/util.go", namely `Revision2Int()` and `Revision2Str()`
- Code for finding the next package revision number and comparing package revisions order is much simplified

#### Introduces proper key types on PackageRevision, Draft, and Repo entities so that it is easier and more consistent to keep track of them

1. The "repository/repository.go" contains the structs `RepositoryKey`, `PackageKey`, and `PackageRevisionKey`
  - A `PackageRevisionKey` contains a `Packagekey` which contains a `RepositoryKey`
  - A `RepositoryKey` holds the repo info, most significantly the repo name and its directory (for dereferencing)
  - A `PackageKey` contains the package name and its relative path (relative to its repo)
  - A `PackageRevisonKey` holds its revision number and its workspace
 2.  Utility functions on each of the keys handle all key conversion, all dereferencing (filepath joins etc) are removed from the code proper into the utility functions so that all pth conversions are done in one place in the code
  - `ToPkgPathName()` returns a git path relative to a repo
  - `ToFullPathName()` returns an absolute git path including the repo directory
  - `FromFullPathName()` returns a package key from a Git branch or tag reference
 3. Listing filters and `Match()` functions also now use these key structs
 4. All creation/update/delete/list code now uses the keys for dereferencing
 5. The `GetKubeObjectName()` functions call the utility `repository.ComposePkgRevObjName()` function to ensure kubernetes names are always consitent and generated in the same way everywhere.

#### Validity checking of package revisions is updated to allow subpackages to be specified

#### Adds the "RUN_E2E_LOCALLY environment variable to Porch e2e tests, which forces the E2E tests to run locally, also adds this environment variable to ".vscode/settings.json" with a default value of "false", set to "true" to run your E2E tests locally

#### Repositories with directories and packages with paths specified are both allowed and are working correctly together

1. A repo called "flat-repo" (no directory) with a package called "coyote-package" and a workspace called "road-runner" will result in
  + A Kube Object Name of "flat-repo.coyote-package.road-runner" for the PackageRevision
  + A directory structure on branches in the repo "flat-repo" of "coyote-package"
  + A draft branch "drafts/coyote-package/road-runner"
  + A proposed branch "proposed/coyote-package/road-runner"
  + An approved tag of "coyote-package/v1"
  + A Kube Object Name of "flat-repo.coyote-package.main" for the main PackageRevision

2. A repo called "flat-repo" (no directory) with a package called "wily/e/coyote-package" and a workspace called "road-runner" will result in
  + A Kube Object Name of "flat-repo.wily.e.coyote-package.road-runner " for the PackageRevision
  + A directory structure on branches in the repo "flat-repo" of "wily/e/coyote-package"
  + A draft branch "drafts/wily/e/coyote-package/road-runner"
  + A proposed branch "proposed/wily/e/coyote-package/road-runner"
  + An approved tag of "wily/e/coyote-package/v1"
  + A Kube Object Name of "flat-repo.wily.e.coyote-package.main" for the main PackageRevision

3. A repo called "dir-repo" with directory "open-ran-packages/acme" with a package called "coyote-package" and a workspace called "road-runner" will result in
  + A Kube Object Name of "dir-repo.coyote-package.road-runner" for the PackageRevision
  + A directory structure on branches in the repo "dir-repo" of "open-ran-packages/acme/coyote-package"
  + A draft branch "drafts/open-ran-packages/acme/coyote-package/road-runner"
  + A proposed branch "proposed/open-ran-packages/acme/coyote-package/road-runner"
  + An approved tag of "open-ran-packages/acme/coyote-package/v1"
  + A Kube Object Name of "dir-repo.coyote-package.main" for the main PackageRevision

4. A repo called "dir-repo" with directory "open-ran-packages/acme" with a package called "wily/e/coyote-package" and a workspace called "road-runner" will result in
  + A Kube Object Name of "dir-repo.wily.e.coyote-package.road-runner " for the PackageRevision
  + A directory structure on branches in the repo "dir-repo" of "open-ran-packages/acme/wily/e/coyote-package"
  + A draft branch "drafts/open-ran-packages/acme/wily/e/coyote-package/road-runner"
  + A proposed branch "proposed/open-ran-packages/acme/wily/e/coyote-package/road-runner"
  + An approved tag of "open-ran-packages/acme/wily/e/coyote-package/v1"
  + A Kube Object Name of "dir-repo.wily.e.coyote-package.main" for the main PackageRevision

#### Goes some way to solve issues with finding the latest revision of a package

You can query the package revision resources and find the latest one by checking the REVISION column

```
kubectl get packagerevisionresources -A                                                           
NAMESPACE    NAME                                    PACKAGE          WORKSPACENAME   REVISION   REPOSITORY   FILES
porch-demo   porch-test.coyote-package.main          coyote-package   beep-beep       -1         porch-test   3
porch-demo   porch-test.coyote-package.road-runner   coyote-package   road-runner     1          porch-test   3
porch-demo   porch-test.coyote-package.beep-beep     coyote-package   beep-beep       2          porch-test   3
```

This PR provides part of the solution for issues https://github.com/nephio-project/nephio/issues/874 and https://github.com/nephio-project/nephio/issues/607.