### PR TITLE
Manually choose the upgrade strategy in porchctl

### DIFF
--- a/pkg/cli/commands/rpkg/docs/docs.go
+++ b/pkg/cli/commands/rpkg/docs/docs.go
@@ -310,10 +310,18 @@ Flags:
   The workspace name of the newly created package revision.
 
   --strategy
-  The strategy to use for the upgrade.
+  (Optional) The strategy to use for the upgrade.
   Options: resource-merge (default), fast-forward, force-delete-replace, copy-merge.
+
+  --discover
+  If set, search for available updates instead of performing an update.
+  Setting this to 'upstream' will discover upstream updates of downstream packages.
+  Setting this to 'downstream' will discover downstream package revisions of upstream packages that need to be updated.
 `
 var UpgradeExamples = `
+  # discover available upstream updates for downstream packages
+  $ porchctl rpkg upgrade --discover=upstream
+
   # upgrade deployment.some-package.v1 package to v3 of its upstream
   $ porchctl rpkg upgrade deployment.some-package.v1 --revision=3 --workspace=v2
 

--- a/pkg/cli/commands/rpkg/docs/docs.go
+++ b/pkg/cli/commands/rpkg/docs/docs.go
@@ -308,6 +308,10 @@ Flags:
 
   --workspace
   The workspace name of the newly created package revision.
+
+  --strategy
+  The strategy to use for the upgrade.
+  Options: resource-merge (default), fast-forward, force-delete-replace, copy-merge.
 `
 var UpgradeExamples = `
   # upgrade deployment.some-package.v1 package to v3 of its upstream
@@ -315,4 +319,7 @@ var UpgradeExamples = `
 
   # upgrade deployment.some-package.v1 package to the latest of its upstream
   $ porchctl rpkg upgrade deployment.some-package.v1 --workspace=v2
+
+  # upgrade deployment.some-package.v1 package to v3 of its upstream, using copy-merge strategy
+  $ porchctl rpkg upgrade deployment.some-package.v1 --revision=3 --workspace=v2 --strategy=copy-merge
 `

--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"slices"
+
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/internal/kpt/errors"
 	"github.com/nephio-project/porch/internal/kpt/util/porch"
@@ -57,6 +59,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	}
 	r.Command.Flags().IntVar(&r.revision, "revision", 0, "Revision of the upstream package to upgrade to.")
 	r.Command.Flags().StringVar(&r.workspace, "workspace", "", "Workspace name of the upgrade package revision.")
