### PR TITLE
Fix missing Tasks List in db-cache, update wrapper-server and render logs

### DIFF
--- a/func/wrapper-server/main.go
+++ b/func/wrapper-server/main.go
@@ -133,7 +133,8 @@ func (e *singleFunctionEvaluator) EvaluateFunction(ctx context.Context, req *pb.
 		}
 	}
 
-	klog.Infof("Evaluated %q: stdout length: %d\nstderr:\n%v", req.Image, len(outbytes), stderrStr)
+	klog.Infof("Evaluated %q: stdout length in bytes: %d", req.Image, len(outbytes))
+
 	rl, pErr := fn.ParseResourceList(outbytes)
 	if pErr != nil {
 		klog.V(4).Infof("Input Resource List: %s\nOutput Resource List: %s", req.ResourceList, outbytes)

--- a/internal/kpt/util/render/executor.go
+++ b/internal/kpt/util/render/executor.go
@@ -527,8 +527,6 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
 		return nil, errors.E(op, pn.pkg.UniquePath, err)
 	}
-	// print a new line after a pipeline running
-	pr.Printf("\n")
 	return mutatedResources, nil
 }
 

--- a/pkg/engine/pushpr.go
+++ b/pkg/engine/pushpr.go
@@ -50,7 +50,12 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not create package revision draft:", pr.Key(), repo.Key())
 	}
 
-	if err = draft.UpdateResources(ctx, resources, &v1alpha1.Task{Type: v1alpha1.TaskTypePush}); err != nil {
+	commitTask := &v1alpha1.Task{Type: v1alpha1.TaskTypePush}
+	if len(apiPr.Spec.Tasks) > 0 {
+		commitTask = &apiPr.Spec.Tasks[0]
+	}
+
+	if err = draft.UpdateResources(ctx, resources, commitTask); err != nil {
 		return v1.UpstreamLock{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update package revision resources:", pr.Key(), repo.Key())
 	}
 


### PR DESCRIPTION
This PR resolves https://github.com/nephio-project/nephio/issues/962.
It adds a fix to the missing tasks list in certain situations with db-cache.

This PR updates the wrapper-server log to remove a new line with empty stderr for every kpt execution. 
This PR removes an empty line printed in the porch-server logs after pipeline execution.