### PR TITLE
Evict failed pods from cache and trigger fresh pod creation.

### DIFF
--- a/func/internal/podevaluator_podmanager_test.go
+++ b/func/internal/podevaluator_podmanager_test.go
@@ -625,6 +625,52 @@ func TestPodManager(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "Failed pod is deleted and new one is created",
+			skip:          false,
+			expectFail:    false,
+			functionImage: "apply-replacements",
+			kubeClient: fake.NewClientBuilder().WithObjects([]client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "apply-replacements-5245a527",
+						Namespace: "porch-fn-system",
+						Labels: map[string]string{
+							krmFunctionLabel: "apply-replacements-5245a527",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "function",
+								Image: "apply-replacements",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						PodIP: "localhost",
+					},
+				},
+			}...).Build(),
+			namespace:          "porch-fn-system",
+			wrapperServerImage: "wrapper-server",
+			imageMetadataCache: defaultImageMetadataCache,
+			evalFunc:           defaultSuccessEvalFunc,
+			useGenerateName:    true,
+			podPatch: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					PodIP: "localhost",
+				},
+			},
+		},
 	}
 	fakeServer := &fakeFunctionEvalServer{
 		port: defaultWrapperServerPort,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2224,6 +2224,74 @@ func (t *PorchSuite) TestPodEvaluatorWithFailure() {
 	}
 }
 
+func (t *PorchSuite) TestFailedPodEvictionAndRecovery() {
+	if t.TestRunnerIsLocal {
+		t.Skipf("Skipping test: evaluator pod not available in local mode")
+	}
+
+	t.RegisterMainGitRepositoryF("git-fn-failed-recovery")
+
+	// Define a bogus kpt function image that will fail (image doesn't exist)
+	bogusFnImage := "quay.io/invalid/kpt-fn-broken:v0.0.1"
+
+	// Create a PackageRevision with an eval task that will fail
+	pr := &porchapi.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.Namespace,
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			PackageName:    "test-fn-pod-eviction",
+			WorkspaceName:  "workspace",
+			RepositoryName: "git-fn-failed-recovery",
+			Tasks: []porchapi.Task{
+				{
+					Type: "clone",
+					Clone: &porchapi.PackageCloneTaskSpec{
+						Upstream: porchapi.UpstreamPackage{
+							Type: "git",
+							Git: &porchapi.GitPackage{
+								Repo:      "https://github.com/GoogleCloudPlatform/blueprints.git",
+								Ref:       "bucket-blueprint-v0.4.3",
+								Directory: "catalog/bucket",
+							},
+						},
+					},
+				},
+				{
+					Type: "eval",
+					Eval: &porchapi.FunctionEvalTaskSpec{
+						Image: bogusFnImage,
+					},
+				},
+			},
+		},
+	}
+
+	// Create the package revision
+	err := t.Client.Create(t.GetContext(), pr)
+
+	// Assert: creation should fail, and the error should reflect evaluator pod failure
+	if err == nil || !strings.Contains(err.Error(), "failed to evaluate function") {
+		t.Fatalf("expected evaluator failure for broken image, but got: %v", err)
+	}
+
+	// Optional: verify no stuck pods exist for the failed image
+	pods := &corev1.PodList{}
+	if err := t.Client.List(t.GetContext(), pods, client.InNamespace(t.Namespace)); err != nil {
+		t.Fatalf("failed to list pods: %v", err)
+	}
+
+	for _, pod := range pods.Items {
+		if strings.Contains(pod.Spec.Containers[0].Image, "kpt-fn-broken") {
+			if pod.Status.Phase == corev1.PodFailed {
+				t.Logf("Found pod %s in Failed state (expected, cleanup should follow)", pod.Name)
+			} else {
+				t.Logf("Found pod %s in %s state", pod.Name, pod.Status.Phase)
+			}
+		}
+	}
+}
+
 func (t *PorchSuite) TestLargePackageRevision() {
 	const (
 		setAnnotationsImage = "gcr.io/kpt-fn/set-annotations:v0.1.3" // set-annotations:v0.1.3 is an older version that porch maps neither to built-in nor exec.


### PR DESCRIPTION
### Problem

In the current implementation, function pods that enter a `Failed` state are not evicted from the cache. Consequently, Porch continues to reuse these failed pods for subsequent evaluations, leading to persistent failures even after the underlying issue (e.g., registry unavailability) has been resolved.

### Solution

This PR introduces the following changes:

* Detects and deletes `Failed` pods during evaluation request handling.
* Deletes and evicts `Failed` pods during garbage collection.
* Adds asynchronous pod deletion (`deleteFailedPod`) with cache safety checks.
* Ensures fresh pod creation is triggered immediately after eviction.
* Adds a unit test case under `TestPodManager` to validate `Failed` pod handling.

