### PR TITLE
Validate Repository name in CRD

### DIFF
--- a/api/generated/openapi/zz_generated.openapi.go
+++ b/api/generated/openapi/zz_generated.openapi.go
@@ -584,7 +584,7 @@ func schema_porch_api_porch_v1alpha1_PackageCloneTaskSpec(ref common.ReferenceCa
 					},
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "\tDefines which strategy should be used to update the package. It defaults to 'resource-merge'.\n * resource-merge: Perform a structural comparison of the original /\n   updated resources, and merge the changes into the local package.\n * fast-forward: Fail without updating if the local package was modified\n   since it was fetched.\n * force-delete-replace: Wipe all the local changes to the package and replace\n   it with the remote version.",
+							Description: "\tDefines which strategy should be used to update the package. It defaults to 'resource-merge'.\n * resource-merge: Perform a structural comparison of the original /\n   updated resources, and merge the changes into the local package.\n * fast-forward: Fail without updating if the local package was modified\n   since it was fetched.\n * force-delete-replace: Wipe all the local changes to the package and replace\n   it with the remote version.\n * copy-merge: Copy all the remote changes to the local package.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -209,6 +209,11 @@ spec:
                 type: array
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must conform to the RFC1123 DNS label standard
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+        - message: metadata.name must be no more than 63 characters
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/api/porchconfig/v1alpha1/types.go
+++ b/api/porchconfig/v1alpha1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import (
 //+kubebuilder:printcolumn:name="Deployment",type=boolean,JSONPath=`.spec.deployment`
 //+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 //+kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.spec['git','oci']['repo','registry']`
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')",message="metadata.name must conform to the RFC1123 DNS label standard"
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="metadata.name must be no more than 63 characters"
 
 // Repository
 type Repository struct {


### PR DESCRIPTION
#210 introduced changes to validations for PackageRevision creation, including the validation of `spec.repository`. However, this validation was not enforced on the Repository CRs themselves (only via the background task, which did not prevent the creation of such Repository objects).

In this PR, I'm simply adding that validation to the CRD as well.