### PR TITLE
Added Race Condition Checking & Fixed Concurrent CrCache Map Read & Write

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,11 @@
         // With the configuration above one can use Vscode (Run & Debug) and launch server.
         // This launches the porch server through vscode outside the cluster and the logs can be viewed in the debug console.
         // Breakpoints can be added throughout the porch server code to debug.
+
+        // CGO_ENABLED & buildFlags
+        // Enables race condition checking (Slows down porch-server processing) NOTE: The Go race detector uses C code under the hood (via cgo),
+        // and to build it, your system needs a C toolchain—i.e., a compiler like gcc and other basic build tools.
+        // on a linux distro e.g. ubuntu these can be installed with (sudo apt install build-essential), this will install the (gcc = GNU C Compiler, g++ = GNU C++ Compiler, make, libc6-dev etc...)
         {
             "name": "Launch Server",
             "type": "go",
@@ -27,8 +32,10 @@
             "env": {
                 "CERT_STORAGE_DIR": "${workspaceFolder}/.build/pki/tmp",
                 "WEBHOOK_HOST": "localhost",
-                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true"
-            }
+                "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_NEW_AUTH_LIB": "true",
+                // "CGO_ENABLED": "1"   // Enables race condition checking
+            },
+            // "buildFlags": "-race"    // Enables race condition checking
         },
         {
             "name": "Launch Controllers",

--- a/pkg/cache/crcache/util.go
+++ b/pkg/cache/crcache/util.go
@@ -30,7 +30,9 @@ func identifyLatestRevisions(ctx context.Context, result map[repository.PackageR
 	// TODO: Should map[string] be map[repository.PackageKey]?
 	latest := map[string]*cachedPackageRevision{}
 	for _, current := range result {
+		current.mutex.Lock()
 		current.isLatestRevision = false // Clear all values
+		current.mutex.Unlock()
 
 		// Check if the current package revision is more recent than the one seen so far.
 		// Only consider Published packages
@@ -53,7 +55,9 @@ func identifyLatestRevisions(ctx context.Context, result map[repository.PackageR
 
 	// Mark the winners as latest
 	for _, v := range latest {
+		v.mutex.Lock()
 		v.isLatestRevision = true
+		v.mutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
This PR adds 3 main things,

1. Fixes a Fatal Error that occurs when making multiple parallel requests to the porch API to create/update PackageRevisions ("fatal error: concurrent map iteration and map write" ).
2. Amends a number of race conditions mostly found in the pkg/crcache section of the code.
3. Adds a new way of running the porch-server to enable race condition checking to allow to investigate potential holes in the code related to read/write conflicts. (more details on its usage can be found [here](https://go.dev/doc/articles/race_detector))


