### PR TITLE
Sync porch pkg details with catalog repo

### DIFF
--- a/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -1,4 +1,16 @@
----
+# Copyright 2024 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/controllers/config/crd/bases/config.porch.kpt.dev_packagevariants.yaml
+++ b/controllers/config/crd/bases/config.porch.kpt.dev_packagevariants.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/controllers/config/crd/bases/config.porch.kpt.dev_packagevariantsets.yaml
+++ b/controllers/config/crd/bases/config.porch.kpt.dev_packagevariantsets.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/controllers/config/rbac/role.yaml
+++ b/controllers/config/rbac/role.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/controllers/packagevariants/config/rbac/role.yaml
+++ b/controllers/packagevariants/config/rbac/role.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/controllers/packagevariants/config/rbac/rolebinding.yaml
+++ b/controllers/packagevariants/config/rbac/rolebinding.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/controllers/packagevariantsets/config/rbac/role.yaml
+++ b/controllers/packagevariantsets/config/rbac/role.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -27,6 +26,17 @@ rules:
   - config.porch.kpt.dev
   resources:
   - packagevariants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
   - packagevariantsets
   verbs:
   - create

--- a/controllers/packagevariantsets/config/rbac/rolebinding.yaml
+++ b/controllers/packagevariantsets/config/rbac/rolebinding.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployments/porch/3-porch-server.yaml
+++ b/deployments/porch/3-porch-server.yaml
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: porch-server
   namespace: porch-system
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -47,12 +45,16 @@ spec:
           # Update image to the image of your porch apiserver build.
           image: docker.io/nephio/porch-server:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              memory: 256Mi
+              cpu: 250m
             limits:
-              memory: "512Mi"
+              memory: 512Mi
           volumeMounts:
             - mountPath: /cache
               name: cache-volume
@@ -67,7 +69,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: porch-server
             - name: CERT_STORAGE_DIR
-              value: "/etc/webhook/certs"
+              value: /etc/webhook/certs
             - name: GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB
               value: "true"
           args:
@@ -75,19 +77,19 @@ spec:
             - --cache-directory=/cache
             - --cert-dir=/tmp/certs
             - --secure-port=4443
-            - --repo-sync-frequency=10m
+            - --repo-sync-frequency=3m
             - --disable-validating-admissions-policy=true
             - --max-request-body-size=6291456 # Keep this in sync with function-runner's corresponding argument
-
           #adding livenessProbes and readinessProbes for porch server
           livenessProbe:
             httpGet:
-              path: /livez
+              path: /healthz
               port: 4443
               scheme: HTTPS
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
+            successThreshold: 1
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
@@ -97,8 +99,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3
-            timeoutSeconds: 3              
-
+            successThreshold: 1
+            timeoutSeconds: 3                            
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/porch/5-rbac.yaml
+++ b/deployments/porch/5-rbac.yaml
@@ -24,9 +24,6 @@ rules:
     resources:
       ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "watch", "list", "create", "patch", "delete"]
-  - apiGroups: ["porch.kpt.dev"]
-    resources: ["functions"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["config.porch.kpt.dev"]
     resources: ["repositories", "repositories/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/deployments/porch/9-controllers.yaml
+++ b/deployments/porch/9-controllers.yaml
@@ -11,39 +11,41 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: porch-controllers
   namespace: porch-system
-
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: porch-controllers
   namespace: porch-system
   labels:
-    k8s-app: "porch-controllers"
+    k8s-app: porch-controllers
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: "porch-controllers"
+      k8s-app: porch-controllers
   template:
     metadata:
       labels:
-        k8s-app: "porch-controllers"
+        k8s-app: porch-controllers
     spec:
       serviceAccountName: porch-controllers
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
         image: docker.io/nephio/porch-controllers:latest
+        imagePullPolicy: IfNotPresent
+        # Note: only the existence of the variable matters for enabling the reconciler
+        # So, be sure to remove the var not just change the value to false
         env:
-        - name: EXAMPLE_ENV
+        - name: ENABLE_PACKAGEVARIANTS
+          value: "true"
+        - name: ENABLE_PACKAGEVARIANTSETS
           value: "true"
         livenessProbe:
           failureThreshold: 3

--- a/internal/api/porchinternal/v1alpha1/config.porch.kpt.dev_packagerevs.yaml
+++ b/internal/api/porchinternal/v1alpha1/config.porch.kpt.dev_packagerevs.yaml
@@ -1,4 +1,16 @@
----
+# Copyright 2024 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
To proceed with an automated update of the catalog repo from porch we need the kpt pkg contents to be more aligned.