### PR TITLE
Minor improvements to Porch

### DIFF
--- a/pkg/cache/dbcache/dbcache.go
+++ b/pkg/cache/dbcache/dbcache.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-Package dbcache implements a database cache for Porch.
-*/
+// Package dbcache implements a database cache for Porch.
 package dbcache
 
 import (

--- a/pkg/cache/dbcache/dbpackage.go
+++ b/pkg/cache/dbcache/dbpackage.go
@@ -120,8 +120,8 @@ func (p *dbPackage) DeletePackageRevision(ctx context.Context, old repository.Pa
 	_, span := tracer.Start(ctx, "dbPackage:DeletePackageRevision", trace.WithAttributes())
 	defer span.End()
 
-	dpPR := old.(*dbPackageRevision)
-	if err := dpPR.Delete(ctx, deleteExternal); err != nil {
+	dbPR := old.(*dbPackageRevision)
+	if err := dbPR.Delete(ctx, deleteExternal); err != nil {
 		return err
 	}
 

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cachetypes contains type definitions for caches in Porch.
 package cachetypes
 
 import (

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -331,7 +331,7 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version int, re
 
 	err = cad.updatePkgRevMeta(ctx, repoPkgRev, newObj)
 	if err != nil {
-		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(newObj) {
+		if (apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)) && repository.AnyBlockOwnerDeletionSet(newObj.ObjectMeta) {
 			return nil, fmt.Errorf("failed to update internal PackageRev object, because blockOwnerDeletion is enabled for some ownerReference "+
 				"(it is likely that the serviceaccount of porch-server does not have the rights to update finalizers in the owner object): %w", err)
 		}

--- a/pkg/engine/pushpr.go
+++ b/pkg/engine/pushpr.go
@@ -19,48 +19,55 @@ import (
 	"fmt"
 
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
+	v1 "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 )
 
-func PushPackageRevision(ctx context.Context, repo repository.Repository, pr repository.PackageRevision) error {
+func PushPackageRevision(ctx context.Context, repo repository.Repository, pr repository.PackageRevision) (v1.UpstreamLock, error) {
 	ctx, span := tracer.Start(ctx, "PushPackageRevision", trace.WithAttributes())
 	defer span.End()
 
 	prLifecycle := pr.Lifecycle(ctx)
 	if prLifecycle != v1alpha1.PackageRevisionLifecyclePublished {
-		return fmt.Errorf("cannot push package revision %+v, package revision lifecycle is %q, it should be \"Published\"", pr.Key(), prLifecycle)
+		return v1.UpstreamLock{}, fmt.Errorf("cannot push package revision %+v, package revision lifecycle is %q, it should be \"Published\"", pr.Key(), prLifecycle)
 	}
 
 	apiPr, err := pr.GetPackageRevision(ctx)
 	if err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not get API definition:", pr.Key(), repo.Key())
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not get API definition:", pr.Key(), repo.Key())
 	}
 
 	resources, err := pr.GetResources(ctx)
 	if err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not get package revision resources:", pr.Key(), repo.Key())
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not get package revision resources:", pr.Key(), repo.Key())
 	}
 
 	draft, err := repo.CreatePackageRevisionDraft(ctx, apiPr)
 	if err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not create package revision draft:", pr.Key(), repo.Key())
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not create package revision draft:", pr.Key(), repo.Key())
 	}
 
 	if err = draft.UpdateResources(ctx, resources, &v1alpha1.Task{Type: v1alpha1.TaskTypePush}); err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update package revision resources:", pr.Key(), repo.Key())
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update package revision resources:", pr.Key(), repo.Key())
 	}
 
 	if err = draft.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished); err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update package revision draft lifecycle to \"Published\":", pr.Key(), repo.Key())
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update package revision draft lifecycle to \"Published\":", pr.Key(), repo.Key())
 	}
 
-	if _, err = repo.ClosePackageRevisionDraft(ctx, draft, pr.Key().Revision); err != nil {
-		return pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not close package revision draft:", pr.Key(), repo.Key())
+	pushedPR, err := repo.ClosePackageRevisionDraft(ctx, draft, pr.Key().Revision)
+	if err != nil {
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not close package revision draft:", pr.Key(), repo.Key())
+	}
+
+	_, pushedPRUpstreamLock, err := pushedPR.GetLock()
+	if err != nil {
+		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "read of upstream lock for package revision %+v pushed to repository %+v failed", pr.Key(), repo.Key())
 	}
 
 	klog.Infof("PushPackageRevision: package %+v pushed to repository %+v", pr.Key(), repo.Key())
