### PR TITLE
fix controller-runtime logger not set

### DIFF
--- a/cmd/porch/main.go
+++ b/cmd/porch/main.go
@@ -34,6 +34,8 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func main() {
@@ -42,6 +44,7 @@ func main() {
 }
 
 func run() int {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
 	t := &telemetry{}
 	if err := t.Start(); err != nil {
 		klog.Warningf("failed to start telemetry: %v", err)


### PR DESCRIPTION
After a restart of porch-server at the first delete we would get a controller-runtime logger not set warning that is polluting the logs.
This logger is used in pkg/controllerrestmapper/caching.go in the fetch() Function. 
If we initialize it in main, we will not have this warnings


```
I0807 10:29:49.105541  485661 webhooks.go:442] received request to validate deletion
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 3604 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:26 +0x6b
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/home/flapenta/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/log/log.go:60 +0xa5
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0003bf840, {0x697f6a2, 0x14})
	>  	/home/flapenta/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/log/deleg.go:147 +0x45
	>  github.com/go-logr/logr.Logger.WithName({{0x6d13638, 0xc0003bf840}, 0x0}, {0x697f6a2, 0x14})
	>  	/home/flapenta/go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:345 +0x62
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0xc000e6c6c8, {0x0, 0xc000521730, {0x6d16280, 0xc001c6e440}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/flapenta/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/client.go:129 +0x128
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0xc000e4eb48, {0x0, 0xc000521730, {0x6d16280, 0xc001c6e440}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/flapenta/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/client.go:110 +0xcc
	>  github.com/nephio-project/porch/internal/kpt/util/porch.CreateClient(0xc000e4eb48)
	>  	/home/flapenta/NEPHIO/main-porch/porch/internal/kpt/util/porch/client.go:39 +0x192
	>  github.com/nephio-project/porch/pkg/apiserver.createPorchClient()
	>  	/home/flapenta/NEPHIO/main-porch/porch/pkg/apiserver/webhooks.go:548 +0x1ce
	>  github.com/nephio-project/porch/pkg/apiserver.validateDeletion({0x6cf4960, 0xc000d281d0}, 0xc001826b40)
	>  	/home/flapenta/NEPHIO/main-porch/porch/pkg/apiserver/webhooks.go:459 +0x34e
	>  net/http.HandlerFunc.ServeHTTP(0x6aea400, {0x6cf4960, 0xc000d281d0}, 0xc001826b40)
	>  	/usr/local/go/src/net/http/server.go:2294 +0x33
	>  net/http.(*ServeMux).ServeHTTP(0x8b93f00, {0x6cf4960, 0xc000d281d0}, 0xc001826b40)
	>  	/usr/local/go/src/net/http/server.go:2822 +0x3c2
	>  net/http.serverHandler.ServeHTTP({0xc000298800}, {0x6cf4960, 0xc000d281d0}, 0xc001826b40)
	>  	/usr/local/go/src/net/http/server.go:3301 +0x257
	>  net/http.initALPNRequest.ServeHTTP({{0x6d0a398, 0xc000ca1920}, 0xc000d64e08, {0xc000298800}}, {0x6cf4960, 0xc000d281d0}, 0xc001826b40)
	>  	/usr/local/go/src/net/http/server.go:3968 +0x2a7
	>  net/http.(*http2serverConn).runHandler(0xc001a632c0, 0xc000d281d0, 0xc001826b40, 0xc000421ad0)
	>  	/usr/local/go/src/net/http/h2_bundle.go:6529 +0x26f
	>  created by net/http.(*http2serverConn).scheduleHandler in goroutine 3560
	>  	/usr/local/go/src/net/http/h2_bundle.go:6463 +0x1e5
```