### PR TITLE
Increas the context timeout so that e2e tests don't fail

### DIFF
--- a/test/e2e/suite_utils.go
+++ b/test/e2e/suite_utils.go
@@ -468,7 +468,7 @@ func (t *TestSuite) WaitUntilRepositoryReady(name, namespace string) {
 	}
 
 	// While we're using an aggregated apiserver, make sure we can query the generated objects
-	if err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(t.GetContext(), time.Second, 32*time.Second, true, func(ctx context.Context) (bool, error) {
 		var revisions porchapi.PackageRevisionList
 		if err := t.Client.List(ctx, &revisions, client.InNamespace(nn.Namespace)); err != nil {
 			innerErr = err


### PR DESCRIPTION
The "TestGitRepositoryWithReleaseTagsAndDirectory" fails very often. This e2e test pulls the very large "https://github.com/kptdev/kpt.git" repo and the current context timeout of 10 seconds for listing the contents of the repo can often be exceeded because it takes Porch some time to download the repo contents and to find and load the kpt packages in the repo.

This PR increases the context deadline to 32 seconds, which should be sufficient to allow the test to pass.