### PR TITLE
Fix path output on package revisions with paths in DB cache

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -204,7 +204,7 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 			Finalizers:        readPR.GetMeta().Finalizers,
 		},
 		Spec: porchapi.PackageRevisionSpec{
-			PackageName:    readPR.Key().PKey().Package,
+			PackageName:    readPR.Key().PKey().ToPkgPathname(),
 			RepositoryName: readPR.Key().RKey().Name,
 			Lifecycle:      readPR.Lifecycle(ctx),
 			Tasks:          readPR.tasks,


### PR DESCRIPTION
The entire path of a package should be output on `porchctl rpkg get`

fixes: https://github.com/nephio-project/nephio/issues/951