### PR TITLE
Add a hint about the Git cache if git repo open fails

### DIFF
--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -155,7 +155,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 
 		r, err := openRepository(dir)
 		if err != nil {
-			return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, open of repository failed in gogit", spec.Repo)
+			return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, open of repository failed in gogit (check the local git cache)", spec.Repo)
 		}
 
 		repo = r


### PR DESCRIPTION
When the local porch git cache gets corrupt, the error message is not helpful. Usually one has to delete the local GIt cache in `.cache/git` to force gogit to re-pull the remote repo.

This PR adds a hint to the error message to check the cache.