### PR TITLE
porchctl - Fix Update issue when the package has local changes

### DIFF
--- a/pkg/cli/commands/rpkg/update/command.go
+++ b/pkg/cli/commands/rpkg/update/command.go
@@ -159,7 +159,7 @@ func (r *runner) doUpdate(pr *porchapi.PackageRevision) error {
 		newTask := porchapi.Task{
 			Type: porchapi.TaskTypeUpdate,
 			Update: &porchapi.PackageUpdateTaskSpec{
-				Upstream: cloneTask.Clone.Upstream,
+				Upstream: *cloneTask.Clone.Upstream.DeepCopy(),
 			},
 		}
 		newTask.Update.Upstream.UpstreamRef.Name = newUpstreamPr.Name

--- a/test/e2e/cli/testdata/rpkg-update/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-update/config.yaml
@@ -151,3 +151,277 @@ commands:
       - --discover=upstream
     stderr: "Error: could not parse upstreamLock in Kptfile of package \"git.basens-edit-clone.update-2\": malformed upstreamLock.Git.Ref \"invalid\" \n"
     exitCode: 1
+##COPY-MERGE UPDATE
+  # Step 1: Create Blueprint v1
+  - args:
+      - porchctl
+      - rpkg
+      - init
+      - blueprint
+      - --namespace=rpkg-update
+      - --repository=git
+      - --workspace=v1
+    stdout: "git.blueprint.v1 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-blueprint
+  - args:
+      - sh
+      - -c
+      - |
+        echo "ORIGINAL" > /tmp/porch-e2e/local-pack-blueprint/README.md && \
+        kubectl create deployment test-dep --image=busybox --dry-run=client -o yaml > /tmp/porch-e2e/local-pack-blueprint/a.yaml && \
+        kubectl create configmap test-dep --dry-run=client -o yaml > /tmp/porch-e2e/local-pack-blueprint/b.yaml
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-blueprint
+    stdout: "git.blueprint.v1 pushed\n"
+  # Step 2: Approve Blueprint v1
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v1 proposed\n"
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v1 approved\n"
+
+  # Step 3: Copy Blueprint v1 to v2 and update
+  - args:
+      - porchctl
+      - rpkg
+      - copy
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+      - --workspace=v2
+    stdout: "git.blueprint.v2 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - git.blueprint.v2
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-blueprint2
+  - args:
+      - sh
+      - -c
+      - |
+        sed -i 's/replicas: 1/replicas: 2/' /tmp/porch-e2e/local-pack-blueprint2/a.yaml && \
+        kubectl create deployment my-dep --image=nginx --dry-run=client -o yaml > /tmp/porch-e2e/local-pack-blueprint2/c.yaml
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - git.blueprint.v2
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-blueprint2
+    stdout: "git.blueprint.v2 pushed\n"
+  # Step 4: Approve Blueprint v2
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - git.blueprint.v2
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v2 proposed\n"
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - git.blueprint.v2
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v2 approved\n"
+
+  # Step 5: Clone Blueprint v1 to Deployment v1 with copy-merge strategy
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - git.blueprint.v1
+      - --namespace=rpkg-update
+      - --repository=git
+      - --workspace=v0
+      - --strategy=copy-merge
+      - deployment
+    stdout: "git.deployment.v0 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - copy
+      - git.deployment.v0
+      - --namespace=rpkg-update
+      - --workspace=v1
+      - --replay-strategy
+    stdout: "git.deployment.v1 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - git.deployment.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-deployment
+  - args:
+      - sh
+      - -c
+      - |
+        kubectl create service clusterip CIQ --tcp=80:80 --dry-run=client -o yaml > /tmp/porch-e2e/local-pack-deployment/cIQ.yaml && \
+        kubectl create secret generic test-val --dry-run=client -o yaml > /tmp/porch-e2e/local-pack-deployment/day0value.yaml && \
+        echo "LOCAL" > /tmp/porch-e2e/local-pack-deployment/README.md && \
+        sed -i 's/replicas: 1/replicas: 3/' /tmp/porch-e2e/local-pack-deployment/a.yaml
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - git.deployment.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-deployment
+    stdout: "git.deployment.v1 pushed\n"
+  # Step 6: Update Deployment v1 with Blueprint v2
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - git.deployment.v1
+      - --namespace=rpkg-update
+      - --revision=2
+    stdout: "git.deployment.v1 updated\n"
+  # Step 7: Check the updated value
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-update
+      - git.deployment.v1
+      - /tmp/porch-e2e/local-pack-result
+  - args:
+      - sh
+      - -c
+      - |
+        cat /tmp/porch-e2e/local-pack-result/a.yaml | grep "replicas: 2"
+    stdout: "  replicas: 2\n"
+  - args:
+      - sh
+      - -c
+      - |
+        ls /tmp/porch-e2e/local-pack-result
+    stdout: "Kptfile\nREADME.md\na.yaml\nb.yaml\nc.yaml\ncIQ.yaml\nday0value.yaml\npackage-context.yaml\n"
+##FORCE-DELETE-REPLACE UPDATE
+  # Step 8: Copy Blueprint v1 to v2 and update
+  - args:
+      - porchctl
+      - rpkg
+      - copy
+      - git.blueprint.v2
+      - --namespace=rpkg-update
+      - --workspace=v3
+    stdout: "git.blueprint.v3 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-update
+      - git.blueprint.v3
+      - /tmp/porch-e2e/delete-replace-pack
+  - args:
+      - sh
+      - -c
+      - |
+        sed -i 's/replicas: 2/replicas: 5/' /tmp/porch-e2e/delete-replace-pack/a.yaml && rm /tmp/porch-e2e/delete-replace-pack/b.yaml
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - git.blueprint.v3
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/delete-replace-pack
+    stdout: "git.blueprint.v3 pushed\n"
+  # Step 9: Approve Blueprint v3
+  - args:
+      - porchctl
+      - rpkg
+      - propose
+      - git.blueprint.v3
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v3 proposed\n"
+  - args:
+      - porchctl
+      - rpkg
+      - approve
+      - git.blueprint.v3
+      - --namespace=rpkg-update
+    stdout: "git.blueprint.v3 approved\n"
+  # Step 10: Clone Blueprint v3 to DeleteReplace v1 with force-delete-replace strategy
+  - args:
+      - porchctl
+      - rpkg
+      - clone
+      - git.blueprint.v3
+      - --namespace=rpkg-update
+      - --repository=git
+      - --workspace=v1
+      - --strategy=force-delete-replace
+      - deletereplace
+    stdout: "git.deletereplace.v1 created\n"
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - git.deletereplace.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-deletereplace
+  - args:
+      - sh
+      - -c
+      - |
+        sed -i 's/replicas: 1/replicas: 11/' /tmp/porch-e2e/local-pack-deletereplace/a.yaml
+  - args:
+      - porchctl
+      - rpkg
+      - push
+      - git.deletereplace.v1
+      - --namespace=rpkg-update
+      - /tmp/porch-e2e/local-pack-deletereplace
+    stdout: "git.deletereplace.v1 pushed\n"
+  # Step 11: Update deletereplace v1 with Blueprint v3
+  - args:
+      - porchctl
+      - rpkg
+      - update
+      - git.deletereplace.v1
+      - --namespace=rpkg-update
+      - --revision=3
+    stdout: "git.deletereplace.v1 updated\n"
+  # Step 12: Check the updated values
+  - args:
+      - porchctl
+      - rpkg
+      - pull
+      - --namespace=rpkg-update
+      - git.deletereplace.v1
+      - /tmp/porch-e2e/local-pack-deletereplace-result
+  - args:
+      - sh
+      - -c
+      - |
+        cat /tmp/porch-e2e/local-pack-deletereplace-result/a.yaml | grep "replicas: 5"
+    stdout: "  replicas: 5\n"
+  - args:
+      - sh
+      - -c
+      - |
+        ls /tmp/porch-e2e/local-pack-deletereplace-result
+    stdout: "Kptfile\nREADME.md\na.yaml\nc.yaml\npackage-context.yaml\n"


### PR DESCRIPTION
https://github.com/nephio-project/nephio/issues/898

The line

```go
Upstream: cloneTask.Clone.Upstream,
```

could potentially cause issues if the `cloneTask.Clone.Upstream` object is modified elsewhere in the code. Since Go passes structs by value, this line assigns a reference to the `Upstream` field of the `cloneTask.Clone` object. If the `Upstream` field is later modified, it could unintentionally affect the `cloneTask.Clone.Upstream` object.

Making a copy ensures that the `Upstream` object in the new task is independent of the original `cloneTask.Clone.Upstream`.

```go
Upstream: *cloneTask.Clone.Upstream.DeepCopy(),
```

---

Here's an example based on the script from before:
1. **Deployment v1** was cloned from **Blueprint v1**.
2. **Blueprint v2** was copied and approved.
3. **Deployment v1** can be updated to the second revision of **Blueprint**.

The issue is that after the update to revision=2, `spec.tasks.clone.upstreamRef.name` was changing 

### Old Version of `porchctl`
```yaml
porchctl rpkg get -n porch-demo porch-test.deployment.v1 -o yaml
apiVersion: porch.kpt.dev/v1alpha1
kind: PackageRevision
...
spec:
  lifecycle: Published
  packageName: deployment
  repository: porch-test
  revision: -1
  tasks:
  - clone:
      strategy: copy-merge
      upstreamRef:
        upstreamRef:
          name: porch-test.blueprint.v2
...
  - type: update
    update:
      upstreamRef:
        upstreamRef:
          name: porch-test.blueprint.v2
```

### New Version of `porchctl`
```yaml
.build/porchctl rpkg get -n porch-demo porch-test.deployment.v1 -o yaml
apiVersion: porch.kpt.dev/v1alpha1
kind: PackageRevision
...
spec:
  lifecycle: Published
  packageName: deployment
  repository: porch-test
  revision: 1
  tasks:
  - clone:
      strategy: copy-merge
      upstreamRef:
        upstreamRef:
          name: porch-test.blueprint.v1
    type: clone
...
  - type: update
    update:
      upstreamRef:
        upstreamRef:
          name: porch-test.blueprint.v2
```