### PR TITLE
Update PVS to allow WorkspaceName on Upstream PR references

### DIFF
--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -165,7 +165,7 @@ func (r *PackageVariantSetReconciler) getUpstreamPR(upstream *pkgvarapi.Upstream
 	for _, pr := range prList.Items {
 		if pr.Spec.RepositoryName == upstream.Repo &&
 			pr.Spec.PackageName == upstream.Package &&
-			pr.Spec.Revision == upstream.Revision {
+			(pr.Spec.Revision == upstream.Revision || pr.Spec.WorkspaceName == upstream.WorkspaceName) {
 			return &pr, nil
 		}
 	}

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate.go
@@ -33,8 +33,8 @@ func validatePackageVariantSet(pvs *api.PackageVariantSet) []error {
 		if pvs.Spec.Upstream.Repo == "" {
 			allErrs = append(allErrs, fmt.Errorf("spec.upstream.repo is a required field"))
 		}
-		if pvs.Spec.Upstream.Revision == 0 {
-			allErrs = append(allErrs, fmt.Errorf("spec.upstream.revision is a required field"))
+		if pvs.Spec.Upstream.Revision == 0 && pvs.Spec.Upstream.WorkspaceName == "" {
+			allErrs = append(allErrs, fmt.Errorf("either spec.upstream.revision or spec.upstream.workspaceName must be specified"))
 		}
 	}
 

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/validate_test.go
@@ -64,7 +64,7 @@ spec:
   upstream:
     repo: foo
     package: foopkg`,
-			expectedErrs: []string{"spec.upstream.revision is a required field",
+			expectedErrs: []string{"either spec.upstream.revision or spec.upstream.workspaceName must be specified",
 				"must specify at least one item in spec.targets",
 			},
 		},


### PR DESCRIPTION
This PR fixes references of upstream PRs by allowing support for workspace names on PVS upstream specifications in the same way as it is already allowed on PV specifications.

This change is required to fix the end to end tests in test-infra.
