### PR TITLE
Fix custom CA bundle resolution

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -212,7 +212,6 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 	resolverChain := []porch.Resolver{
 		porch.NewBasicAuthResolver(),
 		porch.NewBearerTokenAuthResolver(),
-		// porch.NewCaBundleResolver(),
 		porch.NewGcloudWIResolver(coreV1Client, stsClient),
 	}
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -212,11 +212,12 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 	resolverChain := []porch.Resolver{
 		porch.NewBasicAuthResolver(),
 		porch.NewBearerTokenAuthResolver(),
-		porch.NewCaBundleResolver(),
+		// porch.NewCaBundleResolver(),
 		porch.NewGcloudWIResolver(coreV1Client, stsClient),
 	}
 
 	credentialResolver := porch.NewCredentialResolver(coreClient, resolverChain)
+	caBundleResolver := porch.NewCredentialResolver(coreClient, []porch.Resolver{porch.NewCaBundleResolver()})
 	referenceResolver := porch.NewReferenceResolver(coreClient)
 	userInfoProvider := &porch.ApiserverUserInfoProvider{}
 
@@ -225,6 +226,7 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 	c.ExtraConfig.CacheOptions.CoreClient = coreClient
 	c.ExtraConfig.CacheOptions.RepoPRChangeNotifier = watcherMgr
 	c.ExtraConfig.CacheOptions.ExternalRepoOptions.CredentialResolver = credentialResolver
+	c.ExtraConfig.CacheOptions.ExternalRepoOptions.CaBundleResolver = caBundleResolver
 	c.ExtraConfig.CacheOptions.ExternalRepoOptions.UserInfoProvider = userInfoProvider
 
 	cacheImpl, err := cache.GetCacheImpl(ctx, c.ExtraConfig.CacheOptions)

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -196,8 +196,8 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 		deployment:         deployment,
 	}
 
-	if opts.ExternalRepoOptions.UseUserDefinedCaBundle {
-		if caBundle, err := opts.ExternalRepoOptions.CredentialResolver.ResolveCredential(ctx, namespace, namespace+"-ca-bundle"); err != nil {
+	if opts.UseUserDefinedCaBundle && opts.CaBundleResolver != nil {
+		if caBundle, err := opts.CaBundleResolver.ResolveCredential(ctx, namespace, namespace+"-ca-bundle"); err != nil {
 			klog.Errorf("failed to obtain caBundle from secret %s/%s: %v", namespace, namespace+"-ca-bundle", err)
 		} else {
 			repository.caBundle = []byte(caBundle.ToString())

--- a/pkg/externalrepo/types/externalrepotypes.go
+++ b/pkg/externalrepo/types/externalrepotypes.go
@@ -29,5 +29,6 @@ type ExternalRepoOptions struct {
 	LocalDirectory         string
 	UseUserDefinedCaBundle bool
 	CredentialResolver     repository.CredentialResolver
+	CaBundleResolver       repository.CredentialResolver
 	UserInfoProvider       repository.UserInfoProvider
 }


### PR DESCRIPTION
It looks like #192 seems to have broken custom git CA bundle resolution, and this PR is meant to fix that by separating the git auth and the git CA bundle secret resolvers.