### PR TITLE
Update Kpt File before replacing the files for `copy-merge`

### DIFF
--- a/internal/kpt/util/update/copy-merge.go
+++ b/internal/kpt/util/update/copy-merge.go
@@ -22,18 +22,23 @@ import (
 	"github.com/nephio-project/porch/pkg/kpt/kptfileutil"
 )
 
+// CopyMergeUpdater is responsible for synchronizing the destination package
+// with the source package by updating the Kptfile and copying and replacing package contents.
 type CopyMergeUpdater struct{}
 
+// Update synchronizes the destination/local package with the source/update package by updating the Kptfile
+// and copying package contents. It takes an Options struct as input, which specifies the paths
+// and other parameters for the update operation. Returns an error if the update fails.
 func (u CopyMergeUpdater) Update(options Options) error {
-	return copyDirectories(options.UpdatedPath, options.LocalPath, options.IsRoot)
-}
-
-func copyDirectories(src, dst string, isRoot bool) error {
 	const op errors.Op = "update.Update"
-	if err := kptfileutil.UpdateKptfile(dst, src, dst, true); err != nil {
+
+	dst := options.LocalPath
+	src := options.UpdatedPath
+
+	if err := kptfileutil.UpdateKptfile(dst, src, options.OriginPath, true); err != nil {
 		return errors.E(op, types.UniquePath(dst), err)
 	}
-	if err := pkgutil.CopyPackage(src, dst, isRoot, pkg.All); err != nil {
+	if err := pkgutil.CopyPackage(src, dst, options.IsRoot, pkg.All); err != nil {
 		return errors.E(op, types.UniquePath(dst), err)
 	}
 	return nil

--- a/internal/kpt/util/update/copy-merge_test.go
+++ b/internal/kpt/util/update/copy-merge_test.go
@@ -263,6 +263,37 @@ func TestCopyMergeError(t *testing.T) {
 
 }
 
+func TestCopyMergeErrorUpdatingKptfile(t *testing.T) {
+	// Mock the file system
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(src, "Kptfile"), []byte(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: source-package
+`), 0644)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dst, "Kptfile"), []byte(`
+apiVersion: kpt.dev/v000
+kind: malformedKptfile
+`), 0644)
+	assert.NoError(t, err)
+
+	updater := &CopyMergeUpdater{}
+	options := Options{
+		UpdatedPath: src,
+		LocalPath:   dst,
+		IsRoot:      true,
+	}
+
+	err = updater.Update(options)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource type")
+}
+
 func TestCopyMergeErrorCopyingFile(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()

--- a/internal/kpt/util/update/copy-merge_test.go
+++ b/internal/kpt/util/update/copy-merge_test.go
@@ -264,7 +264,6 @@ func TestCopyMergeError(t *testing.T) {
 }
 
 func TestCopyMergeErrorUpdatingKptfile(t *testing.T) {
-	// Mock the file system
 	src := t.TempDir()
 	dst := t.TempDir()
 


### PR DESCRIPTION
Issue Explained here: https://github.com/nephio-project/nephio/issues/913

1. Clone blueprint -> deployment
2. update deployment to a newer version of blueprint
3. metadata.name in the Kptfile changes from deployment to blueprint (because the whole file gets overridden)

Before:
```
apiVersion: kpt.dev/v1
kind: Kptfile
metadata: # kpt-merge: /blueprint
  name: blueprint
upstream: ..
upstreamLock: ..  
```

After this change:
```
apiVersion: kpt.dev/v1
kind: Kptfile
metadata: # kpt-merge: /deployment
  name: deployment
upstream: ..
upstreamLock: ..  

```

The metadata name of the package `deployment` that was cloned from `blueprint` will not change, but the upstream and upstreamLock will update to the new version of the blueprint like in the past

steps taken:
- Removed the walk over each file in the directories and subdirectories
- Added first the `kptfileutil.UpdateKptfile` to update the /Kptfile so that in the local path the Kptfile will already have changed. The boolean variable is set to `True` to always update the upstream and upstreamLock.
- Then use the `pkgutil.CopyPackage` that will copy all the content of a folder into another, using `pkg.All` will take care of subfolders.
- Added unit test to check changing the metadata.name and upstream references in subpackages
