### PR TITLE
Improve function runner logging

### DIFF
--- a/func/healthchecker/healthchecker.go
+++ b/func/healthchecker/healthchecker.go
@@ -32,20 +32,20 @@ func NewHealthChecker() *HealthChecker {
 }
 
 func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	klog.Info("Serving the Check request for health check")
+	klog.V(3).Info("Serving the Check request for health check")
 	return &grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}, nil
 }
 
 func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
-	klog.Info("Serving the Watch request for health check")
+	klog.V(3).Info("Serving the Watch request for health check")
 	return server.Send(&grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
 	})
 }
 
 func (h *HealthChecker) List(ctx context.Context, req *grpc_health_v1.HealthListRequest) (*grpc_health_v1.HealthListResponse, error) {
-    // Return UNIMPLEMENTED if you don't actually support List
-    return nil, status.Errorf(codes.Unimplemented, "List is not implemented")
+	// Return UNIMPLEMENTED if you don't actually support List
+	return nil, status.Errorf(codes.Unimplemented, "List is not implemented")
 }

--- a/func/healthchecker/healthchecker.go
+++ b/func/healthchecker/healthchecker.go
@@ -32,6 +32,7 @@ func NewHealthChecker() *HealthChecker {
 }
 
 func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// Only logs if log-level is 3 or higher
 	klog.V(3).Info("Serving the Check request for health check")
 	return &grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
@@ -39,6 +40,7 @@ func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthChe
 }
 
 func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	// Only logs if log-level is 3 or higher
 	klog.V(3).Info("Serving the Watch request for health check")
 	return server.Send(&grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,

--- a/internal/kpt/fnruntime/runner.go
+++ b/internal/kpt/fnruntime/runner.go
@@ -242,14 +242,18 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	pr := printer.FromContextOrDie(fr.ctx)
 	if !fr.disableCLIOutput {
 		if fr.opts.AllowWasm {
-			pr.Printf("[RUNNING] WASM %q", fr.name)
+			if fr.opts.DisplayResourceCount {
+				pr.Printf("[RUNNING] WASM %q on %d resource(s)", fr.name, len(input))
+			} else {
+				pr.Printf("[RUNNING] WASM %q", fr.name)
+			}
 		} else {
-			pr.Printf("[RUNNING] %q", fr.name)
+			if fr.opts.DisplayResourceCount {
+				pr.Printf("[RUNNING] %q on %d resource(s)", fr.name, len(input))
+			} else {
+				pr.Printf("[RUNNING] %q", fr.name)
+			}
 		}
-		if fr.opts.DisplayResourceCount {
-			pr.Printf(" on %d resource(s)", len(input))
-		}
-		pr.Printf("\n")
 	}
 	t0 := time.Now()
 	output, err = fr.do(input)


### PR DESCRIPTION
In this PR the function runner logging is improved as follows:
- Increase the klog log-level(3) for health checks. This makes sure that at the default log-level(2), the health check messages are not printed every 10 seconds. 
- It removes printing an empty line and it appends the resouceCount number to the same line during rendering.