-	return nil
+	return pushedPRUpstreamLock, nil
 }

--- a/pkg/engine/pushpr_test.go
+++ b/pkg/engine/pushpr_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
+	v1 "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/repository"
 	mockrepo "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
@@ -36,40 +37,45 @@ func TestPushPR(t *testing.T) {
 	mockPR.EXPECT().Key().Return(repository.PackageRevisionKey{}).Maybe()
 
 	mockPR.EXPECT().Lifecycle(mock.Anything).Return(v1alpha1.PackageRevisionLifecycleDraft).Once()
-	err := PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err := PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockPR.EXPECT().Lifecycle(mock.Anything).Return(v1alpha1.PackageRevisionLifecyclePublished).Maybe()
 	mockPR.EXPECT().GetPackageRevision(mock.Anything).Return(nil, err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockPR.EXPECT().GetPackageRevision(mock.Anything).Return(&v1alpha1.PackageRevision{}, nil).Maybe()
 	mockPR.EXPECT().GetResources(mock.Anything).Return(nil, err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockPR.EXPECT().GetResources(mock.Anything).Return(&v1alpha1.PackageRevisionResources{}, nil).Maybe()
 	mockRepo.EXPECT().CreatePackageRevisionDraft(mock.Anything, mock.Anything).Return(nil, err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockRepo.EXPECT().CreatePackageRevisionDraft(mock.Anything, mock.Anything).Return(mockPRD, nil).Maybe()
 	mockPRD.EXPECT().UpdateResources(mock.Anything, mock.Anything, mock.Anything).Return(err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockPRD.EXPECT().UpdateResources(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockPRD.EXPECT().UpdateLifecycle(mock.Anything, mock.Anything).Return(err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
 	mockPRD.EXPECT().UpdateLifecycle(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockRepo.EXPECT().ClosePackageRevisionDraft(mock.Anything, mock.Anything, mock.Anything).Return(nil, err).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.NotNil(t, err)
 
-	mockRepo.EXPECT().ClosePackageRevisionDraft(mock.Anything, mock.Anything, mock.Anything).Return(mockPR, nil).Once()
-	err = PushPackageRevision(ctx, mockRepo, mockPR)
+	mockRepo.EXPECT().ClosePackageRevisionDraft(mock.Anything, mock.Anything, mock.Anything).Return(mockPR, nil).Maybe()
+	mockPR.EXPECT().GetLock().Return(v1.Upstream{}, v1.UpstreamLock{}, err).Once()
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
+	assert.NotNil(t, err)
+
+	mockPR.EXPECT().GetLock().Return(v1.Upstream{}, v1.UpstreamLock{}, nil).Maybe()
+	_, err = PushPackageRevision(ctx, mockRepo, mockPR)
 	assert.Nil(t, err)
 }

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -96,7 +96,7 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 	status := v1alpha1.PackageRevisionStatus{
 		UpstreamLock: lockCopy,
 		Deployment:   p.repo.deployment,
-		Conditions:   repository.ToApiConditions(kf),
+		Conditions:   repository.ToAPIConditions(kf),
 	}
 
 	if v1alpha1.LifecycleIsPublished(p.Lifecycle(ctx)) {
@@ -127,7 +127,7 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 			RepositoryName: key.RKey().Name,
 			Lifecycle:      p.Lifecycle(ctx),
 			Tasks:          p.tasks,
-			ReadinessGates: repository.ToApiReadinessGates(kf),
+			ReadinessGates: repository.ToAPIReadinessGates(kf),
 			WorkspaceName:  key.WorkspaceName,
 			Revision:       key.Revision,
 		},

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -132,7 +132,7 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 	}, nil
 }
 
-// DiscoveryPackagesOptions holds the configuration for walking a git tree
+// DiscoverPackagesOptions holds the configuration for walking a git tree
 type DiscoverPackagesOptions struct {
 	// FilterPrefix restricts package discovery to a particular subdirectory.
 	// The subdirectory is not required to exist (we will return an empty list of packages).

--- a/pkg/externalrepo/oci/oci.go
+++ b/pkg/externalrepo/oci/oci.go
@@ -365,12 +365,12 @@ func (p *ociPackageRevision) GetPackageRevision(ctx context.Context) (*v1alpha1.
 
 			Lifecycle:      p.Lifecycle(ctx),
 			Tasks:          p.tasks,
-			ReadinessGates: repository.ToApiReadinessGates(kf),
+			ReadinessGates: repository.ToAPIReadinessGates(kf),
 		},
 		Status: v1alpha1.PackageRevisionStatus{
 			// TODO:        UpstreamLock,
 			Deployment: p.parent.deployment,
-			Conditions: repository.ToApiConditions(kf),
+			Conditions: repository.ToAPIConditions(kf),
 		},
 	}, nil
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package repository defines Porch generic repository interfaces and provides utility functions for repositories.
 package repository
 
 import (
@@ -265,7 +266,7 @@ type PackageRevision interface {
 	// GetUpstreamLock returns the kpt lock information.
 	GetUpstreamLock(ctx context.Context) (kptfile.Upstream, kptfile.UpstreamLock, error)
 
-	// GetKptfile returns the Kptfile for hte package
+	// GetKptfile returns the Kptfile for the package
 	GetKptfile(ctx context.Context) (kptfile.KptFile, error)
 
 	// GetLock returns the current revision's lock information.

--- a/pkg/repository/update.go
+++ b/pkg/repository/update.go
@@ -26,7 +26,7 @@ import (
 
 const LocalUpdateDir = "kpt-pkg-update-*"
 
-// defaultPackageUpdater implements packageUpdater interface.
+// DefaultPackageUpdater implements packageUpdater interface.
 type DefaultPackageUpdater struct{}
 
 func (m *DefaultPackageUpdater) Update(

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -22,10 +22,10 @@ import (
 	api "github.com/nephio-project/porch/api/porch/v1alpha1"
 	kptfile "github.com/nephio-project/porch/pkg/kpt/api/kptfile/v1"
 	"github.com/nephio-project/porch/pkg/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ToApiReadinessGates(kf kptfile.KptFile) []api.ReadinessGate {
+func ToAPIReadinessGates(kf kptfile.KptFile) []api.ReadinessGate {
 	var readinessGates []api.ReadinessGate
 	if kf.Info != nil {
 		for _, rg := range kf.Info.ReadinessGates {
@@ -37,13 +37,13 @@ func ToApiReadinessGates(kf kptfile.KptFile) []api.ReadinessGate {
 	return readinessGates
 }
 
-func ToApiConditions(kf kptfile.KptFile) []api.Condition {
+func ToAPIConditions(kf kptfile.KptFile) []api.Condition {
 	var conditions []api.Condition
 	if kf.Status != nil && kf.Status.Conditions != nil {
 		for _, s := range kf.Status.Conditions {
 			conditions = append(conditions, api.Condition{
 				Type:    s.Type,
-				Status:  toApiConditionStatus(s.Status),
+				Status:  toAPIConditionStatus(s.Status),
 				Reason:  s.Reason,
 				Message: s.Message,
 			})
@@ -52,7 +52,7 @@ func ToApiConditions(kf kptfile.KptFile) []api.Condition {
 	return conditions
 }
 
-func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
+func toAPIConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 	switch s {
 	case kptfile.ConditionTrue:
 		return api.ConditionTrue
@@ -67,7 +67,7 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 
 // AnyBlockOwnerDeletionSet checks whether there are any ownerReferences in the Object
 // which have blockOwnerDeletion enabled (meaning either nil or true).
-func AnyBlockOwnerDeletionSet(obj client.Object) bool {
+func AnyBlockOwnerDeletionSet(obj metav1.ObjectMeta) bool {
 	for _, owner := range obj.GetOwnerReferences() {
 		if owner.BlockOwnerDeletion == nil || *owner.BlockOwnerDeletion {
 			return true


### PR DESCRIPTION
Some minor improvements to Porch:
- Package comments added
- typos fixed
- incorrectly spelt variable names corrected
- updated field corrected to be only changed when the package contents are changed
- resourceVersion on dbPackageRevision changed to microsecond to ensure version changes in a single second are different
- pushPackageRevision changed to return the git lock (the commit that resulted from the push)
- repository.AnyBlockOwnerDeletionSet() changed to use `metav1.ObjectMeta` to avoid an import of the k8s API client in the repository package