### PR TITLE
Update ubuntu version on porchctl action

### DIFF
--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: porchctl-dev-release
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
Job to build porchctl is failing because the ubuntu version is too old.