### PR TITLE
Update performance test Prometheus config

### DIFF
--- a/test/e2e/performance/config.yml
+++ b/test/e2e/performance/config.yml
@@ -7,3 +7,6 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:2113']
     scrape_interval: 0s100ms
+
+rule_files:
+  - "./rules.yml"

--- a/test/e2e/performance/performance_suite.go
+++ b/test/e2e/performance/performance_suite.go
@@ -27,7 +27,7 @@ type PerformanceSuite struct {
 func (t *PerformanceSuite) SetupSuite() {
 	flag.Parse()
 	t.TestSuiteWithGit.SetupSuite()
-	t.metricsServer = &http.Server{Addr: fmt.Sprintf(":%d", *metricsPort)}
+	t.metricsServer = &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", *metricsPort)}
 	t.metricsShutdown = make(chan struct{})
 	t.ServeMetrics()
 }

--- a/test/e2e/performance/prometheus_in_docker.sh
+++ b/test/e2e/performance/prometheus_in_docker.sh
@@ -13,7 +13,8 @@ function create() {
     --network prometheus \
     --add-host host.docker.internal:host-gateway \
     -p 9090:9090 \
-    -v $SCRIPT_DIR/config.yaml:/etc/prometheus/prometheus.yml \
+    -v $SCRIPT_DIR/config.yml:/etc/prometheus/prometheus.yml \
+    -v $SCRIPT_DIR/rules.yml:/etc/prometheus/rules.yml \
     prom/prometheus:v3.2.1
 }
 

--- a/test/e2e/performance/rules.yml
+++ b/test/e2e/performance/rules.yml
@@ -1,0 +1,47 @@
+groups:
+  - name: porch_rules
+    interval: 10s
+    rules:
+      - record: porch:package_revisions_count
+        expr: porch_package_revisions_count
+
+      # Average duration for create operations
+      - record: porch:create_operation_duration_seconds
+        expr: rate(porch_operation_duration_ms_sum{operation="create"}[1m]) / rate(porch_operation_duration_ms_count{operation="create"}[1m])
+        labels:
+          operation: create
+
+      # Average duration for propose operations
+      - record: porch:propose_operation_duration_seconds
+        expr: rate(porch_operation_duration_ms_sum{operation="propose"}[1m]) / rate(porch_operation_duration_ms_count{operation="propose"}[1m])
+        labels:
+          operation: propose
+
+      # Average duration for approve operations
+      - record: porch:approve_operation_duration_seconds
+        expr: rate(porch_operation_duration_ms_sum{operation="approve"}[1m]) / rate(porch_operation_duration_ms_count{operation="approve"}[1m])
+        labels:
+          operation: approve
+
+
+  - name: porch_alerts
+    rules:
+      # Alert for high propose operation latency
+      - alert: HighProposeLatency
+        expr: rate(porch_operation_duration_ms_sum{operation="propose"}[1m]) / rate(porch_operation_duration_ms_count{operation="propose"}[1m]) > 500
+        for: 10s
+        labels:
+          severity: warning
+        annotations:
+          summary: "High latency on propose operations"
+          description: "Propose operation latency is above 500ms for more than 10 seconds."
+
+      # Alert for high create operation latency
+      - alert: HighCreateLatency
+        expr: rate(porch_operation_duration_ms_sum{operation="create"}[1m]) / rate(porch_operation_duration_ms_count{operation="create"}[1m]) > 500
+        for: 10s
+        labels:
+          severity: warning
+        annotations:
+          summary: "High latency on create operations"
+          description: "Create operation latency is above 500ms for more than 10 seconds."


### PR DESCRIPTION
with net/http Server with address ":2113" serves the metrics using ipv6, adding an ip would serve on ipv4 "127.0.0.1:2113"
```bash
#Before
$ netstat -tuln | grep 2113
tcp6       0      0 :::2113                 :::*                    LISTEN

#After
$ netstat -tuln | grep 2113
tcp        0      0 127.0.0.1:2113          0.0.0.0:*               LISTEN
```
This is beneficial for developers on WSL2 that does not support ipv6 connections to the docker host.

Added also `rules.yml` with basic warnings and alerts http://localhost:9090/rules
