### PR TITLE
Top To Bottom Render order

### DIFF
--- a/internal/kpt/util/render/executor.go
+++ b/internal/kpt/util/render/executor.go
@@ -353,6 +353,7 @@ func hydrateBFS(ctx context.Context, root *pkgNode, hctx *hydrationContext) (out
 	// Initialize the BFS queue with the root package
 	queue := []*pkgNode{root}
 
+	// Loop until the queue is empty
 	for len(queue) > 0 {
 		// Dequeue the next package
 		current := queue[0]

--- a/internal/kpt/util/render/executor.go
+++ b/internal/kpt/util/render/executor.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ import (
 )
 
 var errAllowedExecNotSpecified = fmt.Errorf("must run with `--allow-exec` option to allow running function binaries")
+
+const (
+	TopToBottomRenderAnnotation = "kpt.dev/top-to-bottom-rendering"
+)
 
 // Renderer hydrates a given pkg by running the functions in the input pipeline
 type Renderer struct {
@@ -92,10 +96,10 @@ func (e *Renderer) Execute(ctx context.Context) (*fnresult.ResultList, error) {
 	}
 
 	// Choose hydration function based on annotation
-	// If the annotation "top-bottom-rendering" is set to "true", use hydrateTopBottom
+	// If the annotation "kpt.dev/top-bottom-rendering" is set to "true", use hydrateTopBottom
 	// otherwise use the default hydrate function in bottom-up order.
 	hydrateFn := hydrate
-	if value, exists := kptfile.Annotations["top-bottom-rendering"]; exists && value == "true" {
+	if value, exists := kptfile.Annotations[TopToBottomRenderAnnotation]; exists && value == "true" {
 		hydrateFn = hydrateTopBottom
 	}
 

--- a/internal/kpt/util/render/executor.go
+++ b/internal/kpt/util/render/executor.go
@@ -65,9 +65,6 @@ type Renderer struct {
 
 	// FileSystem is the input filesystem to operate on
 	FileSystem filesys.FileSystem
-
-	// New flag to toggle BFS rendering
-	UseBFS bool
 }
 
 // Execute runs a pipeline.
@@ -91,8 +88,13 @@ func (e *Renderer) Execute(ctx context.Context) (*fnresult.ResultList, error) {
 		runtime:       e.Runtime,
 	}
 
+	kptfile, err := pkg.ReadKptfile(e.FileSystem, e.PkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Kptfile: %w", err)
+	}
+
 	// Use BFS or the old recursive method based on the flag
-	if e.UseBFS {
+	if kptfile.UseBFS != nil && *kptfile.UseBFS {
 		if _, err := hydrateBFS(ctx, root, hctx); err != nil {
 			_ = e.saveFnResults(ctx, hctx.fnResults)
 			return hctx.fnResults, errors.E(op, root.pkg.UniquePath, err)

--- a/internal/kpt/util/render/executor.go
+++ b/internal/kpt/util/render/executor.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"slices"
+
 	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/internal/kpt/fnruntime"
 	"github.com/nephio-project/porch/internal/kpt/pkg"
@@ -389,8 +391,8 @@ func hydrateBFS(ctx context.Context, root *pkgNode, hctx *hydrationContext) (out
 			return nil, err
 		}
 
-		// Include current package's resources in the input resource list
-		input := append([]*yaml.RNode{}, currPkgResources...)
+		// Append current package's resources in the input resource list
+		input := slices.Clone(currPkgResources)
 
 		// Enqueue subpackages
 		subpkgs, err := current.pkg.DirectSubpackages()

--- a/internal/kpt/util/render/executor_test.go
+++ b/internal/kpt/util/render/executor_test.go
@@ -256,7 +256,7 @@ kind: Kptfile
 metadata:
   name: root-package
   annotations:
-    top-bottom-rendering: %t
+    ktp.dev/top-bottom-rendering: %t
 `, renderTopBtm))
 	assert.NoError(t, err)
 
@@ -396,7 +396,7 @@ kind: Kptfile
 metadata:
   name: root-package
   annotations:
-    top-bottom-rendering: true
+    ktp.dev/top-bottom-rendering: true
 `))
 	assert.NoError(t, err)
 

--- a/internal/kpt/util/render/executor_test.go
+++ b/internal/kpt/util/render/executor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt and Nephio Authors
+// Copyright 2022-2025 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -425,7 +425,7 @@ metadata:
 			state: Hydrating,
 		}
 
-		_, err := hydrateTopBottom(context.Background(), root, hctx)
+		_, err := hydrateTopBottom(ctx, root, hctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cycle detected in pkg dependencies")
 	})
@@ -437,7 +437,7 @@ metadata:
 			state: -1, // Invalid state
 		}
 
-		_, err := hydrateTopBottom(context.Background(), root, hctx)
+		_, err := hydrateTopBottom(ctx, root, hctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "package found in invalid state")
 	})

