### PR TITLE
Adding check for docker desktop

### DIFF
--- a/scripts/remove-porch-server-from-deployment-config.sh
+++ b/scripts/remove-porch-server-from-deployment-config.sh
@@ -48,7 +48,7 @@ kpt fn eval \
   -- 'source=ctx.resource_list["items"] = []'
 
 # make the api service point to the local porch-server
-if [ "$(uname)" = "Darwin" -o -n "${DOCKER_HOST+x}" ]
+if [[ "$(uname)" == "Darwin" || -n "${DOCKER_HOST+x}" ]] || docker info 2>/dev/null | grep -q "Docker Desktop";
 then
   echo "--- Docker Desktop detected. ---"
   kpt fn eval \


### PR DESCRIPTION
This script is called when using: `make run-in-kind` or `make run-in-kind-no-server`

Adding an extra check with OR to see if the user is using Windows with WSL and Docker Desktop where the DOCKER_HOST env should be unset.
This way porch packagerevisions will be available, and the setup will be successful.

Change-Id: Ie1f275b75e435cb5926efdc3ade52453e39b3b6c