### PR TITLE
Updated DB cache to support placeholder PRs

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/internal/kpt/pkg"
 	"github.com/nephio-project/porch/pkg/engine"
@@ -113,15 +112,9 @@ func (pr *dbPackageRevision) UpdateLifecycle(ctx context.Context, newLifecycle p
 	defer span.End()
 
 	if pr.lifecycle == porchapi.PackageRevisionLifecycleProposed && newLifecycle == porchapi.PackageRevisionLifecyclePublished {
-		latestRev, err := pkgRevGetlatestRevFromDB(ctx, pr.Key().PkgKey)
-		if err != nil {
-			return err
-		}
-
-		pr.pkgRevKey.Revision = latestRev + 1
-		if err := pr.publishToExternalRepo(ctx, newLifecycle); err != nil {
+		if err := pr.publishPR(ctx, newLifecycle); err != nil {
 			pr.pkgRevKey.Revision = 0
-			return err
+			return pkgerrors.Wrapf(err, "dbPackageRevision:UpdateLifecycle: could not publish package revision %+v", pr.Key())
 		}
 	} else if porchapi.LifecycleIsPublished(pr.lifecycle) {
 		return pr.updateLifecycleOnPublishedPR(ctx, newLifecycle)
@@ -151,9 +144,9 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 	// when https://github.com/GoogleContainerTools/kpt/issues/3297 is complete.
 	// Until then, we have to translate from one type to another.
 	if lock.Git != nil {
-		lockCopy = &v1alpha1.UpstreamLock{
-			Type: v1alpha1.OriginType(lock.Type),
-			Git: &v1alpha1.GitLock{
+		lockCopy = &porchapi.UpstreamLock{
+			Type: porchapi.OriginType(lock.Type),
+			Git: &porchapi.GitLock{
 				Repo:      lock.Git.Repo,
 				Directory: lock.Git.Directory,
 				Commit:    lock.Git.Commit,
@@ -288,8 +281,31 @@ func (pr *dbPackageRevision) GetUpstreamLock(ctx context.Context) (kptfile.Upstr
 func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) repository.PackageRevision {
 	_, span := tracer.Start(ctx, "dbPackageRevision::SetMeta", trace.WithAttributes())
 	defer span.End()
-	klog.V(5).Infof("ToMainPackageRevision: %+v, main package revisions are only generated on external repos", pr.Key().PKey())
-	return nil
+
+	mainPR := &dbPackageRevision{
+		repo: pr.repo,
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        pr.Key().PKey(),
+			Revision:      -1,
+			WorkspaceName: pr.Key().RKey().PlaceholderWSname,
+		},
+		meta:      metav1.ObjectMeta{},
+		spec:      &porchapi.PackageRevisionSpec{},
+		updated:   time.Now(),
+		updatedBy: getCurrentUser(),
+		lifecycle: pr.lifecycle,
+		latest:    false,
+		tasks:     pr.tasks,
+		resources: pr.resources,
+	}
+
+	if mainPR.pkgRevKey.WorkspaceName == "" {
+		mainPR.pkgRevKey.WorkspaceName = "main"
+	}
+
+	klog.V(5).Infof("ToMainPackageRevision: %+v, main package revision generated", mainPR.Key())
+
+	return mainPR
 }
 
 func (pr *dbPackageRevision) GetMeta() metav1.ObjectMeta {
@@ -385,15 +401,33 @@ func (pr *dbPackageRevision) UpdateResources(ctx context.Context, new *porchapi.
 	return nil
 }
 
-func (pr *dbPackageRevision) publishToExternalRepo(ctx context.Context, newLifecycle porchapi.PackageRevisionLifecycle) error {
+func (pr *dbPackageRevision) publishPR(ctx context.Context, newLifecycle porchapi.PackageRevisionLifecycle) error {
 	_, span := tracer.Start(ctx, "dbPackageRevision::publishToExternalRepo", trace.WithAttributes())
 	defer span.End()
 
+	latestRev, err := pkgRevGetlatestRevFromDB(ctx, pr.Key().PkgKey)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "dbPackageRevision:publishPR: could not get latest package revision for package revision %+v from DB", pr.Key())
+	}
+
+	pr.pkgRevKey.Revision = latestRev + 1
 	pr.lifecycle = newLifecycle
+
 	if err := engine.PushPackageRevision(ctx, pr.repo.externalRepo, pr); err != nil {
 		klog.Warningf("push of package revision %+v to external repo failed, %q", pr.Key(), err)
+		pr.pkgRevKey.Revision = 0
 		pr.lifecycle = porchapi.PackageRevisionLifecycleProposed
-		return err
+		return pkgerrors.Wrapf(err, "dbPackageRevision:publishPR: push of package revision %+v to external repo failed", pr.Key())
+	}
+
+	if pr.pkgRevKey.Revision == 1 {
+		if err = pkgRevWriteToDB(ctx, pr.ToMainPackageRevision(ctx).(*dbPackageRevision)); err != nil {
+			return pkgerrors.Wrapf(err, "dbPackageRevision:UpdateLifecycle: could not write placeholder package revision for package revision %+v to DB", pr.Key())
+		}
+	} else if pr.pkgRevKey.Revision > 1 {
+		if err = pkgRevUpdateDB(ctx, pr.ToMainPackageRevision(ctx).(*dbPackageRevision), true); err != nil {
+			return pkgerrors.Wrapf(err, "dbPackageRevision:UpdateLifecycle: could not update placeholder package revision for package revision %+v to DB", pr.Key())
+		}
 	}
 
 	return nil

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -63,7 +63,9 @@ func TestDBPackageRevision(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, dbPR)
 
-	assert.Nil(t, dbPR.ToMainPackageRevision(ctx))
+	assert.Equal(t, "main", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
+	dbPR.(*dbPackageRevision).pkgRevKey.PkgKey.RepoKey.PlaceholderWSname = "my-branch"
+	assert.Equal(t, "my-branch", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
 
 	meta := dbPR.GetMeta()
 	assert.Equal(t, meta.Name, "")
@@ -79,8 +81,9 @@ func TestDBPackageRevision(t *testing.T) {
 	prKey := repository.PackageRevisionKey{
 		PkgKey: repository.PackageKey{
 			RepoKey: repository.RepositoryKey{
-				Namespace: "my-ns",
-				Name:      "my-repo-name",
+				Namespace:         "my-ns",
+				Name:              "my-repo-name",
+				PlaceholderWSname: "my-branch",
 			},
 			Package: "my-package",
 		},


### PR DESCRIPTION
DB Cache generates main PRs on it's sync. This PR adds the feature of generating main PRs on publishing of a PR.