### PR TITLE
Fixing repo directory value trimming when pkg name contains it

### DIFF
--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -155,7 +155,7 @@ func (t *packageList) discoverPackages(repoKey repository.RepositoryKey, tree *o
 
 			// Found a package
 			t.packages[treePath] = &packageListEntry{
-				// When discovering packages we need the absolute path of the package in relation to the root of the repo
+				// When discovering packages the absolute path of the package is needed in relation to the root of the repo
 				pkgKey:   repository.FromFullPathname(repoKey, strings.TrimPrefix(treePath, repoKey.Path)),
 				treeHash: tree.Hash,
 				parent:   t,

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -155,6 +155,7 @@ func (t *packageList) discoverPackages(repoKey repository.RepositoryKey, tree *o
 
 			// Found a package
 			t.packages[treePath] = &packageListEntry{
+				// When discovering packages we need the absolute path of the package in relation to the root of the repo
 				pkgKey:   repository.FromFullPathname(repoKey, strings.TrimPrefix(treePath, repoKey.Path)),
 				treeHash: tree.Hash,
 				parent:   t,

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -154,7 +155,7 @@ func (t *packageList) discoverPackages(repoKey repository.RepositoryKey, tree *o
 
 			// Found a package
 			t.packages[treePath] = &packageListEntry{
-				pkgKey:   repository.FromFullPathname(repoKey, treePath),
+				pkgKey:   repository.FromFullPathname(repoKey, strings.TrimPrefix(treePath, repoKey.Path)),
 				treeHash: tree.Hash,
 				parent:   t,
 			}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -160,7 +160,7 @@ func K8SName2PkgName(k8sName string) string {
 }
 
 func FromFullPathname(repoKey RepositoryKey, fullpath string) PackageKey {
-	pkgPath := strings.Trim(strings.TrimPrefix(fullpath, repoKey.Path), "/")
+	pkgPath := strings.Trim(fullpath, "/")
 	slashIndex := strings.LastIndex(pkgPath, "/")
 
 	if slashIndex >= 0 {


### PR DESCRIPTION
This PR addresses and fixes https://github.com/nephio-project/nephio/issues/950.
There was seemingly an unnecessary trim which when the packageName contained the value of the directory variable in the yaml file of a repository resource would be trimmed away from the package.