### PR TITLE
Disable InferAssociativeLists, add more tests

### DIFF
--- a/pkg/util/merge3/testdata/infer-crd-empty-dest/destination.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-dest/destination.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits: []

--- a/pkg/util/merge3/testdata/infer-crd-empty-dest/original.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-dest/original.yaml
@@ -1,0 +1,30 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits:
+        - name: apple
+          amount: 10
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/infer-crd-empty-dest/updated.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-dest/updated.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits:
+        - name: pear
+          amount: 30
+        - name: apple
+          amount: 20
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/infer-crd-empty-orig/destination.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-orig/destination.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits:
+        - name: grape
+          amount: 5
+        - name: apple
+          amount: 25
+        - name: banana
+          amount: 3

--- a/pkg/util/merge3/testdata/infer-crd-empty-orig/original.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-orig/original.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits: []

--- a/pkg/util/merge3/testdata/infer-crd-empty-orig/updated.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-orig/updated.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits:
+        - name: pear
+          amount: 30
+        - name: apple
+          amount: 20
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/infer-crd-empty-updated/destination.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-updated/destination.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits:
+        - name: grape
+          amount: 5
+        - name: apple
+          amount: 25
+        - name: banana
+          amount: 3

--- a/pkg/util/merge3/testdata/infer-crd-empty-updated/original.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-updated/original.yaml
@@ -1,0 +1,30 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits:
+        - name: apple
+          amount: 10
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/infer-crd-empty-updated/updated.yaml
+++ b/pkg/util/merge3/testdata/infer-crd-empty-updated/updated.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits: []

--- a/pkg/util/merge3/testdata/one-key-crd-empty-dest/destination.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-dest/destination.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits: []

--- a/pkg/util/merge3/testdata/one-key-crd-empty-dest/fruitstore.crd.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-dest/fruitstore.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fruitstores.test.group
+spec:
+  group: test.group
+  names:
+    kind: FruitStore
+    plural: fruitstores
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                airConditioned:  # control field
+                  type: bool
+                  default: false
+                preferredTemperature:  # control field
+                  type: integer
+                fruits:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [ name ]
+                  x-kubernetes-patch-merge-key: name
+                  x-kubernetes-patch-strategy: merge
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      amount:
+                        type: integer
+                    required:
+                      - name
+                      - amount
+              required:
+                - preferredTemperature

--- a/pkg/util/merge3/testdata/one-key-crd-empty-dest/original.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-dest/original.yaml
@@ -1,0 +1,30 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits:
+        - name: apple
+          amount: 10
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/one-key-crd-empty-dest/updated.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-dest/updated.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits:
+        - name: pear
+          amount: 30
+        - name: apple
+          amount: 20
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/one-key-crd-empty-orig/destination.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-orig/destination.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits:
+        - name: grape
+          amount: 5
+        - name: apple
+          amount: 25
+        - name: banana
+          amount: 3

--- a/pkg/util/merge3/testdata/one-key-crd-empty-orig/fruitstore.crd.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-orig/fruitstore.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fruitstores.test.group
+spec:
+  group: test.group
+  names:
+    kind: FruitStore
+    plural: fruitstores
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                airConditioned:  # control field
+                  type: bool
+                  default: false
+                preferredTemperature:  # control field
+                  type: integer
+                fruits:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [ name ]
+                  x-kubernetes-patch-merge-key: name
+                  x-kubernetes-patch-strategy: merge
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      amount:
+                        type: integer
+                    required:
+                      - name
+                      - amount
+              required:
+                - preferredTemperature

--- a/pkg/util/merge3/testdata/one-key-crd-empty-orig/original.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-orig/original.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits: []

--- a/pkg/util/merge3/testdata/one-key-crd-empty-orig/updated.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-orig/updated.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits:
+        - name: pear
+          amount: 30
+        - name: apple
+          amount: 20
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/one-key-crd-empty-updated/destination.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-updated/destination.yaml
@@ -1,0 +1,32 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v2"
+  revision: 2
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 20
+        fruits:
+        - name: grape
+          amount: 5
+        - name: apple
+          amount: 25
+        - name: banana
+          amount: 3

--- a/pkg/util/merge3/testdata/one-key-crd-empty-updated/fruitstore.crd.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-updated/fruitstore.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fruitstores.test.group
+spec:
+  group: test.group
+  names:
+    kind: FruitStore
+    plural: fruitstores
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                airConditioned:  # control field
+                  type: bool
+                  default: false
+                preferredTemperature:  # control field
+                  type: integer
+                fruits:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [ name ]
+                  x-kubernetes-patch-merge-key: name
+                  x-kubernetes-patch-strategy: merge
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      amount:
+                        type: integer
+                    required:
+                      - name
+                      - amount
+              required:
+                - preferredTemperature

--- a/pkg/util/merge3/testdata/one-key-crd-empty-updated/original.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-updated/original.yaml
@@ -1,0 +1,30 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v1"
+  revision: 1
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 15
+        fruits:
+        - name: apple
+          amount: 10
+        - name: grape
+          amount: 5

--- a/pkg/util/merge3/testdata/one-key-crd-empty-updated/updated.yaml
+++ b/pkg/util/merge3/testdata/one-key-crd-empty-updated/updated.yaml
@@ -1,0 +1,26 @@
+apiVersion: porch.kpt.dev/v1alpha1
+kind: PackageRevisionResources
+metadata:
+  name: "test-resources"
+spec:
+  packageName: "test-package"
+  workspaceName: "v3"
+  revision: 3
+  repositoryName: "test-repo"
+  resources:
+    Kptfile: |
+      apiVersion: kpt.dev/v1
+      kind: Kptfile
+      metadata:
+        name: test-package
+      info:
+        description: test package
+    fruitstore.yaml: |
+      apiVersion: test.group/v1
+      kind: FruitStore
+      metadata:
+        name: test-fruit-store
+      spec:
+        airConditioned: false
+        preferredTemperature: 10
+        fruits: []

--- a/pkg/util/merge3/tuple.go
+++ b/pkg/util/merge3/tuple.go
@@ -40,7 +40,7 @@ func (t *tuple) merge() (*yaml.RNode, error) {
 		Sources:            []*yaml.RNode{t.dest, t.original, t.updated},
 
 		// added
-		InferAssociativeLists: true,
+		InferAssociativeLists: false,
 	}.Walk()
 }
 


### PR DESCRIPTION
@lapentad found that having `InferAssociativeLists` enabled for the 3 way merge causes errors for empty lists. In my opinion this is a bug in kyaml.

In this PR I added a lot more tests for this behaviour, including some for infer which are skipped for now. Also had to skip `one-key-crd-empty-dest` because somehow during the merge of the associative list in the test, one of the list items does not get it's `tag` field set, resulting in our KubeObject/SubObject util code returning in error:

```
err: node was not a string, was
```

Problematic example:
```
Tag = ""
Value = "apple"
```

The other element right after:
```
Tag = "!!str"
Value = "pear"
```

This also might be a bug in kyaml, but should be investigated further.