### PR TITLE
Add flag to disable fn pods deployed at startup

### DIFF
--- a/func/server/server.go
+++ b/func/server/server.go
@@ -63,7 +63,7 @@ func main() {
 	flag.StringVar(&o.exec.ConfigFileName, "config", "./config.yaml", "Path to the config file of the exec runtime.")
 	// flags for the pod runtime
 	flag.StringVar(&o.pod.PodCacheConfigFileName, "pod-cache-config", "/pod-cache-config/pod-cache-config.yaml", "Path to the pod cache config file. The file is map of function name to TTL.")
-	flag.BoolVar(&o.pod.WarmUpPodCacheOnStartup, "warm-up-pod-cache", false, "if true, pod-cache-config image pods will be deployed at startup")
+	flag.BoolVar(&o.pod.WarmUpPodCacheOnStartup, "warm-up-pod-cache", true, "if true, pod-cache-config image pods will be deployed at startup")
 	flag.StringVar(&o.pod.PodNamespace, "pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
 	flag.DurationVar(&o.pod.PodTTL, "pod-ttl", 30*time.Minute, "TTL for pods before GC.")
 	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", time.Minute, "The interval of GC between scans.")

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -63,6 +63,7 @@ func main() {
 	flag.StringVar(&o.exec.ConfigFileName, "config", "./config.yaml", "Path to the config file of the exec runtime.")
 	// flags for the pod runtime
 	flag.StringVar(&o.pod.PodCacheConfigFileName, "pod-cache-config", "/pod-cache-config/pod-cache-config.yaml", "Path to the pod cache config file. The file is map of function name to TTL.")
+	flag.BoolVar(&o.pod.WarmUpPodCacheOnStartup, "warm-up-pod-cache", false, "if true, pod-cache-config image pods will be deployed at startup")
 	flag.StringVar(&o.pod.PodNamespace, "pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
 	flag.DurationVar(&o.pod.PodTTL, "pod-ttl", 30*time.Minute, "TTL for pods before GC.")
 	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", time.Minute, "The interval of GC between scans.")


### PR DESCRIPTION
Avoid the default list of fn pods starting up at deploy time which can be expensive on a limited internet connection.
