### PR TITLE
Fix "svc already exists" errors while executing concurrent API calls

### DIFF
--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -1057,7 +1057,7 @@ func (pm *podManager) retrieveOrCreateService(ctx context.Context, serviceName s
 			if errors.IsAlreadyExists(err) {
 				klog.Infof("service %v/%v already exists - trying to retrieve it", pm.namespace, serviceName)
 				err = pm.kubeClient.Get(ctx, client.ObjectKey{Namespace: pm.namespace, Name: serviceName}, existingService)
-				if errExistingSvc == nil {
+				if err == nil {
 					klog.Infof("retrieved function evaluator service %v/%v", existingService.Namespace, existingService.Name)
 					return client.ObjectKey{Namespace: existingService.Namespace, Name: existingService.Name}, nil
 				}

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -1056,7 +1056,7 @@ func (pm *podManager) retrieveOrCreateService(ctx context.Context, serviceName s
 			// Try to retrieve again
 			if errors.IsAlreadyExists(err) {
 				klog.Infof("service %v/%v already exists - trying to retrieve it", pm.namespace, serviceName)
-				errExistingSvc := pm.kubeClient.Get(ctx, client.ObjectKey{Namespace: pm.namespace, Name: serviceName}, existingService)
+				err = pm.kubeClient.Get(ctx, client.ObjectKey{Namespace: pm.namespace, Name: serviceName}, existingService)
 				if errExistingSvc == nil {
 					klog.Infof("retrieved function evaluator service %v/%v", existingService.Namespace, existingService.Name)
 					return client.ObjectKey{Namespace: existingService.Namespace, Name: existingService.Name}, nil


### PR DESCRIPTION
This PR fixes an issue where executing concurrent API calls without KPT pods/services active was leading to svc already exists. 

Instead of crashing the whole flow, this change will try to retrieve the service if it already exists. 