### PR TITLE
Improve error messages in Git repository opening to make debugging easier

### DIFF
--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -143,19 +143,19 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 
 		r, err := initEmptyRepository(dir)
 		if err != nil {
-			return nil, fmt.Errorf("error cloning git repository %q: %w", spec.Repo, err)
+			return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, could not initialize empty repository", spec.Repo)
 		}
 
 		repo = r
 	} else if !fi.IsDir() {
 		// Internal error - corrupted cache. We will cleanup on the way out.
-		return nil, fmt.Errorf("cannot clone git repository %q: %w", spec.Repo, err)
+		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, local cache location %q is not a directory", spec.Repo, dir)
 	} else {
 		cleanup = "" // Existing directory; do not delete it.
 
 		r, err := openRepository(dir)
 		if err != nil {
-			return nil, err
+			return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, open of repository failed in gogit", spec.Repo)
 		}
 
 		repo = r
@@ -163,7 +163,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 
 	// Create Remote
 	if err := initializeOrigin(repo, spec.Repo); err != nil {
-		return nil, fmt.Errorf("error cloning git repository %q, cannot create remote: %v", spec.Repo, err)
+		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, cannot create remote", spec.Repo)
 	}
 
 	// NOTE: the spec.git.branch field in the Repository CRD (OpenAPI schema) is defined with
@@ -175,7 +175,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 	}
 
 	if err := util.ValidateDirectoryName(string(branch), false); err != nil {
-		return nil, fmt.Errorf("branch name %s invalid: %v", branch, err)
+		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, branch name %q invalid", spec.Repo, branch)
 	}
 
 	repository := &gitRepository{
@@ -203,11 +203,11 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 	}
 
 	if err := repository.fetchRemoteRepositoryWithRetry(ctx); err != nil {
-		return nil, err
+		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, fetch of remote repository failed", spec.Repo)
 	}
 
 	if err := repository.verifyRepository(ctx, &opts); err != nil {
-		return nil, err
+		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, fetch of remote repository failed", spec.Repo)
 	}
 
 	cleanup = "" // Success. Keep the git directory.
@@ -654,19 +654,19 @@ func (r *gitRepository) fetchRemoteRepositoryWithRetry(ctx context.Context) erro
 			if retryNumber >= 0 {
 				err := r.fetchRemoteRepository(ctx)
 				if err != nil {
-					klog.Errorf("Fetching Remote Repository %s failed - try number %d", r.Key().Name, retryNumber)
+					klog.Errorf("Fetching Remote Repository %+v failed - try number %d", r.Key(), retryNumber)
 					time.Sleep(1 * time.Second)
-					return err
+					return pkgerrors.Wrapf(err, "fetch of remote repository %+v with retry failed on try number %d", r.Key(), retryNumber)
 				}
 				if retryNumber > 1 {
-					klog.Infof("Successfully Fetched Remote Repository %s after %d retries", r.Key(), retryNumber)
+					klog.Infof("Successfully Fetched Remote Repository %+v after %d retries", r.Key(), retryNumber)
 				}
 				return nil
 			}
 			return nil
 		},
 	); err != nil {
-		return err
+		return pkgerrors.Wrapf(err, "fetch of remote repository %+v with retry failed", r.Key())
 	}
 	return nil
 }


### PR DESCRIPTION
The logs in git.go and gogit.go are improved to provide better explanations of what went wrong when errors occur.