--- a/pkg/kpt/api/kptfile/v1/types.go
+++ b/pkg/kpt/api/kptfile/v1/types.go
@@ -83,6 +83,8 @@ type KptFile struct {
 	Inventory *Inventory `yaml:"inventory,omitempty" json:"inventory,omitempty"`
 
 	Status *Status `yaml:"status,omitempty" json:"status,omitempty"`
+
+	UseBFS *bool `yaml:"useBFS,omitempty"`
 }
 
 // OriginType defines the type of origin for a package.

--- a/pkg/kpt/api/kptfile/v1/types.go
+++ b/pkg/kpt/api/kptfile/v1/types.go
@@ -83,8 +83,6 @@ type KptFile struct {
 	Inventory *Inventory `yaml:"inventory,omitempty" json:"inventory,omitempty"`
 
 	Status *Status `yaml:"status,omitempty" json:"status,omitempty"`
-
-	RenderBFS *bool `yaml:"renderBFS,omitempty" json:"renderBFS,omitempty"`
 }
 
 // OriginType defines the type of origin for a package.

--- a/pkg/kpt/api/kptfile/v1/types.go
+++ b/pkg/kpt/api/kptfile/v1/types.go
@@ -84,7 +84,7 @@ type KptFile struct {
 
 	Status *Status `yaml:"status,omitempty" json:"status,omitempty"`
 
-	RenderBFS *bool `yaml:"renderBFS,omitempty"`
+	RenderBFS *bool `yaml:"renderBFS,omitempty" json:"renderBFS,omitempty"`
 }
 
 // OriginType defines the type of origin for a package.

--- a/pkg/kpt/api/kptfile/v1/types.go
+++ b/pkg/kpt/api/kptfile/v1/types.go
@@ -403,3 +403,9 @@ const (
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
 )
+
+// BFSRenderAnnotation is an annotation that can be used to indicate that a package
+// should be hydrated from the root package to the subpackages in a Breadth-First Level Order manner.
+const (
+	BFSRenderAnnotation = "kpt.dev/bfs-rendering"
+)

--- a/pkg/kpt/api/kptfile/v1/types.go
+++ b/pkg/kpt/api/kptfile/v1/types.go
@@ -84,7 +84,7 @@ type KptFile struct {
 
 	Status *Status `yaml:"status,omitempty" json:"status,omitempty"`
 
-	UseBFS *bool `yaml:"useBFS,omitempty"`
+	RenderBFS *bool `yaml:"renderBFS,omitempty"`
 }
 
 // OriginType defines the type of origin for a package.


### PR DESCRIPTION
Suppose we have a kpt package with a root directory and multiple sub-directories in the following folder tree structure:

<img src="https://github.com/user-attachments/assets/8e954341-8af5-4bce-81fd-897d387eb72c" width="200" height="200">



The current hydrate function will operate bottom-up because it's using recursion. So the order in the example will be:
C, A, B, ROOT -> [Depth-First Post-Order](https://miro.medium.com/v2/resize:fit:640/format:webp/1*4KpXD6en9pbN2mgbq4XraA.gif)


> **_NOTE:_**  In the code the subpackages are ordered from left to right in ascendant alphabetical order.

I am proposing a top-to-bottom approach to add beside the hydrate function, using 2 arrays as queues so that the order in the example will be:

ROOT, A, B, C -> [Breadth-First Level-Order](https://i.giphy.com/media/LP0RRlb0SXqw6GqcyK/giphy.gif)

`hydrateTopToBottom` operates only if an annotation `kpt.dev/bfs-rendering: "true"` is present in the Kptfile.metadata.annotations.

If the annotation is missing, or it is any other value than true then porch operates as default with the current implementation of the hydrate function. 

``` 
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: root-package
  annotations:
    kpt.dev/bfs-rendering: "true"
 ```

|              | **hydrate (Bottom-Up)**                                      | **hydrateTopBottom (Top-Bottom)**                                  |
|------------------------|---------------------------------------------------------------|-------------------------------------------------------------------|
| **Traversal Order**    | Depth-first (post-order), processes subpackages before parent              | Breadth-first, processes parent before subpackages                |
| **Processing Order**   | C, A, B, root                                       | root, A, B, C                                          |
| **Queue Mechanism**    | Implicit via recursion                                        | Explicit queue (`queue`) and `orderedQueue`                       |
| **Resource Handling**  | Subpackage resources appended to parent’s input               | All self resources + Descendants resources                 |
| **Implementation**     | Recursive                                                     | Two-phase: gather resources, then run pipelines                   |
| **Use Case**           | When subpackage outputs are needed by parent                  | When parent’s output affects subpackages                          |

https://en.wikipedia.org/wiki/Tree_traversal 