### PR TITLE
Skip patch mutation for Copy-Merge

### DIFF
--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ type genericTaskHandler struct {
 	repoOpener            repository.RepositoryOpener
 	credentialResolver    repository.CredentialResolver
 	referenceResolver     repository.ReferenceResolver
+	cloneStrategy         api.PackageMergeStrategy
 }
 
 func (th *genericTaskHandler) GetRuntime() fn.FunctionRuntime {
@@ -84,7 +85,13 @@ func (th *genericTaskHandler) ApplyTasks(ctx context.Context, draft repository.P
 			},
 		})
 	}
-
+	if len(tasks) > 0 {
+		cloneTask := obj.Spec.Tasks[0].Clone
+		if cloneTask != nil {
+			klog.Infof("Clone strategy is %s", cloneTask.Strategy)
+			th.cloneStrategy = cloneTask.Strategy
+		}
+	}
 	for i := range tasks {
 		task := &tasks[i]
 		mutation, err := th.mapTaskToMutation(ctx, obj, task, repositoryObj.Spec.Deployment, packageConfig)
@@ -159,7 +166,7 @@ func (th *genericTaskHandler) DoPRMutations(ctx context.Context, namespace strin
 		return err
 	}
 	if created {
-		kfPatchMutation, err := buildPatchMutation(ctx, kfPatchTask)
+		kfPatchMutation, err := buildPatchMutation(ctx, kfPatchTask, th.cloneStrategy)
 		if err != nil {
 			return err
 		}
@@ -292,7 +299,7 @@ func (th *genericTaskHandler) mapTaskToMutation(ctx context.Context, obj *api.Pa
 		}, nil
 
 	case api.TaskTypePatch:
-		return buildPatchMutation(ctx, task)
+		return buildPatchMutation(ctx, task, th.cloneStrategy)
 
 	case api.TaskTypeEdit:
 		if task.Edit == nil {

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -116,3 +116,41 @@ func TestApplyTasks(t *testing.T) {
 		})
 	}
 }
+
+func TestMapTaskToMutationPatchTask(t *testing.T) {
+	ctx := context.Background()
+
+	// Mock genericTaskHandler
+	handler := &genericTaskHandler{
+		cloneStrategy: api.CopyMerge,
+	}
+
+	// Mock task of type Patch
+	patchTask := &api.Task{
+		Type: api.TaskTypePatch,
+		Patch: &api.PackagePatchTaskSpec{
+			Patches: []api.PatchSpec{
+				{
+					File:      "test.yaml",
+					Contents:  "patch contents",
+					PatchType: api.PatchTypePatchFile,
+				},
+			},
+		},
+	}
+
+	// Mock PackageRevision
+	obj := &api.PackageRevision{
+		Spec: api.PackageRevisionSpec{
+			PackageName: "test-package",
+		},
+	}
+
+	// Call mapTaskToMutation
+	mutation, err := handler.mapTaskToMutation(ctx, obj, patchTask, false, nil)
+
+	// Verify results
+	assert.NoError(t, err)
+	assert.NotNil(t, mutation)
+	assert.IsType(t, &applyPatchMutation{}, mutation)
+}


### PR DESCRIPTION
https://github.com/nephio-project/nephio/issues/898


The following error still occurs in some corner cases when updating a package using the `copy-merge` strategy:

```
Error: Internal error occurred: error applying patch: conflict: fragment line does not match src line
```

To address this issue, this solution avoids performing a `git diff` between the original and local files for update strategies such as `copy-merge` and `force-delete-replace`.

### Key changes:

* Added a function to check whether the update strategy is `copy-merge` or `force-delete-replace`.
* For files that have changed, the patching step is skipped. Instead, the original content is returned, and the loop continues to process the remaining files.
* After all tasks are completed, the update function will overwrite any changed files. As a result, it's safe to skip mutation tasks for `copy-merge` and `force-delete-replace`, since the final overwrite ensures correctness.

