### PR TITLE
Porchctl: Upgrade fallback when there is no original edit task

### DIFF
--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -279,9 +279,6 @@ func (r *runner) findUpstreamName(pr *porchapi.PackageRevision) string {
 		if n := r.findEditOrigin(pr); n != "" {
 			return n
 		}
-		if pr.Spec.Parent != nil && pr.Spec.Parent.Name != "" {
-			return pr.Spec.Parent.Name
-		}
 		if pr.Status.UpstreamLock != nil {
 			if up := r.findUpstreamByLock(pr.Status.UpstreamLock); up != nil {
 				return up.Name

--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -276,7 +276,18 @@ func (r *runner) findUpstreamName(pr *porchapi.PackageRevision) string {
 	case porchapi.TaskTypeClone:
 		return pr.Spec.Tasks[0].Clone.Upstream.UpstreamRef.Name
 	case porchapi.TaskTypeEdit:
-		return r.findEditOrigin(pr)
+		if n := r.findEditOrigin(pr); n != "" {
+			return n
+		}
+		if pr.Spec.Parent != nil && pr.Spec.Parent.Name != "" {
+			return pr.Spec.Parent.Name
+		}
+		if pr.Status.UpstreamLock != nil {
+			if up := r.findUpstreamByLock(pr.Status.UpstreamLock); up != nil {
+				return up.Name
+			}
+		}
+		return ""
 	case porchapi.TaskTypeUpgrade:
 		return pr.Spec.Tasks[0].Upgrade.NewUpstream.Name
 	default:
@@ -300,4 +311,47 @@ func (r *runner) findEditOrigin(currentPr *porchapi.PackageRevision) string {
 		return r.findUpstreamName(pr)
 	}
 	return ""
+}
+
+func (r *runner) findUpstreamByLock(lock *porchapi.UpstreamLock) *porchapi.PackageRevision {
+	if lock == nil || lock.Git == nil {
+		return nil
+	}
+
+	target := lock.Git
+	var bestMatch *porchapi.PackageRevision
+
+	for i := range r.prs {
+		candidate := r.prs[i]
+
+		if !r.matchesTarget(candidate, target) {
+			continue
+		}
+
+		if target.Ref != "" && candidate.Status.UpstreamLock.Git.Ref == target.Ref {
+			if bestMatch == nil || candidate.Spec.Revision > bestMatch.Spec.Revision {
+				tmp := candidate
+				bestMatch = &tmp
+			}
+		}
+	}
+
+	return bestMatch
+}
+
+func (r *runner) matchesTarget(candidate porchapi.PackageRevision, target *porchapi.GitLock) bool {
+	if !candidate.IsPublished() {
+		return false
+	}
+	upstream := candidate.Status.UpstreamLock
+	if upstream == nil || upstream.Git == nil {
+		return false
+	}
+
+	cGit := upstream.Git
+	if cGit.Repo != target.Repo || cGit.Directory != target.Directory {
+		return false
+	}
+
+	return true
 }

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -503,3 +503,471 @@ func TestPreRunStrategyValidation(t *testing.T) {
 		})
 	}
 }
