### PR TITLE
Update pkgRevUpdateDB to create row if it doesn't exist or update it for main pkgRev

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -356,6 +356,25 @@ func pkgRevUpdateDB(ctx context.Context, pr *dbPackageRevision, updateResources 
         UPDATE package_revisions SET package_k8s_name=$3, revision=$4, meta=$5, spec=$6, updated=$7, updatedby=$8, lifecycle=$9, tasks=$10
         WHERE k8s_name_space=$1 AND k8s_name=$2
 	`
+	if pr.pkgRevKey.Revision == -1 {
+		sqlStatement = `
+    INSERT INTO package_revisions (
+        k8s_name_space, k8s_name, package_k8s_name, revision, meta, spec, updated, updatedby, lifecycle, tasks
+    ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    )
+    ON CONFLICT (k8s_name_space, k8s_name)
+    DO UPDATE SET
+        package_k8s_name = EXCLUDED.package_k8s_name,
+        meta = EXCLUDED.meta,
+		revision = EXCLUDED.revision,
+        spec = EXCLUDED.spec,
+        updated = EXCLUDED.updated,
+        updatedby = EXCLUDED.updatedby,
+        lifecycle = EXCLUDED.lifecycle,
+        tasks = EXCLUDED.tasks;
+	`
+	}
 
 	klog.V(6).Infof("pkgRevUpdateDB: running query %q on package revision %+v", sqlStatement, pr)
 	prk := pr.Key()


### PR DESCRIPTION
This PR fixes an issue where the DB would throw an error when a revision was approved while the .main didn't exist. 

This PR changes the sql statement for the main revision to use an UPSERT instead of UPDATE.