### PR TITLE
feat: allow discovery of package revisions with executable Kptfile

### DIFF
--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -147,8 +147,8 @@ func (t *packageList) discoverPackages(repoKey repository.RepositoryKey, tree *o
 	for _, e := range tree.Entries {
 		if e.Name == "Kptfile" {
 			p := path.Join(treePath, e.Name)
-			if !e.Mode.IsRegular() {
-				klog.Warningf("skipping %q: Kptfile is not a file", p)
+			if !e.Mode.IsRegular() && e.Mode&0111 == 0 {
+				klog.Warningf("skipping %q: Kptfile is not a regular or executable file", p)
 				continue
 			}
 


### PR DESCRIPTION
feat: allow discovery of package revisions with executable Kptfile

Currently porch's git packagerevision auto-discovery code only finds kpt packages 
whose Kptfile is a "regular" file. This prevents porch from discovering packages 
whose Kptfiles have their executable flag set, which can be unexpected for users.

Changes:
- Modified package discovery logic to accept both regular and executable Kptfiles

This change ensures that porch can discover and work with packages regardless of 
whether their Kptfile is a regular file or has executable permissions.