+func TestFindUpstreamByLock(t *testing.T) {
+	const ns = "ns"
+
+	testCases := []struct {
+		name     string
+		lock     *porchapi.UpstreamLock
+		prs      []porchapi.PackageRevision
+		expected string
+	}{
+		{
+			name:     "nil lock returns nil",
+			lock:     nil,
+			prs:      []porchapi.PackageRevision{},
+			expected: "",
+		},
+		{
+			name: "lock with nil Git returns nil",
+			lock: &porchapi.UpstreamLock{
+				Git: nil,
+			},
+			prs:      []porchapi.PackageRevision{},
+			expected: "",
+		},
+		{
+			name: "no matching package revisions",
+			lock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+			prs: []porchapi.PackageRevision{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "different-repo"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  1,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/different/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v1",
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "finds exact match with same ref",
+			lock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+			prs: []porchapi.PackageRevision{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "matching-pr-v1"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  1,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/user/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v1",
+							},
+						},
+					},
+				},
+			},
+			expected: "matching-pr-v1",
+		},
+		{
+			name: "finds highest revision when multiple matches with same ref",
+			lock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v2",
+				},
+			},
+			prs: []porchapi.PackageRevision{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "matching-pr-v1"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  1,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/user/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "matching-pr-v3"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  3,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/user/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "matching-pr-v2"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  2,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/user/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v2",
+							},
+						},
+					},
+				},
+			},
+			expected: "matching-pr-v3",
+		},
+		{
+			name: "ignores draft package revisions",
+			lock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+			prs: []porchapi.PackageRevision{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "draft-pr"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  1,
+						Lifecycle: porchapi.PackageRevisionLifecycleDraft,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: &porchapi.UpstreamLock{
+							Git: &porchapi.GitLock{
+								Repo:      "https://github.com/user/repo",
+								Directory: "packages/foo",
+								Ref:       "refs/tags/v1",
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "ignores PRs with no upstream lock",
+			lock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+			prs: []porchapi.PackageRevision{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "no-lock-pr"},
+					Spec: porchapi.PackageRevisionSpec{
+						Revision:  1,
+						Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+					},
+					Status: porchapi.PackageRevisionStatus{
+						UpstreamLock: nil,
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := createRunner(context.Background(), fake.NewClientBuilder().Build(), tc.prs, ns, 0)
+
+			result := r.findUpstreamByLock(tc.lock)
+
+			if tc.expected == "" {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tc.expected, result.Name)
+			}
+		})
+	}
+}
+
+func TestMatchesTarget(t *testing.T) {
+	testCases := []struct {
+		name      string
+		candidate porchapi.PackageRevision
+		target    *porchapi.GitLock
+		expected  bool
+	}{
+		{
+			name: "draft package revision does not match",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecycleDraft,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: &porchapi.UpstreamLock{
+						Git: &porchapi.GitLock{
+							Repo:      "https://github.com/user/repo",
+							Directory: "packages/foo",
+						},
+					},
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+			},
+			expected: false,
+		},
+		{
+			name: "candidate with no upstream lock does not match",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: nil,
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+			},
+			expected: false,
+		},
+		{
+			name: "candidate with no git lock does not match",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: &porchapi.UpstreamLock{
+						Git: nil,
+					},
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+			},
+			expected: false,
+		},
+		{
+			name: "different repo does not match",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: &porchapi.UpstreamLock{
+						Git: &porchapi.GitLock{
+							Repo:      "https://github.com/different/repo",
+							Directory: "packages/foo",
+						},
+					},
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+			},
+			expected: false,
+		},
+		{
+			name: "different directory does not match",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: &porchapi.UpstreamLock{
+						Git: &porchapi.GitLock{
+							Repo:      "https://github.com/user/repo",
+							Directory: "packages/bar",
+						},
+					},
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+			},
+			expected: false,
+		},
+		{
+			name: "exact match returns true",
+			candidate: porchapi.PackageRevision{
+				Spec: porchapi.PackageRevisionSpec{
+					Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+				},
+				Status: porchapi.PackageRevisionStatus{
+					UpstreamLock: &porchapi.UpstreamLock{
+						Git: &porchapi.GitLock{
+							Repo:      "https://github.com/user/repo",
+							Directory: "packages/foo",
+							Ref:       "refs/tags/v1",
+						},
+					},
+				},
+			},
+			target: &porchapi.GitLock{
+				Repo:      "https://github.com/user/repo",
+				Directory: "packages/foo",
+				Ref:       "refs/tags/v2",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &runner{}
+			result := r.matchesTarget(tc.candidate, tc.target)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFindUpstreamInEditTaskWithUpstreamLock(t *testing.T) {
+	const ns = "ns"
+
+	editPr := porchapi.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "broken-edit-pr",
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			Tasks: []porchapi.Task{
+				{
+					Type: porchapi.TaskTypeEdit,
+					Edit: &porchapi.PackageEditTaskSpec{
+						Source: &porchapi.PackageRevisionRef{
+							Name: "non-existent-source",
+						},
+					},
+				},
+			},
+		},
+		Status: porchapi.PackageRevisionStatus{
+			UpstreamLock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+		},
+	}
+
+	upstreamPr := porchapi.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "upstream-pr-v2",
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			Revision:  2,
+			Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+		},
+		Status: porchapi.PackageRevisionStatus{
+			UpstreamLock: &porchapi.UpstreamLock{
+				Git: &porchapi.GitLock{
+					Repo:      "https://github.com/user/repo",
+					Directory: "packages/foo",
+					Ref:       "refs/tags/v1",
+				},
+			},
+		},
+	}
+
+	prs := []porchapi.PackageRevision{editPr, upstreamPr}
+	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+
+	result := r.findUpstreamName(&editPr)
+
+	assert.Equal(t, "upstream-pr-v2", result)
+}
+
+func TestFindUpstreamInEditTaskNoUpstreamLock(t *testing.T) {
+	const ns = "ns"
+
+	// edit package revision with no upstream lock
+	editPrNoLock := porchapi.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "edit-pr-no-lock",
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			Tasks: []porchapi.Task{
+				{
+					Type: porchapi.TaskTypeEdit,
+					Edit: &porchapi.PackageEditTaskSpec{
+						Source: &porchapi.PackageRevisionRef{
+							Name: "non-existent-source",
+						},
+					},
+				},
+			},
+		},
+		Status: porchapi.PackageRevisionStatus{
+			UpstreamLock: nil,
+		},
+	}
+
+	prs := []porchapi.PackageRevision{editPrNoLock}
+	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+
+	result := r.findUpstreamName(&editPrNoLock)
+
+	assert.Equal(t, "", result)
+}
+
+func TestFindUpstreamInUpgradeTask(t *testing.T) {
+	const ns = "ns"
+
+	upgradePr := porchapi.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "upgrade-pr",
+		},
+		Spec: porchapi.PackageRevisionSpec{
+			Tasks: []porchapi.Task{
+				{
+					Type: porchapi.TaskTypeUpgrade,
+					Upgrade: &porchapi.PackageUpgradeTaskSpec{
+						NewUpstream: porchapi.PackageRevisionRef{
+							Name: "new-upstream-v2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prs := []porchapi.PackageRevision{upgradePr}
+	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+
+	result := r.findUpstreamName(&upgradePr)
+
+	assert.Equal(t, "new-upstream-v2", result)
+}


### PR DESCRIPTION
Explained here
https://github.com/nephio-project/nephio/issues/970

Added:
- `findUpstreamByLock` if the `findEditOrigin` fails (returns empty string)
- the function will find the "best" candidate to be the upstream based on the `status.UpstreamLock.Git.Ref`

Question:
-  Could there be multiple package revisions that match the same upstream repository and directory but have different revisions or refs? 
