### PR TITLE
Remove storage of DeletionProposed status in git

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -403,20 +403,10 @@ func (pr *dbPackageRevision) updateLifecycleOnPublishedPR(ctx context.Context, n
 	ctx, span := tracer.Start(ctx, "dbPackageRevision::updateLifecycleOnPublishedPR", trace.WithAttributes())
 	defer span.End()
 
-	externalPr, err := pr.repo.getExternalPr(ctx, pr.Key())
-	if err != nil {
-		return err
-	}
-
-	if err := externalPr.UpdateLifecycle(ctx, newLifecycle); err != nil {
-		klog.Warningf("error setting lifecycle to %q on package revision %+v for external repo, %q", newLifecycle, pr.Key(), err)
-		return err
-	}
-
 	pr.lifecycle = newLifecycle
 	pr.updated = time.Now()
 	pr.updatedBy = getCurrentUser()
 
-	_, err = pr.savePackageRevision(ctx, false)
+	_, err := pr.savePackageRevision(ctx, false)
 	return err
 }


### PR DESCRIPTION
We do not need to store the deletionproposed status in Git because it is already stored in the DB.