+	r.Command.Flags().StringVar(&r.strategy, "strategy", "", "Strategy to use for the upgrade. Options: resource-merge (default), fast-forward, force-delete-replace, copy-merge.")
 	r.Command.Flags().StringVar(&r.discover, "discover", "",
 		`If set, search for available updates instead of performing an update.
 Setting this to 'upstream' will discover upstream updates of downstream packages.
@@ -72,6 +75,7 @@ type runner struct {
 
 	revision  int // Target package revision
 	workspace string
+	strategy  string // Merge strategy to use, default is "resource-merge"
 
 	discover string // If set, discover updates rather than do updates
 
@@ -101,6 +105,13 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 		}
 		if r.workspace == "" {
 			return errors.E(op, fmt.Errorf("workspace is required"))
+		}
+		if r.strategy != "" {
+			validStrategies := []string{"resource-merge", "fast-forward", "force-delete-replace", "copy-merge"}
+			valid := slices.Contains(validStrategies, r.strategy)
+			if !valid {
+				return errors.E(op, fmt.Errorf("invalid strategy %q; must be one of: %v", r.strategy, validStrategies))
+			}
 		}
 	case upstream, downstream:
 		// do nothing
@@ -189,6 +200,20 @@ func (r *runner) doUpgrade(pr *porchapi.PackageRevision) (*porchapi.PackageRevis
 		return nil, pkgerrors.Errorf("new upstream package revision %s is not published", newUpstreamPr.Name)
 	}
 
+	strategy := porchapi.ResourceMerge
+	if r.strategy != "" {
+		switch r.strategy {
+		case "resource-merge":
+			strategy = porchapi.ResourceMerge
+		case "fast-forward":
+			strategy = porchapi.FastForward
+		case "force-delete-replace":
+			strategy = porchapi.ForceDeleteReplace
+		case "copy-merge":
+			strategy = porchapi.CopyMerge
+		}
+	}
+
 	upgradeTask := &porchapi.Task{
 		Type: porchapi.TaskTypeUpgrade,
 		Upgrade: &porchapi.PackageUpgradeTaskSpec{
@@ -201,7 +226,7 @@ func (r *runner) doUpgrade(pr *porchapi.PackageRevision) (*porchapi.PackageRevis
 			LocalPackageRevisionRef: porchapi.PackageRevisionRef{
 				Name: pr.Name,
 			},
-			Strategy: porchapi.ResourceMerge,
+			Strategy: strategy,
 		},
 	}
 	newPr := makePackageRevision(pr, r.workspace, upgradeTask)

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -448,7 +448,7 @@ func TestDiscoverUpdates(t *testing.T) {
 
 func TestPreRunStrategyValidation(t *testing.T) {
 	ns := "ns"
-	mockClient := mockclient.NewMockClient(t)
+	fakeClient := fake.NewClientBuilder().Build()
 	cfg := &genericclioptions.ConfigFlags{Namespace: &ns}
 	ctx := context.Background()
 
@@ -462,13 +462,13 @@ func TestPreRunStrategyValidation(t *testing.T) {
 			name:          "Valid strategy: copy-merge",
 			strategy:      string(porchapi.CopyMerge),
 			expectErr:     true,
-			expectedError: "the server is currently unable to handle the request",
+			expectedError: "cmdrpkgupgrade", // this means the strategy is valid and it fails elsewhere
 		},
 		{
 			name:          "Empty strategy is valid (uses default resource-merge)",
 			strategy:      "",
 			expectErr:     true,
-			expectedError: "the server is currently unable to handle the request",
+			expectedError: "cmdrpkgupgrade",
 		},
 		{
 			name:          "Invalid strategy",
@@ -483,7 +483,7 @@ func TestPreRunStrategyValidation(t *testing.T) {
 			r := &runner{
 				ctx:       ctx,
 				cfg:       cfg,
-				client:    mockClient,
+				client:    fakeClient,
 				revision:  2,
 				workspace: "v2",
 				strategy:  tc.strategy,

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -448,7 +448,7 @@ func TestDiscoverUpdates(t *testing.T) {
 
 func TestPreRunStrategyValidation(t *testing.T) {
 	ns := "ns"
-	fakeClient := fake.NewClientBuilder().Build()
+	mockClient := mockclient.NewMockClient(t)
 	cfg := &genericclioptions.ConfigFlags{Namespace: &ns}
 	ctx := context.Background()
 
@@ -483,7 +483,7 @@ func TestPreRunStrategyValidation(t *testing.T) {
 			r := &runner{
 				ctx:       ctx,
 				cfg:       cfg,
-				client:    fakeClient,
+				client:    mockClient,
 				revision:  2,
 				workspace: "v2",
 				strategy:  tc.strategy,

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -445,3 +445,61 @@ func TestDiscoverUpdates(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid argument \"lowstream\" for --discover")
 	})
 }
+
+func TestPreRunStrategyValidation(t *testing.T) {
+	ns := "ns"
+	fakeClient := fake.NewClientBuilder().Build()
+	cfg := &genericclioptions.ConfigFlags{Namespace: &ns}
+	ctx := context.Background()
+
+	testCases := []struct {
+		name          string
+		strategy      string
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name:          "Valid strategy: copy-merge",
+			strategy:      string(porchapi.CopyMerge),
+			expectErr:     true,
+			expectedError: "the server is currently unable to handle the request",
+		},
+		{
+			name:          "Empty strategy is valid (uses default resource-merge)",
+			strategy:      "",
+			expectErr:     true,
+			expectedError: "the server is currently unable to handle the request",
+		},
+		{
+			name:          "Invalid strategy",
+			strategy:      "non-existent-strategy",
+			expectErr:     true,
+			expectedError: "invalid strategy \"non-existent-strategy\"; must be one of:",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &runner{
+				ctx:       ctx,
+				cfg:       cfg,
+				client:    fakeClient,
+				revision:  2,
+				workspace: "v2",
+				strategy:  tc.strategy,
+			}
+			r.Command = NewCommand(r.ctx, r.cfg)
+
+			err := r.preRunE(r.Command, []string{"some-package-revision"})
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				if tc.expectedError != "" {
+					assert.Contains(t, err.Error(), tc.expectedError)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding a "strategy " flag to the upgrade command

`porchctl rpkg upgrade repository.package.1 --revision=2 --workspace=2 --strategy=copy-merge`

If you do not specify `--strategy` it will use `resource-merge`