### PR TITLE
Remove unnecessary remote interactions for `gitRepository.DeletePackageRevision`

### DIFF
--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -40,7 +40,7 @@ func TestPackageCommitEmptyRepo(t *testing.T) {
 	parent := plumbing.ZeroHash      // Empty repository
 	packageTree := plumbing.ZeroHash // Empty package
 	packagePath := "catalog/namespaces/istions"
-	ch, err := newCommitHelper(repo, userInfoProvider, parent, packagePath, packageTree)
+	ch, err := newCommitHelper(repo.repo, userInfoProvider, parent, packagePath, packageTree)
 	if err != nil {
 		t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 	}
@@ -113,7 +113,7 @@ func TestPackageCommitToMain(t *testing.T) {
 	draftTree := getCommitTree(t, gitRepo, draft.Hash())
 	bucketEntry := findTreeEntry(t, draftTree, packagePath)
 	bucketTree := bucketEntry.Hash
-	ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, bucketTree)
+	ch, err := newCommitHelper(repo.repo, userInfoProvider, main.Hash(), packagePath, bucketTree)
 	if err != nil {
 		t.Fatalf("Failed to create commit helper: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestCommitWithUser(t *testing.T) {
 
 		var zeroHash plumbing.Hash
 		const packagePath = "testpackage"
-		ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
+		ch, err := newCommitHelper(repo.repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
 		if err != nil {
 			t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 		}
@@ -210,7 +210,7 @@ func TestCommitWithUser(t *testing.T) {
 
 		var zeroHash plumbing.Hash
 		const packagePath = "testpackage-nouser"
-		ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
+		ch, err := newCommitHelper(repo.repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
 		if err != nil {
 			t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 		}

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1113,16 +1113,6 @@ func (r *gitRepository) createPackageDeleteCommit(ctx context.Context, branch pl
 	return commitHash, nil
 }
 
-func (r *gitRepository) PushAndCleanup(ctx context.Context, ph *pushRefSpecBuilder) error {
-	ctx, span := tracer.Start(ctx, "gitRepository::PushAndCleanup", trace.WithAttributes())
-	defer span.End()
-
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	return r.pushAndCleanup(ctx, ph)
-}
-
 func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuilder) error {
 	ctx, span := tracer.Start(ctx, "gitRepository::pushAndCleanup", trace.WithAttributes())
 	defer span.End()

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1045,10 +1045,6 @@ func (r *gitRepository) createBranch(ctx context.Context, branch BranchName) err
 	return r.pushAndCleanup(ctx, refSpecs)
 }
 
-func (r *gitRepository) getCommit(h plumbing.Hash) (*object.Commit, error) {
-	return object.GetCommit(r.repo.Storer, h)
-}
-
 // Creates a commit which deletes the package from the branch, and returns its commit hash.
 // If the branch doesn't exist, will return zero hash and no error.
 func (r *gitRepository) createPackageDeleteCommit(ctx context.Context, branch plumbing.ReferenceName, pkg *gitPackageRevision) (plumbing.Hash, error) {

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -544,6 +544,12 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 				refSpecs.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
 
 			case isDraftBranchNameInLocal(rn), isProposedBranchNameInLocal(rn):
+				// In case the remote has moved, the ref that points to a tag needs to have it's hash updated.
+				ref, err := r.repo.Reference(rn, true)
+				if err != nil {
+					return err
+				}
+
 				// PackageRevision is proposed or draft; delete the branch directly.
 				refSpecs.AddRefToDelete(ref)
 

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1304,16 +1304,8 @@ func (r *gitRepository) findLatestPackageCommit(startCommit *object.Commit, key 
 	return nil, pkgerrors.Errorf("could not find latest commit for package %s", key.ToFullPathname())
 }
 
-func (r *gitRepository) blobObject(h plumbing.Hash) (*object.Blob, error) {
-	return r.repo.BlobObject(h)
-}
-
 // commitCallback is the function type that needs to be provided to the history iterator functions.
 type commitCallback func(*object.Commit) error
-
-func (r *gitRepository) getTree(h plumbing.Hash) (*object.Tree, error) {
-	return object.GetTree(r.repo.Storer, h)
-}
 
 func (r *gitRepository) GetLifecycle(ctx context.Context, pkgRev *gitPackageRevision) v1alpha1.PackageRevisionLifecycle {
 	_, span := tracer.Start(ctx, "gitRepository::GetLifecycle", trace.WithAttributes())

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -1961,7 +1961,10 @@ func TestDeleteOnManuallyMovedTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create commit: %v", err)
 	}
-	gitRepo.Storer.SetReference(plumbing.NewHashReference(prv1.(*gitPackageRevision).ref.Name(), newHash))
+	err = gitRepo.Storer.SetReference(plumbing.NewHashReference(prv1.(*gitPackageRevision).ref.Name(), newHash))
+	if err != nil {
+		t.Fatalf("Failed to set reference: %v", err)
+	}
 	t.Logf("Moved %s from %s to %s", prv1.(*gitPackageRevision).ref, prv1.(*gitPackageRevision).commit, newHash)
 
 	t.Logf("Trying to delete published PackageRevision with a remote that's moved %s", prv1.Key())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -262,3 +262,15 @@ func CompareObjectMeta(left metav1.ObjectMeta, right metav1.ObjectMeta) bool {
 
 	return true
 }
+
+// RetryOnErrorConditional retries f up to retries times if it returns an error that matches shouldRetryFunc
+func RetryOnErrorConditional(retries int, shouldRetryFunc func(error) bool, f func(retryNumber int) error) error {
+	var err error
+	for i := 0; i < retries; i++ {
+		err = f(i)
+		if err == nil || !shouldRetryFunc(err) {
+			return err
+		}
+	}
+	return err
+}


### PR DESCRIPTION
Related to https://github.com/nephio-project/porch/issues/866

Cleaning up unnecessary fetches, and making the push logic retry in case the remote has moved on. The git repository now tries 0-3 times with a push-fetch-rebase loop, instead of a fixed fetch-push.

`TestApproveOnManuallyMovedMain` is not verifying new functionality, but will be used to ensure that follow-up porch PRs are not breaking cases when the Main has manually moved.

`TestDeleteOnManuallyMovedTag ` verifies that if a git tag is modified for any reason compared to the local, then the repository pulls down the new remote for that tag, and retries.  Test is green both on the baseline and in this current PR's contents. It ensures that the new retry logic in `gitRepository. DeletePackageRevision` is not breaking any previously available functionality. 

`TestDeleteManuallyMovedNonApproved` verfies that if a draft/proposed branch has changed in the remote while the local has not been updated, the delete command is still working correctly.

`TestDeleteOnManuallyMovedMainBranch` verifies if the `main` packageRevision (or any branch tracking packageRevision) is deleted, then `gitRepository` can remove it even if the remote branch has moved on compared to the local.

Removed `removeDeletionProposedBranchIfExists` as it was doing a separate push, and added the removal of the branch to the single push that's executed in `gitRepository. DeletePackageRevision`.

Utility changes:

Also a bit of refactoring on `git.go` moving some functions that don't rely on `repository.gitRepsository` just the `gogit.Repository` contained in it. New location is in the `gogit.go` file containing gogit helpers.

`commithelper` doesn't depend on `externalRepository.gitRepository`, only on `gogit.Repository`

