### PR TITLE
(TestEditPackageRevision) fixing package name in await for deletion checks

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -607,28 +607,6 @@ func (t *PorchSuite) TestEditPackageRevision() {
 		t.Fatalf("Expected error for source revision being from different package")
 	}
 
-	// if the PR has been created and not yet deleted
-	// then we await for this invalid packageRevision creation to be deleted then proceed else timeout after 10 seconds
-	var existingPR porchapi.PackageRevision
-	err := t.Client.Get(t.GetContext(),
-		client.ObjectKey{
-			Namespace: t.Namespace,
-			Name:      repository + "." + otherPackageName + "." + workspace2,
-		},
-		&existingPR,
-	)
-
-	if err == nil {
-		t.WaitUntilObjectDeleted(
-			packageRevisionGVK,
-			types.NamespacedName{
-				Name:      repository + "." + otherPackageName + "." + workspace2,
-				Namespace: t.Namespace,
-			},
-			10*time.Second,
-		)
-	}
-
 	// Create a new revision of the package with a source that is a revision
 	// of the same package.
 	editPR := &porchapi.PackageRevision{
@@ -661,7 +639,8 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	}
 
 	// We await for this invalid packageRevision creation to be deleted then proceed else timeout after 10 seconds
-	err = t.Client.Get(t.GetContext(),
+	var existingPR porchapi.PackageRevision
+	err := t.Client.Get(t.GetContext(),
 		client.ObjectKey{
 			Namespace: t.Namespace,
 			Name:      repository + "." + packageName + "." + workspace2,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -607,6 +607,16 @@ func (t *PorchSuite) TestEditPackageRevision() {
 		t.Fatalf("Expected error for source revision being from different package")
 	}
 
+	// We await for this invalid packageRevision creation to be deleted then proceed else timeout after 10 seconds
+	t.WaitUntilObjectDeleted(
+		packageRevisionGVK,
+		types.NamespacedName{
+			Name:      repository + "." + otherPackageName + "." + workspace2,
+			Namespace: t.Namespace,
+		},
+		10*time.Second,
+	)
+
 	// Create a new revision of the package with a source that is a revision
 	// of the same package.
 	editPR := &porchapi.PackageRevision{
@@ -642,7 +652,7 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	t.WaitUntilObjectDeleted(
 		packageRevisionGVK,
 		types.NamespacedName{
-			Name:      otherPackageName,
+			Name:      repository + "." + packageName + "." + workspace2,
 			Namespace: t.Namespace,
 		},
 		10*time.Second,


### PR DESCRIPTION
Addresses an error made in #267 

The correct Package Revision name was not being used according to Kubernetes naming convention and as such was not correctly finding the object which should be awaited for deletion.

This PR addresses this issue along with added a check for if the object even exists at the point where we await its deletion if not we pass to avoid awaiting the deletion of a package revision that does not exist (because it has already been cleaned up)