### PR TITLE
Fix upstream references in DB Cache

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/internal/kpt/pkg"
 	"github.com/nephio-project/porch/pkg/engine"
@@ -151,9 +150,9 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 	// when https://github.com/GoogleContainerTools/kpt/issues/3297 is complete.
 	// Until then, we have to translate from one type to another.
 	if lock.Git != nil {
-		lockCopy = &v1alpha1.UpstreamLock{
-			Type: v1alpha1.OriginType(lock.Type),
-			Git: &v1alpha1.GitLock{
+		lockCopy = &porchapi.UpstreamLock{
+			Type: porchapi.OriginType(lock.Type),
+			Git: &porchapi.GitLock{
 				Repo:      lock.Git.Repo,
 				Directory: lock.Git.Directory,
 				Commit:    lock.Git.Commit,
@@ -325,12 +324,26 @@ func (pr *dbPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, 
 		externalPr, err := pr.repo.getExternalPr(context.Background(), pr.Key())
 		if err != nil {
 			return kptfile.Upstream{}, kptfile.UpstreamLock{},
-				pkgerrors.Wrapf(err, "dbPackageRevision:GetLock: getting loc of %+v failed, could not find package revision on external repository", pr.Key())
+				pkgerrors.Wrapf(err, "dbPackageRevision:GetLock: getting lock of %+v failed, could not find package revision on external repository", pr.Key())
 		}
 
 		return externalPr.GetLock()
 	} else {
-		return kptfile.Upstream{}, kptfile.UpstreamLock{}, nil
+		return kptfile.Upstream{
+				Type: kptfile.GitOrigin,
+				Git: &kptfile.Git{
+					Repo:      pr.repo.spec.Spec.Git.Repo,
+					Directory: pr.Key().PKey().ToPkgPathname(),
+					Ref:       "drafts/" + pr.Key().PKey().ToPkgPathname() + "/" + pr.Key().WorkspaceName,
+				},
+			}, kptfile.UpstreamLock{
+				Type: kptfile.GitOrigin,
+				Git: &kptfile.GitLock{
+					Repo:      pr.repo.spec.Spec.Git.Repo,
+					Directory: pr.Key().PKey().ToPkgPathname(),
+					Ref:       "drafts/" + pr.Key().PKey().ToPkgPathname() + "/" + pr.Key().WorkspaceName,
+				},
+			}, nil
 	}
 }
 

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -41,7 +41,11 @@ func TestDBPackageRevision(t *testing.T) {
 
 	testRepo := createTestRepo(t, "my-ns", "my-repo-name")
 	testRepo.spec = &configapi.Repository{
-		Spec: configapi.RepositorySpec{},
+		Spec: configapi.RepositorySpec{
+			Git: &configapi.GitRepository{
+				Repo: "https://aurl/repo.git",
+			},
+		},
 	}
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&testRepo).Maybe()
 
@@ -55,6 +59,7 @@ func TestDBPackageRevision(t *testing.T) {
 			WorkspaceName:  "my-workspace",
 		},
 	}
+
 	newPRDraft, err := testRepo.CreatePackageRevisionDraft(ctx, &newPRDef)
 	assert.Nil(t, err)
 	assert.NotNil(t, newPRDraft)
@@ -96,8 +101,8 @@ func TestDBPackageRevision(t *testing.T) {
 
 	newPrUp, newPrUpLock, err = dbPR.GetLock()
 	assert.Nil(t, err)
-	assert.Nil(t, newPrUp.Git)
-	assert.Nil(t, newPrUpLock.Git)
+	assert.NotNil(t, newPrUp.Git)
+	assert.NotNil(t, newPrUpLock.Git)
 
 	prResources, err := dbPR.GetResources(ctx)
 	assert.Nil(t, err)


### PR DESCRIPTION
When cloning, if the upstream package is still in draft, we cannot use a real Git upstream reference (the PR is not in Git yet), we have to send back the upstream reference as it would be if the package was in a Git repository.