### PR TITLE
Fix double polling of repositories at sync startup

### DIFF
--- a/pkg/cache/crcache/repository.go
+++ b/pkg/cache/crcache/repository.go
@@ -463,7 +463,7 @@ func (r *cachedRepository) Close(ctx context.Context) error {
 	return r.repo.Close(ctx)
 }
 
-// pollForever will continue polling until signal channel is closed or ctx is done.
+// pollForever will continue polling until the signal channel is closed or the ctx is done.
 func (r *cachedRepository) pollForever(ctx context.Context, repoSyncFrequency time.Duration) {
 	for {
 		select {

--- a/pkg/cache/crcache/repository.go
+++ b/pkg/cache/crcache/repository.go
@@ -465,7 +465,6 @@ func (r *cachedRepository) Close(ctx context.Context) error {
 
 // pollForever will continue polling until signal channel is closed or ctx is done.
 func (r *cachedRepository) pollForever(ctx context.Context, repoSyncFrequency time.Duration) {
-	r.pollOnce(ctx)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Porch polls repositories twice when it sets up the sync job on a repository. This change eliminates the duplicate poll.