### PR TITLE
Fix an issue where multiple Kpt pods were getting created

### DIFF
--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -362,12 +362,12 @@ func (pcm *podCacheManager) podCacheManager() {
 			_, found = pcm.waitlists[req.image]
 			if !found {
 				pcm.waitlists[req.image] = []chan<- *clientConnAndError{}
+				// We invoke the function with useGenerateName=true to avoid potential name collision, since if pod foo is
+				// being deleted and we can't use the same name.
+				go pcm.podManager.getFuncEvalPodClient(context.Background(), req.image, pcm.podTTL, true)
 			}
 			list := pcm.waitlists[req.image]
 			pcm.waitlists[req.image] = append(list, req.grpcClientCh)
-			// We invoke the function with useGenerateName=true to avoid potential name collision, since if pod foo is
-			// being deleted and we can't use the same name.
-			go pcm.podManager.getFuncEvalPodClient(context.Background(), req.image, pcm.podTTL, true)
 		case resp := <-pcm.podReadyCh:
 			if resp.err != nil {
 				klog.Warningf("received error from the pod manager: %v", resp.err)


### PR DESCRIPTION
This PR fixes https://github.com/nephio-project/nephio/issues/952
The getFuncEvalPodClient was always called, which internally caused errors while creating pods and services because of duplication. 
This change runs the getFuncEvalPodClient only if the image is not in the map.