### PR TITLE
Fix TestEditPackageRevision (workspaceName already exists)

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -551,11 +551,12 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository() {
 
 func (t *PorchSuite) TestEditPackageRevision() {
 	const (
-		repository       = "edit-test"
-		packageName      = "simple-package"
-		otherPackageName = "other-package"
-		workspace        = "workspace"
-		workspace2       = "workspace2"
+		repository                         = "edit-test"
+		packageName                        = "simple-package"
+		otherPackageName                   = "other-package"
+		workspace                          = "workspace"
+		workspace2                         = "workspace2"
+		avoidInvalidCreationWorkspaceError = "avoid-creation-rollback-not-occuring-in-time-workspace"
 	)
 
 	t.RegisterMainGitRepositoryF(repository)
@@ -646,7 +647,7 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	t.UpdateApprovalF(pr, metav1.UpdateOptions{})
 
 	// Changing the workspace of the update to avoid conflicting with invalid create negative test above
-	editPR.Spec.WorkspaceName = "avoid-creation-rollback-not-occuring-in-time-workspace"
+	editPR.Spec.WorkspaceName = avoidInvalidCreationWorkspaceError
 
 	// Create a new revision with the edit task.
 	t.CreateF(editPR)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -645,8 +645,9 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	t.UpdateApprovalF(pr, metav1.UpdateOptions{})
 
-	// Changing the workspace of the update to avoid conflicting with 
+	// Changing the workspace of the update to avoid conflicting with invalid create negative test above
 	editPR.Spec.WorkspaceName = "avoid-creation-rollback-not-occuring-in-time-workspace"
+
 	// Create a new revision with the edit task.
 	t.CreateF(editPR)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -551,11 +551,11 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository() {
 
 func (t *PorchSuite) TestEditPackageRevision() {
 	const (
-		repository                         = "edit-test"
-		packageName                        = "simple-package"
-		otherPackageName                   = "other-package"
-		workspace                          = "workspace"
-		workspace2                         = "workspace2"
+		repository       = "edit-test"
+		packageName      = "simple-package"
+		otherPackageName = "other-package"
+		workspace        = "workspace"
+		workspace2       = "workspace2"
 	)
 
 	t.RegisterMainGitRepositoryF(repository)
@@ -640,13 +640,13 @@ func (t *PorchSuite) TestEditPackageRevision() {
 
 	// We await for this invalid packageRevision creation to be deleted then proceed else timeout after 10s
 	t.WaitUntilObjectDeleted(
-        packageRevisionGVK,
-        types.NamespacedName{
-            Name:      otherPackageName,
-            Namespace: t.Namespace,
-        },
-        10*time.Second,
-    )
+		packageRevisionGVK,
+		types.NamespacedName{
+			Name:      otherPackageName,
+			Namespace: t.Namespace,
+		},
+		10*time.Second,
+	)
 
 	// Publish the source package to make it a valid source for edit.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -638,7 +638,7 @@ func (t *PorchSuite) TestEditPackageRevision() {
 		t.Fatalf("Expected error for source revision not being published")
 	}
 
-	// We await for this invalid packageRevision creation to be deleted then proceed else timeout after 10s
+	// We await for this invalid packageRevision creation to be deleted then proceed else timeout after 10 seconds
 	t.WaitUntilObjectDeleted(
 		packageRevisionGVK,
 		types.NamespacedName{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -633,9 +633,9 @@ func (t *PorchSuite) TestEditPackageRevision() {
 			},
 		},
 	}
-	// if err := t.Client.Create(t.GetContext(), editPR); err == nil {
-	// 	t.Fatalf("Expected error for source revision not being published")
-	// }
+	if err := t.Client.Create(t.GetContext(), editPR); err == nil {
+		t.Fatalf("Expected error for source revision not being published")
+	}
 
 	// Publish the source package to make it a valid source for edit.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
@@ -645,6 +645,8 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	t.UpdateApprovalF(pr, metav1.UpdateOptions{})
 
+	// Changing the workspace of the update to avoid conflicting with 
+	editPR.Spec.WorkspaceName = "avoid-creation-rollback-not-occuring-in-time-workspace"
 	// Create a new revision with the edit task.
 	t.CreateF(editPR)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -579,33 +579,33 @@ func (t *PorchSuite) TestEditPackageRevision() {
 
 	// Create a new revision, but with a different package as the source.
 	// This is not allowed.
-	// invalidEditPR := &porchapi.PackageRevision{
-	// 	TypeMeta: metav1.TypeMeta{
-	// 		Kind:       "PackageRevision",
-	// 		APIVersion: porchapi.SchemeGroupVersion.String(),
-	// 	},
-	// 	ObjectMeta: metav1.ObjectMeta{
-	// 		Namespace: t.Namespace,
-	// 	},
-	// 	Spec: porchapi.PackageRevisionSpec{
-	// 		PackageName:    otherPackageName,
-	// 		WorkspaceName:  workspace2,
-	// 		RepositoryName: repository,
-	// 		Tasks: []porchapi.Task{
-	// 			{
-	// 				Type: porchapi.TaskTypeEdit,
-	// 				Edit: &porchapi.PackageEditTaskSpec{
-	// 					Source: &porchapi.PackageRevisionRef{
-	// 						Name: pr.Name,
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	},
-	// }
-	// if err := t.Client.Create(t.GetContext(), invalidEditPR); err == nil {
-	// 	t.Fatalf("Expected error for source revision being from different package")
-	// }
+	invalidEditPR := &porchapi.PackageRevision{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageRevision",
+			APIVersion: porchapi.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.Namespace,
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			PackageName:    otherPackageName,
+			WorkspaceName:  workspace2,
+			RepositoryName: repository,
+			Tasks: []porchapi.Task{
+				{
+					Type: porchapi.TaskTypeEdit,
+					Edit: &porchapi.PackageEditTaskSpec{
+						Source: &porchapi.PackageRevisionRef{
+							Name: pr.Name,
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := t.Client.Create(t.GetContext(), invalidEditPR); err == nil {
+		t.Fatalf("Expected error for source revision being from different package")
+	}
 
 	// Create a new revision of the package with a source that is a revision
 	// of the same package.
@@ -633,9 +633,9 @@ func (t *PorchSuite) TestEditPackageRevision() {
 			},
 		},
 	}
-	if err := t.Client.Create(t.GetContext(), editPR); err == nil {
-		t.Fatalf("Expected error for source revision not being published")
-	}
+	// if err := t.Client.Create(t.GetContext(), editPR); err == nil {
+	// 	t.Fatalf("Expected error for source revision not being published")
+	// }
 
 	// Publish the source package to make it a valid source for edit.
 	pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -579,33 +579,33 @@ func (t *PorchSuite) TestEditPackageRevision() {
 
 	// Create a new revision, but with a different package as the source.
 	// This is not allowed.
-	invalidEditPR := &porchapi.PackageRevision{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PackageRevision",
-			APIVersion: porchapi.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: t.Namespace,
-		},
-		Spec: porchapi.PackageRevisionSpec{
-			PackageName:    otherPackageName,
-			WorkspaceName:  workspace2,
-			RepositoryName: repository,
-			Tasks: []porchapi.Task{
-				{
-					Type: porchapi.TaskTypeEdit,
-					Edit: &porchapi.PackageEditTaskSpec{
-						Source: &porchapi.PackageRevisionRef{
-							Name: pr.Name,
-						},
-					},
-				},
-			},
-		},
-	}
-	if err := t.Client.Create(t.GetContext(), invalidEditPR); err == nil {
-		t.Fatalf("Expected error for source revision being from different package")
-	}
+	// invalidEditPR := &porchapi.PackageRevision{
+	// 	TypeMeta: metav1.TypeMeta{
+	// 		Kind:       "PackageRevision",
+	// 		APIVersion: porchapi.SchemeGroupVersion.String(),
+	// 	},
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Namespace: t.Namespace,
+	// 	},
+	// 	Spec: porchapi.PackageRevisionSpec{
+	// 		PackageName:    otherPackageName,
+	// 		WorkspaceName:  workspace2,
+	// 		RepositoryName: repository,
+	// 		Tasks: []porchapi.Task{
+	// 			{
+	// 				Type: porchapi.TaskTypeEdit,
+	// 				Edit: &porchapi.PackageEditTaskSpec{
+	// 					Source: &porchapi.PackageRevisionRef{
+	// 						Name: pr.Name,
+	// 					},
+	// 				},
+	// 			},
+	// 		},
+	// 	},
+	// }
+	// if err := t.Client.Create(t.GetContext(), invalidEditPR); err == nil {
+	// 	t.Fatalf("Expected error for source revision being from different package")
+	// }
 
 	// Create a new revision of the package with a source that is a revision
 	// of the same package.


### PR DESCRIPTION
This PR fixes the issues seen in the E2E test `TestE2E/TestEditPackageRevision` which can be seen failing in our pipelines e.g. [here](https://github.com/nephio-project/porch/actions/runs/15610958860/job/43971500339) but this can be seen happening too often to just be a flaky test.

What the failed test log looks like:
```log
=== RUN TestE2E/TestEditPackageRevision
e2e_test.go:553: INFO: creating object Repository porch-test-1749733066650882/edit-test
e2e_test.go:553: INFO: took 2.24151ms to create porch-test-1749733066650882/edit-test
e2e_test.go:553: INFO: Repository porch-test-1749733066650882/edit-test is ready
e2e_test.go:570: INFO: creating object PackageRevision porch-test-1749733066650882/
e2e_test.go:570: INFO: took 15.731624ms to create porch-test-1749733066650882/edit-test.simple-package.workspace
e2e_test.go:634: INFO: updating object *v1alpha1.PackageRevision porch-test-1749733066650882/edit-test.simple-package.workspace
e2e_test.go:638: INFO: updating approval of *v1alpha1.PackageRevision porch-test-1749733066650882/edit-test.simple-package.workspace
e2e_test.go:641: INFO: creating object PackageRevision porch-test-1749733066650882/
e2e_test.go:641: FATAL: failed to create resource PackageRevision porch-test-1749733066650882/: Internal error occurred: package revision workspaceNames must be unique; package revision with name simple-package in repo edit-test with workspaceName workspace2 already exists
panic.go:636: INFO: took 12.946958ms to create porch-test-1749733066650882/
```

What i believe the issue is:

From my investigation i believe the issue is happening [here](https://github.com/Nordix/porch/blob/ac9c7cade2af17ae4a4fe840442eb66c46d5a283/test/e2e/e2e_test.go#L636-L649) 
You see there is a negative test on line 636 which is to ensure that a packageRevision cannot be created from an original package which has not yet been approved.
Then after words this original pkg is proposed and approved and a creation is attempted again and this time it should succeed.
```go
if err := t.Client.Create(t.GetContext(), editPR); err == nil {
t.Fatalf("Expected error for source revision not being published")
}

// Publish the source package to make it a valid source for edit.
pr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
t.UpdateF(pr)

// Approve the package
pr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
t.UpdateApprovalF(pr, metav1.UpdateOptions{})

// Create a new revision with the edit task.
t.CreateF(editPR)
```

But the create function does actually create a draft PR for a brief moment even if there is an error as if you investigate [here](https://github.com/Nordix/porch/blob/ac9c7cade2af17ae4a4fe840442eb66c46d5a283/pkg/engine/engine.go#L154-L185). 
The draft is actually created before errors are checked and later rolled back/deleted if they were present and usually this is almost instantaneous.

However this test never fails locally and if we have a look at those logs below the amount of time taken for those packageRevisions to be created are 3 times or more locally than for the same tests running on prow.

```log
=== RUN TestE2E/TestEditPackageRevision

e2e_test.go:561: INFO: creating object Repository porch-test-1750257492439145/edit-test
e2e_test.go:561: INFO: took 13.875884ms to create porch-test-1750257492439145/edit-test
e2e_test.go:561: INFO: Repository porch-test-1750257492439145/edit-test is ready e2e_test.go:578: INFO: creating object PackageRevision porch-test-1750257492439145/
e2e_test.go:578: INFO: took 44.303204ms to create porch-test-1750257492439145/edit-test.simple-package.workspace
e2e_test.go:642: INFO: updating object *v1alpha1.PackageRevision porch-test-1750257492439145/edit-test.simple-package.workspace
e2e_test.go:646: INFO: updating approval of *v1alpha1.PackageRevision porch-test-1750257492439145/edit-test.simple-package.workspace
e2e_test.go:652: INFO: creating object PackageRevision porch-test-1750257492439145/
e2e_test.go:652: INFO: took 117.448249ms to create porch-test-1750257492439145/edit-test.simple-package.avoid-creation-rollback-not-occuring-in-time-workspace
e2e_test.go:662: INFO: Task: edit e2e_test.go:662: INFO: Task: eval === NAME 
```

Ways to Fix:

- Add artificial delay in the test to give time for porch to catch the error and promptly delete draft before actual valid creation.
- Change workspace of the valid creation PackageRevision so long as they are different they should not conflict and allows the invalid one to be deleted in its own time.
- Using a WaitUntilObjectDeleted function on this invalid packageRevision before proceeding to create the valid one (with a timeout just in case).

For this PR i proposed/implemented the latter fix.