### PR TITLE
Porchfile render status

### DIFF
--- a/api/porch/v1alpha1/types.go
+++ b/api/porch/v1alpha1/types.go
@@ -32,10 +32,6 @@ type PackageRevision struct {
 	Status PackageRevisionStatus `json:"status,omitempty"`
 }
 
-// Porchfile structure
-type PorchFile struct {
-	Status *RenderStatus `yaml:"status,omitempty"`
-}
 // Key and value of the latest package revision label:
 
 const (
@@ -157,6 +153,10 @@ type Task struct {
 type TaskResult struct {
 	Task         *Task         `json:"task"`
 	RenderStatus *RenderStatus `json:"renderStatus,omitempty"`
+}
+
+type PorchFile struct {
+	Status *RenderStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // RenderStatus represents the result of performing render operation
@@ -392,56 +392,56 @@ const (
 
 // ResultList contains aggregated results from multiple functions
 type ResultList struct {
-	metav1.TypeMeta   `yaml:",inline"`
-	metav1.ObjectMeta `yaml:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	// ExitCode is the exit code of kpt command
-	ExitCode int `yaml:"exitCode"`
+	ExitCode int `json:"exitCode" yaml:"exitCode"`
 	// Items contain a list of function result
-	Items []*Result `yaml:"items,omitempty"`
+	Items []*Result `json:"items,omitempty" yaml:"items,omitempty"`
 }
 
 // Result contains the structured result from an individual function
 type Result struct {
 	// Image is the full name of the image that generates this result
 	// Image and Exec are mutually exclusive
-	Image string `yaml:"image,omitempty"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 	// ExecPath is the the absolute os-specific path to the executable file
 	// If user provides an executable file with commands, ExecPath should
 	// contain the entire input string.
-	ExecPath string `yaml:"exec,omitempty"`
+	ExecPath string `json:"exec,omitempty" yaml:"exec,omitempty"`
 	// TODO(droot): This is required for making structured results subpackage aware.
 	// Enable this once test harness supports filepath based assertions.
 	// Pkg is OS specific Absolute path to the package.
 	// Pkg string `yaml:"pkg,omitempty"`
 	// Stderr is the content in function stderr
-	Stderr string `yaml:"stderr,omitempty"`
+	Stderr string `json:"stderr,omitempty" yaml:"stderr,omitempty"`
 	// ExitCode is the exit code from running the function
-	ExitCode int `yaml:"exitCode"`
+	ExitCode int `json:"exitCode" yaml:"exitCode"`
 	// Results is the list of results for the function
-	Results []ResultItem `yaml:"results,omitempty"`
+	Results []ResultItem `json:"results,omitempty" yaml:"results,omitempty"`
 }
 
 // ResultItem defines a validation result
 type ResultItem struct {
 	// Message is a human readable message. This field is required.
-	Message string `yaml:"message,omitempty"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 
 	// Severity is the severity of this result
-	Severity string `yaml:"severity,omitempty"`
+	Severity string `json:"severity,omitempty" yaml:"severity,omitempty"`
 
 	// ResourceRef is a reference to a resource.
 	// Required fields: apiVersion, kind, name.
-	ResourceRef *ResourceIdentifier `yaml:"resourceRef,omitempty"`
+	ResourceRef *ResourceIdentifier `json:"resourceRef,omitempty" yaml:"resourceRef,omitempty"`
 
 	// Field is a reference to the field in a resource this result refers to
-	Field *Field `yaml:"field,omitempty"`
+	Field *Field `json:"field,omitempty" yaml:"field,omitempty"`
 
 	// File references a file containing the resource this result refers to
-	File *File `yaml:"file,omitempty"`
+	File *File `json:"file,omitempty" yaml:"file,omitempty"`
 
 	// Tags is an unstructured key value map stored with a result that may be set
 	// by external tools to store and retrieve arbitrary metadata
-	Tags map[string]string `yaml:"tags,omitempty"`
+	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // File references a file containing a resource

--- a/api/porch/v1alpha1/types.go
+++ b/api/porch/v1alpha1/types.go
@@ -32,6 +32,10 @@ type PackageRevision struct {
 	Status PackageRevisionStatus `json:"status,omitempty"`
 }
 
+// Porchfile structure
+type PorchFile struct {
+	Status *RenderStatus `yaml:"status,omitempty"`
+}
 // Key and value of the latest package revision label:
 
 const (
@@ -159,7 +163,7 @@ type TaskResult struct {
 // on a package resources.
 type RenderStatus struct {
 	Result ResultList `json:"result,omitempty"`
-	Err    string     `json:"error"`
+	Err    string     `json:"error,omitempty"`
 }
 
 // PackageInitTaskSpec defines the package initialization task.
@@ -388,56 +392,56 @@ const (
 
 // ResultList contains aggregated results from multiple functions
 type ResultList struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `yaml:",inline"`
+	metav1.ObjectMeta `yaml:"metadata,omitempty"`
 	// ExitCode is the exit code of kpt command
-	ExitCode int `json:"exitCode"`
+	ExitCode int `yaml:"exitCode"`
 	// Items contain a list of function result
-	Items []*Result `json:"items,omitempty"`
+	Items []*Result `yaml:"items,omitempty"`
 }
 
 // Result contains the structured result from an individual function
 type Result struct {
 	// Image is the full name of the image that generates this result
 	// Image and Exec are mutually exclusive
-	Image string `json:"image,omitempty"`
+	Image string `yaml:"image,omitempty"`
 	// ExecPath is the the absolute os-specific path to the executable file
 	// If user provides an executable file with commands, ExecPath should
 	// contain the entire input string.
-	ExecPath string `json:"exec,omitempty"`
+	ExecPath string `yaml:"exec,omitempty"`
 	// TODO(droot): This is required for making structured results subpackage aware.
 	// Enable this once test harness supports filepath based assertions.
 	// Pkg is OS specific Absolute path to the package.
 	// Pkg string `yaml:"pkg,omitempty"`
 	// Stderr is the content in function stderr
-	Stderr string `json:"stderr,omitempty"`
+	Stderr string `yaml:"stderr,omitempty"`
 	// ExitCode is the exit code from running the function
-	ExitCode int `json:"exitCode"`
+	ExitCode int `yaml:"exitCode"`
 	// Results is the list of results for the function
-	Results []ResultItem `json:"results,omitempty"`
+	Results []ResultItem `yaml:"results,omitempty"`
 }
 
 // ResultItem defines a validation result
 type ResultItem struct {
 	// Message is a human readable message. This field is required.
-	Message string `json:"message,omitempty"`
+	Message string `yaml:"message,omitempty"`
 
 	// Severity is the severity of this result
-	Severity string `json:"severity,omitempty"`
+	Severity string `yaml:"severity,omitempty"`
 
 	// ResourceRef is a reference to a resource.
 	// Required fields: apiVersion, kind, name.
-	ResourceRef *ResourceIdentifier `json:"resourceRef,omitempty"`
+	ResourceRef *ResourceIdentifier `yaml:"resourceRef,omitempty"`
 
 	// Field is a reference to the field in a resource this result refers to
-	Field *Field `json:"field,omitempty"`
+	Field *Field `yaml:"field,omitempty"`
 
 	// File references a file containing the resource this result refers to
-	File *File `json:"file,omitempty"`
+	File *File `yaml:"file,omitempty"`
 
 	// Tags is an unstructured key value map stored with a result that may be set
 	// by external tools to store and retrieve arbitrary metadata
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `yaml:"tags,omitempty"`
 }
 
 // File references a file containing a resource

--- a/internal/kpt/pkg/pkg.go
+++ b/internal/kpt/pkg/pkg.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	rgfilev1alpha1 "github.com/GoogleContainerTools/kpt/pkg/api/resourcegroup/v1alpha1"
+	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/internal/kpt/types"
 	"github.com/nephio-project/porch/internal/kpt/util/git"
@@ -264,6 +265,24 @@ func DecodeKptfile(in io.Reader) (*kptfilev1.KptFile, error) {
 		return kf, err
 	}
 	return kf, nil
+}
+
+func DecodePorchfile(in io.Reader) (*v1alpha1.PorchFile, error) {
+	pf := &v1alpha1.PorchFile{}
+	c, err := io.ReadAll(in)
+	if err != nil {
+		return pf, err
+	}
+	// if err := CheckKptfileVersion(c); err != nil {
+	// 	return kf, err
+	// }
+
+	d := yaml.NewDecoder(bytes.NewBuffer(c))
+	d.KnownFields(true)
+	if err := d.Decode(pf); err != nil {
+		return pf, err
+	}
+	return pf, nil
 }
 
 // CheckKptfileVersion verifies the apiVersion and kind of the resource

--- a/internal/kpt/pkg/pkg.go
+++ b/internal/kpt/pkg/pkg.go
@@ -267,16 +267,13 @@ func DecodeKptfile(in io.Reader) (*kptfilev1.KptFile, error) {
 	return kf, nil
 }
 
+// decoder for Porchfile's in porch packages
 func DecodePorchfile(in io.Reader) (*v1alpha1.PorchFile, error) {
 	pf := &v1alpha1.PorchFile{}
 	c, err := io.ReadAll(in)
 	if err != nil {
 		return pf, err
 	}
-	// if err := CheckKptfileVersion(c); err != nil {
-	// 	return kf, err
-	// }
-
 	d := yaml.NewDecoder(bytes.NewBuffer(c))
 	d.KnownFields(true)
 	if err := d.Decode(pf); err != nil {

--- a/internal/kpt/pkg/pkg.go
+++ b/internal/kpt/pkg/pkg.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 
 	rgfilev1alpha1 "github.com/GoogleContainerTools/kpt/pkg/api/resourcegroup/v1alpha1"
-	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/internal/kpt/types"
 	"github.com/nephio-project/porch/internal/kpt/util/git"
@@ -265,21 +264,6 @@ func DecodeKptfile(in io.Reader) (*kptfilev1.KptFile, error) {
 		return kf, err
 	}
 	return kf, nil
-}
-
-// decoder for Porchfile's in porch packages
-func DecodePorchfile(in io.Reader) (*v1alpha1.PorchFile, error) {
-	pf := &v1alpha1.PorchFile{}
-	c, err := io.ReadAll(in)
-	if err != nil {
-		return pf, err
-	}
-	d := yaml.NewDecoder(bytes.NewBuffer(c))
-	d.KnownFields(true)
-	if err := d.Decode(pf); err != nil {
-		return pf, err
-	}
-	return pf, nil
 }
 
 // CheckKptfileVersion verifies the apiVersion and kind of the resource

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -153,8 +153,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	}
 	rs := pkgResources.Status.RenderStatus
 	if rs.Err != "" {
-		r.printer.Printf("Package is updated, but failed to render the package.\n")
-		r.printer.Printf("Error: %s\n", rs.Err)
+		r.printer.Printf("Package failed render but has still been updated & pushed to git.\n")
 	}
 	if len(rs.Result.Items) > 0 {
 		for _, result := range rs.Result.Items {
@@ -167,6 +166,9 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 			}
 			r.printFnResult(result, printOpt)
 		}
+	}
+	if rs.Err != "" {
+		r.printer.Printf("Error: %s\n", rs.Err)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s pushed\n", packageName)
 	return nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -192,6 +192,9 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	}
 
 	repoPkgRev, err := repo.ClosePackageRevisionDraft(ctx, draft, 0)
+	if err != nil {
+		return nil, err
+	}
 
 	// if render fails we allow resource creation alongside the error
 	if renderFailed {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -191,22 +191,17 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 		return nil, err
 	}
 
-	repoPkgRev, err := repo.ClosePackageRevisionDraft(ctx, draft, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// if render fails we allow resource creation alongside the error
-	if renderFailed {
-		return repoPkgRev, tasksErr
-	}
-
 	// Close the draft
 	repoPkgRev, err := repo.ClosePackageRevisionDraft(ctx, draft, 0)
 	if err != nil {
 		// Don't call rollback() here since it would likely fail again
 		// Just return the error from the close operation
 		return nil, fmt.Errorf("failed to close package revision draft: %w", err)
+	}
+
+	// if render fails we allow resource creation alongside the error
+	if renderFailed {
+		return repoPkgRev, tasksErr
 	}
 
 	return repoPkgRev, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -176,8 +176,8 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	// Apply tasks
 	tasksErr := cad.taskHandler.ApplyTasks(ctx, draft, repositoryObj, obj, packageConfig)
 	if tasksErr != nil {
-		var rerr *task.RenderError
-		if errors.As(tasksErr, &rerr) {
+		var renderErr *task.RenderError
+		if errors.As(tasksErr, &renderErr) {
 			renderFailed = true
 		} else {
 			rollback()
@@ -471,8 +471,8 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 	// if error is a render error we take note and allow further operation else return error and no resource update
 	renderFailed := false
 	if mutationErr != nil {
-		var rerr *task.RenderError
-		if errors.As(mutationErr, &rerr) {
+		var renderErr *task.RenderError
+		if errors.As(mutationErr, &renderErr) {
 			renderFailed = true
 		} else {
 			return nil, renderStatus, err

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -236,7 +236,7 @@ func (p *gitPackageRevision) GetPorchfile(ctx context.Context) (v1alpha1.PorchFi
 	if !found {
 		return v1alpha1.PorchFile{}, nil
 	}
-	pf, err := pkg.DecodePorchfile(strings.NewReader(pfString))
+	pf, err := util.DecodePorchfile(strings.NewReader(pfString))
 	if err != nil {
 		return v1alpha1.PorchFile{}, fmt.Errorf("error decoding Porchfile: %w", err)
 	}

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -147,13 +147,13 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package resources: %w", err)
 	}
-	pf, err := p.GetPorchfile(ctx)
+	porchFile, err := p.GetPorchfile()
 	if err != nil {
 		klog.Errorf("error: %v", err)
 	}
-	var rs v1alpha1.RenderStatus
-	if pf.Status != nil {
-		rs = *pf.Status
+	var renderStatus v1alpha1.RenderStatus
+	if porchFile.Status != nil {
+		renderStatus = *porchFile.Status
 	}
 	p.mutex.Lock()
 	prRes := &v1alpha1.PackageRevisionResources{
@@ -180,7 +180,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			Resources: resources,
 		},
 		Status: v1alpha1.PackageRevisionResourcesStatus{
-			RenderStatus: rs,
+			RenderStatus: renderStatus,
 		},
 	}
 	p.mutex.Unlock()
@@ -227,20 +227,20 @@ func (p *gitPackageRevision) GetKptfile(ctx context.Context) (kptfile.KptFile, e
 	return *kf, nil
 }
 
-func (p *gitPackageRevision) GetPorchfile(ctx context.Context) (v1alpha1.PorchFile, error) {
+func (p *gitPackageRevision) GetPorchfile() (v1alpha1.PorchFile, error) {
 	resources, err := p.repo.GetResources(p.tree)
 	if err != nil {
 		return v1alpha1.PorchFile{}, fmt.Errorf("error loading package resources: %w", err)
 	}
-	pfString, found := resources["Porchfile"]
+	porchFileString, found := resources["Porchfile"]
 	if !found {
 		return v1alpha1.PorchFile{}, nil
 	}
-	pf, err := util.DecodePorchfile(strings.NewReader(pfString))
+	porchFile, err := util.DecodePorchfile(strings.NewReader(porchFileString))
 	if err != nil {
 		return v1alpha1.PorchFile{}, fmt.Errorf("error decoding Porchfile: %w", err)
 	}
-	return *pf, nil
+	return *porchFile, nil
 }
 
 // GetUpstreamLock returns the upstreamLock info present in the Kptfile of the package.

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -189,7 +189,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		if errors.As(rendErr, &rerr) {
 			renderFailed = true
 		} else {
-			return nil, apierrors.NewInternalError(err)
+			return nil, apierrors.NewInternalError(rendErr)
 		}
 	}
 

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -185,8 +185,8 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 	// if the error occurred is a render error allow it to pass else return error
 	renderFailed := false
 	if rendErr != nil {
-		var rerr *task.RenderError
-		if errors.As(rendErr, &rerr) {
+		var renderErr *task.RenderError
+		if errors.As(rendErr, &renderErr) {
 			renderFailed = true
 		} else {
 			return nil, apierrors.NewInternalError(rendErr)

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -182,7 +182,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 
 	createdRepoPkgRev, rendErr := r.cad.CreatePackageRevision(ctx, repositoryObj, newApiPkgRev, parentPackage)
 
-	// if the error occured is a render error allow it to pass else return error
+	// if the error occurred is a render error allow it to pass else return error
 	renderFailed := false
 	if rendErr != nil {
 		var rerr *task.RenderError
@@ -198,7 +198,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		return nil, apierrors.NewInternalError(err)
 	}
 
-	// if render error create resource but also return render error to user
+	// if render error occurred create resource but also return render error to user
 	if renderFailed {
 		status := metav1.Status{
 			Status:  metav1.StatusFailure,

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -187,7 +187,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 
 	renderFailed := false
 
-	// if the error occured is a render error allow it to pass else return error
+	// if the error occurred is a render error allow it to pass else return error
 	if rendErr != nil {
 		var rerr *task.RenderError
 		if errors.As(rendErr, &rerr) {
@@ -205,7 +205,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		created.Status.RenderStatus = *renderStatus
 	}
 
-	// if render error update resource but also return render error to user
+	// if render error occurred update resource but also return render error to user
 	if renderFailed {
 		status := metav1.Status{
 			Status:  metav1.StatusFailure,

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -496,8 +496,6 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageRevisio
 				}, task); err != nil {
 					return updatedResources, renderStatus, err
 				}
-				baseResources = updatedResources
-				applied = updatedResources
 				return updatedResources, renderStatus, err
 			}
 			// else we simply append the render status to the porch file with the new updated resources

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -247,9 +247,9 @@ func (th *genericTaskHandler) DoPRResourceMutations(ctx context.Context, pr2Upda
 				runnerOptions: runnerOptions,
 				runtime:       th.runtime,
 			}})
-		// if err != nil {
-		// 	return renderStatus, nil
-		// }
+		if err != nil {
+			return renderStatus, err
+		}
 	} else {
 		renderStatus = nil
 	}
@@ -481,9 +481,11 @@ func applyResourceMutations(ctx context.Context, draft repository.PackageRevisio
 		if taskResult != nil && task.Type == api.TaskTypeEval {
 			renderStatus = taskResult.RenderStatus
 			if err != nil {
+				err = &RenderError{
+					Err: err,
+					Msg: "Porch Package Pipeline Failed Render",
+				}
 				klog.Error(err)
-				klog.Warning("Package Failed Render")
-				err = fmt.Errorf("%w\n\n%s\n%s\n%s", err, "Error occurred rendering package in kpt function pipeline.", "Package has NOT been pushed to remote.", "Please fix package locally (modify until 'kpt fn render' succeeds) and retry.")
 				// if we fail the render we return the same base resources but with the render status of the failure
 				appendRenderResult(renderStatus, baseResources)
 				updatedResources := baseResources

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -238,7 +238,7 @@ func (th *genericTaskHandler) DoPRResourceMutations(ctx context.Context, pr2Upda
 		// and are returned in the PackageRevisionResources API's status field & in the Porchfile in git.
 		// The package gets pushed further to Git along with its failed render status:
 
-		// NOTE render failure's caused by kpt functions later in the pipeline will cause changes made by 
+		// NOTE render failure's caused by kpt functions later in the pipeline will cause changes made by
 		// previous kpt functions earlier in the pipeline to be annulled (all or nothing)
 		// however user made changes will get propagated appropriately
 		_, renderStatus, err = applyResourceMutations(ctx,
@@ -450,12 +450,14 @@ func isRenderMutation(m mutation) bool {
 	return isRender
 }
 
+var marshalYAML = yaml.Marshal
+
 func appendRenderResult(renderStatus *api.RenderStatus, resources repository.PackageResources) {
 	porchFileContents := api.PorchFile{
 		Status: renderStatus,
 	}
 
-	bytePorchfile, marshErr := yaml.Marshal(&porchFileContents)
+	bytePorchfile, marshErr := marshalYAML(&porchFileContents)
 	if marshErr != nil {
 		klog.Errorf("Error in Marshaling PorchFile: %v", marshErr)
 	}

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -16,10 +16,15 @@ package task
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/nephio-project/porch/internal/kpt/builtins"
 	"github.com/nephio-project/porch/internal/kpt/fnruntime"
@@ -28,10 +33,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type mockPackageRevisionDraft struct{}
+// type mockPackageRevisionDraft struct{}
 
-func (m *mockPackageRevisionDraft) UpdateResources(ctx context.Context, resources *api.PackageRevisionResources, task *api.Task) error {
-	return nil
+type mockPackageRevisionDraft struct {
+	updateResourcesFn func(ctx context.Context, r *api.PackageRevisionResources, task *api.Task) error
+}
+
+// func (m *mockPackageRevisionDraft) UpdateResources(ctx context.Context, resources *api.PackageRevisionResources, task *api.Task) error {
+// 	return nil
+// }
+
+func (m *mockPackageRevisionDraft) UpdateResources(ctx context.Context, r *api.PackageRevisionResources, task *api.Task) error {
+	return m.updateResourcesFn(ctx, r, task)
 }
 
 func (m *mockPackageRevisionDraft) Key() repository.PackageRevisionKey {
@@ -153,4 +166,248 @@ func TestMapTaskToMutationPatchTask(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mutation)
 	assert.IsType(t, &applyPatchMutation{}, mutation)
+}
+
+var sampleRenderStatus = &api.RenderStatus{
+	Result: api.ResultList{
+		Items: []*api.Result{
+			{
+				Image:    "gcr.io/kpt-fn/set-namespace:v0.4.0",
+				ExitCode: 0,
+				Results: []api.ResultItem{
+					{
+						Message:  `namespace "" updated to "example-namespace", 1 value(s) changed`,
+						Severity: "info",
+					},
+				},
+			},
+			{
+				Image:    "gcr.io/kpt-fn/apply-replacements:v0.1.0",
+				ExitCode: 1,
+			},
+		},
+	},
+	Err: "fn.render: pkg /:\n\tpkg.render:\n\tpipeline.run: func eval \"gcr.io/kpt-fn/apply-replacements:v0.1.0\" failed: rpc error: code = Internal desc = unable to evaluate gcr.io/kpt-fn/apply-replacements:v0.1.0 with pod evaluator: rpc error: code = Internal desc = failed to evaluate function \"gcr.io/kpt-fn/apply-replacements:v0.1.0\" with structured results: [error]: target must specify resources to select and stderr: ",
+}
+
+var sampleResourcesOutput = repository.PackageResources{
+	Contents: map[string]string{
+		"Kptfile":                 "Kptfile content string",
+		"README.md":               "readme file content string",
+		"deployment.yaml":         "deployment file content string",
+		"apply-replacements.yaml": "apply-replacements file content string",
+		"package-context.yaml":    "package-context file content string",
+	},
+}
+
+var sampleExpectedYamlOutputString = `status:
+  result:
+    kind: ""
+    apiversion: ""
+    exitCode: 0
+    items:
+      - image: gcr.io/kpt-fn/set-namespace:v0.4.0
+        exitCode: 0
+        results:
+          - message: namespace "" updated to "example-namespace", 1 value(s) changed
+            severity: info
+      - image: gcr.io/kpt-fn/apply-replacements:v0.1.0
+        exitCode: 1
+  err: "fn.render: pkg /:\n\tpkg.render:\n\tpipeline.run: func eval \"gcr.io/kpt-fn/apply-replacements:v0.1.0\" failed: rpc error: code = Internal desc = unable to evaluate gcr.io/kpt-fn/apply-replacements:v0.1.0 with pod evaluator: rpc error: code = Internal desc = failed to evaluate function \"gcr.io/kpt-fn/apply-replacements:v0.1.0\" with structured results: [error]: target must specify resources to select and stderr: "
+`
+
+func copyPackageResources(original repository.PackageResources) repository.PackageResources {
+	newContents := make(map[string]string, len(original.Contents))
+	for key, value := range original.Contents {
+		newContents[key] = value
+	}
+	return repository.PackageResources{
+		Contents: newContents,
+	}
+}
+
+func TestAppendRenderResult(t *testing.T) {
+	type args struct {
+		renderStatus *api.RenderStatus
+		resources    repository.PackageResources
+	}
+
+	tests := []struct {
+		name            string
+		args            args
+		expectedYAML    string
+		overrideMarshal bool
+	}{
+		{
+			name: "Main Use Case",
+			args: args{
+				renderStatus: sampleRenderStatus,
+				resources:    copyPackageResources(sampleResourcesOutput),
+			},
+			expectedYAML: sampleExpectedYamlOutputString,
+		},
+		{
+			name: "Marshal Error Use Case",
+			args: args{
+				renderStatus: sampleRenderStatus,
+				resources:    copyPackageResources(sampleResourcesOutput),
+			},
+			overrideMarshal: true,
+			expectedYAML:    "", // We expect Porchfile to be an empty string
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Optionally override marshal function to simulate error
+			if tt.overrideMarshal {
+				original := marshalYAML
+				defer func() { marshalYAML = original }()
+				marshalYAML = func(v interface{}) ([]byte, error) {
+					return nil, fmt.Errorf("simulated marshal error")
+				}
+			}
+
+			appendRenderResult(tt.args.renderStatus, tt.args.resources)
+			got := tt.args.resources.Contents["Porchfile"]
+
+			if tt.overrideMarshal {
+				if got != "" {
+					t.Errorf("Expected Porchfile to be empty string on marshal error, got: %q", got)
+				}
+				return
+			}
+
+			var gotYAML, expectedYAML map[string]interface{}
+			if err := yaml.Unmarshal([]byte(got), &gotYAML); err != nil {
+				t.Fatalf("Failed to unmarshal generated YAML: %v\nYAML:\n%s", err, got)
+			}
+			if err := yaml.Unmarshal([]byte(tt.expectedYAML), &expectedYAML); err != nil {
+				t.Fatalf("Failed to unmarshal expected YAML: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotYAML, expectedYAML) {
+				t.Errorf("YAML mismatch.\nGot:\n%v\nWant:\n%v", gotYAML, expectedYAML)
+			}
+		})
+	}
+}
+
+type mutationFunc func(context.Context, repository.PackageResources) (repository.PackageResources, *api.TaskResult, error)
+
+func (f mutationFunc) apply(ctx context.Context, res repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
+	return f(ctx, res)
+}
+
+func TestApplyResourceMutations_EvalRenderTask(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake mutation that returns a render taskResult
+	mockMutation := mutationFunc(func(ctx context.Context, res repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
+		return copyPackageResources(sampleResourcesOutput), &api.TaskResult{
+			Task: &api.Task{
+				Type: api.TaskTypeEval,
+			},
+			RenderStatus: sampleRenderStatus,
+		}, nil
+	})
+
+	// Track UpdateResources call
+	var updated bool
+	mockDraft := &mockPackageRevisionDraft{
+		updateResourcesFn: func(ctx context.Context, r *api.PackageRevisionResources, task *api.Task) error {
+			updated = true
+			if r == nil || r.Spec.Resources["Porchfile"] == "" {
+				t.Errorf("Expected Porchfile to be populated in resources, got: %v", r.Spec.Resources)
+			}
+			return nil
+		},
+	}
+
+	applied, renderStatus, err := applyResourceMutations(ctx, mockDraft, copyPackageResources(sampleResourcesOutput), []mutation{mockMutation})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !updated {
+		t.Errorf("Expected UpdateResources to be called")
+	}
+	if renderStatus == nil {
+		t.Errorf("Expected renderStatus to be returned")
+	}
+	if applied.Contents["Porchfile"] == "" {
+		t.Errorf("Expected Porchfile to be added to resources")
+	}
+}
+
+func TestApplyResourceMutations_EvalRenderTaskWithError(t *testing.T) {
+	ctx := context.Background()
+
+	// This mutation returns a render taskResult but with a failure
+	mockMutation := mutationFunc(func(ctx context.Context, res repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
+		return repository.PackageResources{}, &api.TaskResult{
+			Task: &api.Task{
+				Type: api.TaskTypeEval,
+			},
+			RenderStatus: sampleRenderStatus,
+		}, errors.New("render failed")
+	})
+
+	var updateCalled bool
+	mockDraft := &mockPackageRevisionDraft{
+		updateResourcesFn: func(ctx context.Context, r *api.PackageRevisionResources, task *api.Task) error {
+			updateCalled = true
+			if r.Spec.Resources["Porchfile"] == "" {
+				t.Errorf("Expected Porchfile to be included in resources")
+			}
+			return nil
+		},
+	}
+
+	applied, _, err := applyResourceMutations(ctx, mockDraft, copyPackageResources(sampleResourcesOutput), []mutation{mockMutation})
+	if err == nil {
+		t.Fatalf("Expected error to be returned")
+	}
+	if !strings.Contains(err.Error(), "Porch Package Pipeline Failed Render") {
+		t.Errorf("Expected wrapped render error, got: %v", err)
+	}
+	if !updateCalled {
+		t.Errorf("Expected UpdateResources to be called even after render error")
+	}
+	if applied.Contents["Porchfile"] == "" {
+		t.Errorf("Expected Porchfile to be written even after render error")
+	}
+}
+
+func TestApplyResourceMutations_UpdateResourcesFails(t *testing.T) {
+	ctx := context.Background()
+
+	mockMutation := mutationFunc(func(ctx context.Context, res repository.PackageResources) (repository.PackageResources, *api.TaskResult, error) {
+		// Successful mutation (non-render)
+		return copyPackageResources(sampleResourcesOutput), &api.TaskResult{
+			Task: &api.Task{
+				Type: api.TaskTypeInit, // Not Eval
+			},
+		}, nil
+	})
+
+	mockDraft := &mockPackageRevisionDraft{
+		updateResourcesFn: func(ctx context.Context, r *api.PackageRevisionResources, task *api.Task) error {
+			return errors.New("update failed")
+		},
+	}
+
+	applied, renderStatus, err := applyResourceMutations(ctx, mockDraft, copyPackageResources(sampleResourcesOutput), []mutation{mockMutation})
+	if err == nil {
+		t.Fatalf("Expected error due to failed UpdateResources")
+	}
+	if !strings.Contains(err.Error(), "update failed") {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	// Don't expect applied.Contents to be nil — it was set before the update failed.
+	if applied.Contents == nil || len(applied.Contents) == 0 {
+		t.Errorf("Expected applied to be populated before update failure")
+	}
+	if renderStatus != nil {
+		t.Errorf("Expected no renderStatus returned")
+	}
 }

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -396,16 +396,12 @@ func TestApplyResourceMutations_UpdateResourcesFails(t *testing.T) {
 		},
 	}
 
-	applied, renderStatus, err := applyResourceMutations(ctx, mockDraft, copyPackageResources(sampleResourcesOutput), []mutation{mockMutation})
+	_, renderStatus, err := applyResourceMutations(ctx, mockDraft, copyPackageResources(sampleResourcesOutput), []mutation{mockMutation})
 	if err == nil {
 		t.Fatalf("Expected error due to failed UpdateResources")
 	}
 	if !strings.Contains(err.Error(), "update failed") {
 		t.Errorf("Unexpected error returned: %v", err)
-	}
-	// Don't expect applied.Contents to be nil — it was set before the update failed.
-	if applied.Contents == nil || len(applied.Contents) == 0 {
-		t.Errorf("Expected applied to be populated before update failure")
 	}
 	if renderStatus != nil {
 		t.Errorf("Expected no renderStatus returned")

--- a/pkg/task/render_error.go
+++ b/pkg/task/render_error.go
@@ -16,6 +16,7 @@ package task
 
 import "fmt"
 
+// custom error type for differentiating render status errors from other types
 type RenderError struct {
 	Err error
 	Msg string

--- a/pkg/task/render_error.go
+++ b/pkg/task/render_error.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import "fmt"
+
+type RenderError struct {
+	Err error
+	Msg string
+}
+
+func (err *RenderError) Error() string {
+	return fmt.Sprintf("%s: %v", err.Msg, err.Err)
+}
+
+func (err *RenderError) Unwrap() error {
+	return err.Err
+}
+
+func NewRenderError(err error, msg string) error {
+	return &RenderError{Err: err, Msg: msg}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,17 +209,17 @@ func ValidPkgRevObjName(repoName, path, packageName, workspace string) error {
 
 // decoder for Porchfile's in porch packages
 func DecodePorchfile(in io.Reader) (*v1alpha1.PorchFile, error) {
-	pf := &v1alpha1.PorchFile{}
-	c, err := io.ReadAll(in)
+	porchFile := &v1alpha1.PorchFile{}
+	reader, err := io.ReadAll(in)
 	if err != nil {
-		return pf, err
+		return porchFile, err
 	}
-	d := yaml.NewDecoder(bytes.NewBuffer(c))
-	d.KnownFields(true)
-	if err := d.Decode(pf); err != nil {
-		return pf, err
+	decoder := yaml.NewDecoder(bytes.NewBuffer(reader))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(porchFile); err != nil {
+		return porchFile, err
 	}
-	return pf, nil
+	return porchFile, nil
 }
 
 func ParsePkgRevObjName(name string) ([]string, error) {

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -261,7 +261,9 @@ commands:
       - --namespace=rpkg-push
       - git.test-package.push
       - /tmp/porch-e2e/testing-invalid-render
+    stdout: |
+      git.test-package.push pushed
     stderr: |
-      Package failed render but has still been updated & pushed to git 
+      Package failed render but has still been updated & pushed to git.
     containsErrorString: true
-    exitCode: 1
+    exitCode: 0

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -262,8 +262,6 @@ commands:
       - git.test-package.push
       - /tmp/porch-e2e/testing-invalid-render
     stderr: |
-      Error occurred rendering package in kpt function pipeline.
-      Package has NOT been pushed to remote.
-      Please fix package locally (modify until 'kpt fn render' succeeds) and retry. 
+      Package failed render but has still been updated & pushed to git 
     containsErrorString: true
     exitCode: 1

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -861,7 +861,7 @@ func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {
 		Name:      pr.Name,
 	}, &resourcesAfterUpdate)
 
-	assert.Equal(t, 3, len(resourcesAfterUpdate.Spec.Resources))
+	assert.Equal(t, 4, len(resourcesAfterUpdate.Spec.Resources))
 	assert.EqualValues(t, resourcesBeforeUpdate, resourcesAfterUpdate)
 }
 


### PR DESCRIPTION
This PR is a re-implementation of nephio-project/nephio#108 

It attempts to resolve the same issues mentioned in nephio-project/nephio#108 namely
- https://github.com/nephio-project/porch/issues/846,
- https://github.com/nephio-project/porch/issues/602,
- https://github.com/nephio-project/porch/issues/859

The core premise is the introduction of a "Porchfile" in every Porch package which stores metadata regarding Porch
At the current moment in time this metadata is only the render status of the Porch Package.

- The blocker added at the Draft stage of a porch package is removed as part of this PR now that the render status of a Porch package is correctly getting propagated in Git (Porchfile) and in the CR (PackageRevisionResource's status field).
- NOTE: This does NOT apply a blocker to the Proposed or Approved stages of the Porch package which will be required to stop users from pushing faulty packages at any other stage after Draft.

This PR still needs 2 main tests added and this section will be marked as complete when ready
- [ ] Add Unit Tests for code coverage > 80%.
- [ ] E2E CLI Test for rpkg-clone when attempting to clone a faulty package.
- [ ] E2E Tests for pushing faulty rendered packages to git and ensuring the content of the Porchfile correctly gets appended.

Below are two diagrams describing the Before and After of a (Init -> Pull -> [Modify locally] -> Push) & (Clone) operations as both perform renders.

Before Porchfile:
![RENDER-DIAGRAM-WITHOUT-PORCHFILE excalidraw(2)](https://github.com/user-attachments/assets/b0fa3410-fbe0-47b8-9f95-0534faf5896b)

After Porchfile:
![RENDER-DIAGRAM-WITH-PORCHFILE excalidraw](https://github.com/user-attachments/assets/848000b3-ad53-4317-8c04-380d4429adba)
