### PR TITLE
Align rpkg push with kubectl

### DIFF
--- a/pkg/cli/commands/rpkg/docs/docs.go
+++ b/pkg/cli/commands/rpkg/docs/docs.go
@@ -255,7 +255,7 @@ Args:
     The name of a an existing package revision in a repository.
 
   DIR:
-    A local directory with the new manifest. If the manifests have be read from stdin, use '-' in-place of DIR.
+    A local directory with the new manifest. If the manifests have be read from stdin, use '-' in place of DIR.
 `
 var PushExamples = `
   # update the package revision blueprint-f977350dff904fa677100b087a5bd989106d0456 with the resources

--- a/pkg/cli/commands/rpkg/docs/docs.go
+++ b/pkg/cli/commands/rpkg/docs/docs.go
@@ -255,13 +255,16 @@ Args:
     The name of a an existing package revision in a repository.
 
   DIR:
-    A local directory with the new manifest. If not provided,
-    the manifests will be read from stdin.
+    A local directory with the new manifest. If the manifests have be read from stdin, use '-' in-place of DIR.
 `
 var PushExamples = `
   # update the package revision blueprint-f977350dff904fa677100b087a5bd989106d0456 with the resources
   # in the ./package directory
   $ porchctl rpkg push blueprint-f977350dff904fa677100b087a5bd989106d0456 ./package --namespace=default
+
+  # update the package revision blueprint-f977350dff904fa677100b087a5bd989106d0456 with the resources
+  # using stdin
+  $ porchctl rpkg push blueprint-f977350dff904fa677100b087a5bd989106d0456 - <stdin> --namespace=default
 `
 
 var RejectShort = `Reject a proposal to publish or delete a package revision.`

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -117,11 +117,14 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	} else if len(args) > 1 && args[1] == "-" {
 		resources, err = readFromReader(cmd.InOrStdin())
 	} else {
-		return errors.E(op, "Directory name or stdin is required")
+		r.printer.Printf("Warning: This way of using stdin will be deprecated in Porch release 5.x.x. Please use '-' to provide stdin.")
+		resources, err = readFromReader(cmd.InOrStdin())
 	}
 	if err != nil {
 		return errors.E(op, err)
 	}
+
+	r.printer.Printf("Resources - %v", resources)
 
 	pkgResources := porchapi.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -124,8 +124,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		return errors.E(op, err)
 	}
 
-	r.printer.Printf("Resources - %v", resources)
-
 	pkgResources := porchapi.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -105,17 +105,19 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	const op errors.Op = command + ".runE"
 
 	if len(args) == 0 {
-		return errors.E(op, "PACKAGE is a required positional argument")
+		return errors.E(op, "PACKAGE name is a required positional argument")
 	}
 
 	packageName := args[0]
 	var resources map[string]string
 	var err error
 
-	if len(args) > 1 {
+	if len(args) > 1 && args[1] != "-" {
 		resources, err = readFromDir(args[1])
-	} else {
+	} else if len(args) > 1 && args[1] == "-" {
 		resources, err = readFromReader(cmd.InOrStdin())
+	} else {
+		return errors.E(op, "Directory name or stdin is required")
 	}
 	if err != nil {
 		return errors.E(op, err)

--- a/test/e2e/cli/testdata/rpkg-push/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-push/config.yaml
@@ -68,6 +68,7 @@ commands:
       - push
       - --namespace=rpkg-push
       - git.test-package.push
+      - '-'
     stdin: |
       apiVersion: config.kubernetes.io/v1
       items:
@@ -194,6 +195,7 @@ commands:
       - push
       - --namespace=rpkg-push
       - git.test-package.push
+      - '-'
     stdin: |
       apiVersion: config.kubernetes.io/v1
       items:


### PR DESCRIPTION
This PR resolves an issue where rpkg push would wait forever if the dirname/stdin were not provided as a parameter to the cli command. 

Here, the PR aligns rpkg push with how stdin is used in kubectl apply. 

The command will only wait for stdin if '-' is added to the cli command after the package name.