### PR TITLE
Fix Watcher objects continually created, but not removed - fixes issue #943

### DIFF
--- a/pkg/engine/watchermanager.go
+++ b/pkg/engine/watchermanager.go
@@ -76,15 +76,15 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 	for i, watcher := range r.watchers {
 		if watcher != nil {
 			//Remove any watchers if they are finished and insert the new watcher in the empty slot of the first removed watcher
-			if watcher.isDoneFunction() != nil {
+			if err := watcher.isDoneFunction(); err != nil {
 				if !inserted {
 					r.watchers[i] = w
 					inserted = true
 					active += 1
-					klog.Infof("watcher %p is finished and replaced by watcher %p", watcher, w)
+					klog.Infof("watcher %p finished with: %v and is replaced by watcher %p", watcher, err, w)
 				} else {
 					r.watchers[i] = nil
-					klog.Infof("watcher %p is finished and removed", watcher)
+					klog.Infof("watcher %p finished with: %v and is removed", watcher, err)
 				}
 			} else {
 				active += 1

--- a/pkg/engine/watchermanager.go
+++ b/pkg/engine/watchermanager.go
@@ -75,7 +75,20 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 	inserted := false
 	for i, watcher := range r.watchers {
 		if watcher != nil {
-			active += 1
+			//Remove any watchers if they are finished and insert the new watcher in the empty slot of the first removed watcher
+			if watcher.isDoneFunction() != nil {
+				if !inserted {
+					r.watchers[i] = w
+					inserted = true
+					active += 1
+					klog.Infof("watcher %p is finished and replaced by watcher %p", watcher, w)
+				} else {
+					r.watchers[i] = nil
+					klog.Infof("watcher %p is finished and removed", watcher)
+				}
+			} else {
+				active += 1
+			}
 		} else if !inserted {
 			active += 1
 			r.watchers[i] = w

--- a/pkg/engine/watchermanager_test.go
+++ b/pkg/engine/watchermanager_test.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nephio-project/porch/pkg/externalrepo/fake"
+	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type fakeObjectWatcher struct {
+	onChange bool
+}
+
+func (m *fakeObjectWatcher) OnPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision) bool {
+	return m.onChange
+}
+
+func TestWatchPackageRevisions(t *testing.T) {
+	manager := NewWatcherManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 1; i <= 4; i++ {
+		if err := manager.WatchPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{onChange: true}); err != nil {
+			t.Fatalf("Failed to add watcher %d: %v", i, err)
+		}
+	}
+
+	t.Logf("Stopping active watchers")
+	cancel()
+
+	if err := manager.WatchPackageRevisions(context.Background(), repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{onChange: false}); err != nil {
+		t.Fatalf("Failed to add watcher 5: %v", err)
+	}
+
+	if err := manager.WatchPackageRevisions(context.Background(), repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{onChange: false}); err != nil {
+		t.Fatalf("Failed to add watcher 6: %v", err)
+	}
+
+	watchersActive, slots := countActiveWatchers(manager)
+
+	if watchersActive != 2 {
+		t.Errorf("Expected 2 active watchers, but got %d", watchersActive)
+	}
+	if len(manager.watchers) != 4 {
+		t.Errorf("Expected 4 slots, but got %d", slots)
+	}
+}
+
+func TestNotifyPackageRevisionChange(t *testing.T) {
+	manager := NewWatcherManager()
+
+	activeCtx := context.Background()
+	inactiveCtx, cancel := context.WithCancel(context.Background())
+
+	if err := manager.WatchPackageRevisions(activeCtx, repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{onChange: true}); err != nil {
+		t.Fatalf("Failed to add watcher 1: %v", err)
+	}
+
+	if err := manager.WatchPackageRevisions(activeCtx, repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{false}); err != nil {
+		t.Fatalf("Failed to add watcher 2: %v", err)
+	}
+
+	if err := manager.WatchPackageRevisions(inactiveCtx, repository.ListPackageRevisionFilter{}, &fakeObjectWatcher{false}); err != nil {
+		t.Fatalf("Failed to add watcher 3: %v", err)
+	}
+
+	cancel()
+
+	pkgRev := &fake.FakePackageRevision{}
+	sent := manager.NotifyPackageRevisionChange(watch.Added, pkgRev)
+	assert.Equal(t, 2, sent)
+
+	watchersActive, _ := countActiveWatchers(manager)
+	assert.Equal(t, 1, watchersActive)
+}
+
+func countActiveWatchers(manager *watcherManager) (int, int) {
+	active := 0
+	for _, watcher := range manager.watchers {
+		if watcher != nil && watcher.isDoneFunction() == nil {
+			active++
+		}
+	}
+	return active, len(manager.watchers)
+}


### PR DESCRIPTION
Resolves issue [#943](https://github.com/nephio-project/porch/issues/737)

### Issue Description

In the Porch server, every few minutes a new watcher object is created and an message is sent through a channel to stop a previous watcher. Watchers are stopped when they receive an error through the channel and this can be found using the isDoneFunction(). When a new watcher is created, there is no check to see if any of the previous watchers are finished and hence they are never removed. As such the list continually grows.

### Fix

When a new watcher is created, check and remove all watchers which are finished and insert it into the first empty slot. If no watchers can be removed, append the new watcher at the end of the list.

Also implemented unit tests for watchermanager.go

