### PR TITLE
add WaitForReady in grpc client creation

### DIFF
--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -609,6 +609,7 @@ func (pm *podManager) getFuncEvalPodClient(ctx context.Context, image string, tt
 			grpc.WithDefaultCallOptions(
 				grpc.MaxCallRecvMsgSize(pm.maxGrpcMessageSize),
 				grpc.MaxCallSendMsgSize(pm.maxGrpcMessageSize),
+				grpc.WaitForReady(true),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
This PR fixes an intermittent 'connection refused' error when the function runner attempts to create a grpc connection with the KPT pods. 