### PR TITLE
Rewrite DB cache tests to use testify test suite

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -15,9 +15,6 @@
 package dbcache
 
 import (
-	"context"
-	"testing"
-
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
@@ -26,20 +23,19 @@ import (
 	externalrepotypes "github.com/nephio-project/porch/pkg/externalrepo/types"
 	"github.com/nephio-project/porch/pkg/repository"
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestDBPackageRevision(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestDBPackageRevision() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 
 	externalrepo.ExternalRepoInUnitTestMode = true
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
-	testRepo := createTestRepo(t, "my-ns", "my-repo-name")
+	testRepo := t.createTestRepo("my-ns", "my-repo-name")
 	testRepo.spec = &configapi.Repository{
 		Spec: configapi.RepositorySpec{
 			Git: &configapi.GitRepository{
@@ -50,7 +46,7 @@ func TestDBPackageRevision(t *testing.T) {
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(testRepo).Maybe()
 
 	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	newPRDef := v1alpha1.PackageRevision{
 		Spec: v1alpha1.PackageRevisionSpec{
@@ -61,28 +57,28 @@ func TestDBPackageRevision(t *testing.T) {
 	}
 
 	newPRDraft, err := testRepo.CreatePackageRevisionDraft(ctx, &newPRDef)
-	assert.Nil(t, err)
-	assert.NotNil(t, newPRDraft)
+	t.Require().NoError(err)
+	t.Require().NotNil(newPRDraft)
 
 	dbPR, err := testRepo.ClosePackageRevisionDraft(ctx, newPRDraft, -1)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
-	assert.Equal(t, "main", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
+	t.Equal("main", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
 	dbPR.(*dbPackageRevision).pkgRevKey.PkgKey.RepoKey.PlaceholderWSname = "my-branch"
-	assert.Equal(t, "my-branch", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
+	t.Equal("my-branch", dbPR.ToMainPackageRevision(ctx).Key().WorkspaceName)
 
 	meta := dbPR.GetMeta()
-	assert.Equal(t, meta.Name, "")
+	t.Equal(meta.Name, "")
 
-	assert.Nil(t, dbPR.SetMeta(ctx, metav1.ObjectMeta{}))
+	t.Require().Nil(dbPR.SetMeta(ctx, metav1.ObjectMeta{}))
 
 	prDef, err := dbPR.GetPackageRevision(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, "my-workspace", prDef.Spec.WorkspaceName)
+	t.Require().NoError(err)
+	t.Equal("my-workspace", prDef.Spec.WorkspaceName)
 
-	assert.Equal(t, "my-ns", dbPR.KubeObjectNamespace())
-	assert.Equal(t, "my-repo-name.my-package.my-workspace", dbPR.KubeObjectName())
+	t.Equal("my-ns", dbPR.KubeObjectNamespace())
+	t.Equal("my-repo-name.my-package.my-workspace", dbPR.KubeObjectName())
 	prKey := repository.PackageRevisionKey{
 		PkgKey: repository.PackageKey{
 			RepoKey: repository.RepositoryKey{
@@ -94,23 +90,23 @@ func TestDBPackageRevision(t *testing.T) {
 		},
 		WorkspaceName: "my-workspace",
 	}
-	assert.Equal(t, prKey, dbPR.Key())
-	assert.Equal(t, v1alpha1.PackageRevisionLifecycleDraft, dbPR.Lifecycle(ctx))
+	t.Equal(prKey, dbPR.Key())
+	t.Equal(v1alpha1.PackageRevisionLifecycleDraft, dbPR.Lifecycle(ctx))
 
 	newPrUp, newPrUpLock, err := dbPR.GetUpstreamLock(ctx)
-	assert.NotNil(t, err)
-	assert.Nil(t, newPrUp.Git)
-	assert.Nil(t, newPrUpLock.Git)
+	t.Require().NotNil(err)
+	t.Require().Nil(newPrUp.Git)
+	t.Require().Nil(newPrUpLock.Git)
 
 	newPrUp, newPrUpLock, err = dbPR.GetLock()
-	assert.Nil(t, err)
-	assert.NotNil(t, newPrUp.Git)
-	assert.NotNil(t, newPrUpLock.Git)
+	t.Require().NoError(err)
+	t.Require().NotNil(newPrUp.Git)
+	t.Require().NotNil(newPrUpLock.Git)
 
 	prResources, err := dbPR.GetResources(ctx)
-	assert.Nil(t, err)
-	assert.NotNil(t, prResources)
-	assert.Equal(t, 0, len(prResources.Spec.Resources))
+	t.Require().NoError(err)
+	t.Require().NotNil(prResources)
+	t.Equal(0, len(prResources.Spec.Resources))
 
 	newDBPR := dbPR.(*dbPackageRevision)
 
@@ -125,29 +121,29 @@ info:
   description: some kpt package.`
 
 	err = newDBPR.UpdateResources(ctx, prResources, &v1alpha1.Task{})
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
 	gotKptFile, err := newDBPR.GetKptfile(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, "Kptfile", gotKptFile.Kind)
+	t.Require().NoError(err)
+	t.Equal("Kptfile", gotKptFile.Kind)
 
 	err = dbPR.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleProposed)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
 	err = dbPR.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
 	dbPRdb := dbPR.(*dbPackageRevision)
 	dbPR2 := dbPackageRevision{
@@ -163,18 +159,18 @@ info:
 	}
 
 	err = dbPR2.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleProposed)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR2i, err := testRepo.ClosePackageRevisionDraft(ctx, &dbPR2, 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR2i)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR2i)
 
 	err = dbPR2i.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR2i, err = testRepo.ClosePackageRevisionDraft(ctx, &dbPR2, 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR2i)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR2i)
 
 	fakeRepo := testRepo.externalRepo.(*fake.Repository)
 	fakeExtPR := fake.FakePackageRevision{
@@ -185,15 +181,15 @@ info:
 	dbPR.(*dbPackageRevision).lifecycle = v1alpha1.PackageRevisionLifecyclePublished
 	dbPR.(*dbPackageRevision).pkgRevKey.Revision = 1
 	err = dbPR.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleDeletionProposed)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
 	prDef, err = dbPR.GetPackageRevision(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, v1alpha1.PackageRevisionLifecycleDeletionProposed, prDef.Spec.Lifecycle)
+	t.Require().NoError(err)
+	t.Equal(v1alpha1.PackageRevisionLifecycleDeletionProposed, prDef.Spec.Lifecycle)
 
 	prResources.Spec.Resources["Kptfile"] = `apiVersion: kpt.dev/v1
 kind: Kptfile
@@ -221,19 +217,19 @@ upstreamLock:
 	newDBPR2 := dbPR.(*dbPackageRevision)
 
 	err = newDBPR2.UpdateResources(ctx, prResources, &v1alpha1.Task{})
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
-	assert.Nil(t, err)
-	assert.NotNil(t, dbPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(dbPR)
 
 	prDef, err = dbPR.GetPackageRevision(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, "basens-edit", prDef.Status.UpstreamLock.Git.Directory)
+	t.Require().NoError(err)
+	t.Equal("basens-edit", prDef.Status.UpstreamLock.Git.Directory)
 
 	err = testRepo.DeletePackageRevision(ctx, dbPR)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	err = testRepo.Close(ctx)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -15,23 +15,19 @@
 package dbcache
 
 import (
-	"context"
 	"database/sql"
-	"strings"
-	"testing"
 	"time"
 
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/repository"
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestPackageRevisionDBWriteRead(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestPackageRevisionDBWriteRead() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
@@ -89,7 +85,7 @@ func TestPackageRevisionDBWriteRead(t *testing.T) {
 		resources: map[string]string{"Hello.txt": "Hello", "Goodbye.txt": "Goodbye"},
 	}
 
-	pkgRevDBWriteReadTest(t, &dbRepo, dbPkg, dbPR, dbPRUpdate)
+	t.pkgRevDBWriteReadTest(&dbRepo, dbPkg, dbPR, dbPRUpdate)
 
 	dbPkg.pkgKey.Path = ""
 	dbPR.pkgRevKey.PkgKey = dbPkg.Key()
@@ -98,26 +94,26 @@ func TestPackageRevisionDBWriteRead(t *testing.T) {
 	dbPRUpdate.lifecycle = "Proposed"
 	dbPR.resources = map[string]string{"Hello.txt": "Hello", "Goodbye.txt": "Goodbye"}
 	dbPRUpdate.resources = map[string]string{"Hello.txt": "Hello"}
-	pkgRevDBWriteReadTest(t, &dbRepo, dbPkg, dbPR, dbPRUpdate)
+	t.pkgRevDBWriteReadTest(&dbRepo, dbPkg, dbPR, dbPRUpdate)
 
 	dbPRUpdate.lifecycle = "Draft"
 	dbPR.resources = map[string]string{"Hello.txt": "Hello", "Goodbye.txt": "Goodbye"}
 	dbPRUpdate.resources = map[string]string{"AAA": "ZZZ", "BBB": "YYY"}
-	pkgRevDBWriteReadTest(t, &dbRepo, dbPkg, dbPR, dbPRUpdate)
+	t.pkgRevDBWriteReadTest(&dbRepo, dbPkg, dbPR, dbPRUpdate)
 
 	dbPRUpdate.lifecycle = "Draft"
 	dbPR.resources = map[string]string{"Hello.txt": "Hello", "Goodbye.txt": "Goodbye"}
 	dbPRUpdate.resources = map[string]string{}
-	pkgRevDBWriteReadTest(t, &dbRepo, dbPkg, dbPR, dbPRUpdate)
+	t.pkgRevDBWriteReadTest(&dbRepo, dbPkg, dbPR, dbPRUpdate)
 }
 
-func TestPackageRevisionLatest(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestPackageRevisionLatest() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo := createTestRepo(t, "my-ns", "my-repo")
-	dbPkg := createTestPkg(t, dbRepo.Key(), "my-package")
+	dbRepo := t.createTestRepo("my-ns", "my-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "my-package")
 	dbPkg.repo = dbRepo
 
 	dbPR1 := dbPackageRevision{
@@ -134,36 +130,36 @@ func TestPackageRevisionLatest(t *testing.T) {
 		resources: map[string]string{},
 	}
 
-	latestPR, err := pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Nil(t, latestPR)
+	latestPR, err := pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Require().Nil(latestPR)
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR1)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR1)
+	t.Require().NoError(err)
 
 	// Latest PR is only set on published PRs
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Nil(t, latestPR)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Require().Nil(latestPR)
 
 	dbPR1.lifecycle = "Proposed"
-	err = pkgRevUpdateDB(context.TODO(), &dbPR1, true)
-	assert.Nil(t, err)
+	err = pkgRevUpdateDB(t.Context(), &dbPR1, true)
+	t.Require().NoError(err)
 
 	dbPR1.pkgRevKey.Revision = 1
 	dbPR1.lifecycle = "Published"
-	err = pkgRevUpdateDB(context.TODO(), &dbPR1, true)
-	assert.Nil(t, err)
+	err = pkgRevUpdateDB(t.Context(), &dbPR1, true)
+	t.Require().NoError(err)
 
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, latestPR.pkgRevKey.Revision)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Equal(1, latestPR.pkgRevKey.Revision)
 
-	resources, err := pkgRevResourcesReadFromDB(context.TODO(), latestPR.Key())
-	assert.Nil(t, err)
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), latestPR.Key())
+	t.Require().NoError(err)
 
 	latestPR.resources = resources
-	assertPackageRevsEqual(t, &dbPR1, latestPR)
+	t.assertPackageRevsEqual(&dbPR1, latestPR)
 
 	dbPR2 := dbPackageRevision{
 		pkgRevKey: repository.PackageRevisionKey{
@@ -179,12 +175,12 @@ func TestPackageRevisionLatest(t *testing.T) {
 		resources: map[string]string{},
 	}
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR2)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR2)
+	t.Require().NoError(err)
 
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, latestPR.pkgRevKey.Revision)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Equal(1, latestPR.pkgRevKey.Revision)
 
 	dbPR3 := dbPackageRevision{
 		pkgRevKey: repository.PackageRevisionKey{
@@ -200,12 +196,12 @@ func TestPackageRevisionLatest(t *testing.T) {
 		resources: map[string]string{},
 	}
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR3)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR3)
+	t.Require().NoError(err)
 
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Equal(t, 10, latestPR.pkgRevKey.Revision)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Equal(10, latestPR.pkgRevKey.Revision)
 
 	dbPR4 := dbPackageRevision{
 		pkgRevKey: repository.PackageRevisionKey{
@@ -221,100 +217,94 @@ func TestPackageRevisionLatest(t *testing.T) {
 		resources: map[string]string{},
 	}
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR4)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "revision 10 already exists"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR4)
+	t.Require().ErrorContains(err, "revision 10 already exists")
 
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Equal(t, 10, latestPR.pkgRevKey.Revision)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Equal(10, latestPR.pkgRevKey.Revision)
 
 	dbPR4.pkgRevKey.Revision = 11
-	err = pkgRevWriteToDB(context.TODO(), &dbPR4)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR4)
+	t.Require().NoError(err)
 
-	latestPR, err = pkgRevReadLatestPRFromDB(context.TODO(), dbPR1.pkgRevKey.PkgKey)
-	assert.Nil(t, err)
-	assert.Equal(t, 11, latestPR.pkgRevKey.Revision)
+	latestPR, err = pkgRevReadLatestPRFromDB(t.Context(), dbPR1.pkgRevKey.PkgKey)
+	t.Require().NoError(err)
+	t.Equal(11, latestPR.pkgRevKey.Revision)
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 }
 
-func TestPackageRevisionResources(t *testing.T) {
-	dbRepo := createTestRepo(t, "my-ns", "my-repo")
-	dbPkg := createTestPkg(t, dbRepo.Key(), "my-package")
+func (t *DbTestSuite) TestPackageRevisionResources() {
+	dbRepo := t.createTestRepo("my-ns", "my-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "my-package")
 	dbPkg.repo = dbRepo
 
-	_, _, err := pkgRevResourceReadFromDB(context.TODO(), repository.PackageRevisionKey{}, "")
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows in result set"))
+	_, _, err := pkgRevResourceReadFromDB(t.Context(), repository.PackageRevisionKey{}, "")
+	t.Require().ErrorContains(err, "no rows in result set")
 
-	dbPR := createTestPR(t, dbPkg.Key(), "my_pr")
+	dbPR := t.createTestPR(dbPkg.Key(), "my_pr")
 	dbPR.repo = dbRepo
 
-	_, _, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "resource.txt")
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows in result set"))
+	_, _, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "resource.txt")
+	t.Require().ErrorContains(err, "no rows in result set")
 
-	resKey, resVal, err := pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Hello.txt")
-	assert.Nil(t, err)
-	assert.Equal(t, "Hello.txt", resKey)
-	assert.Equal(t, "Hello", resVal)
+	resKey, resVal, err := pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Hello.txt")
+	t.Require().NoError(err)
+	t.Equal("Hello.txt", resKey)
+	t.Equal("Hello", resVal)
 
-	resKey, resVal, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.Nil(t, err)
-	assert.Equal(t, "Goodbye.txt", resKey)
-	assert.Equal(t, "Goodbye", resVal)
+	resKey, resVal, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().NoError(err)
+	t.Equal("Goodbye.txt", resKey)
+	t.Equal("Goodbye", resVal)
 
-	err = pkgRevResourceDeleteFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.Nil(t, err)
+	err = pkgRevResourceDeleteFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().NoError(err)
 
-	err = pkgRevResourceDeleteFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.Nil(t, err)
+	err = pkgRevResourceDeleteFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().NoError(err)
 
-	_, _, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows in result set"))
+	_, _, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().ErrorContains(err, "no rows in result set")
 
-	err = pkgRevResourceWriteToDB(context.TODO(), dbPR.Key(), "Goodbye.txt", "So long")
-	assert.Nil(t, err)
+	err = pkgRevResourceWriteToDB(t.Context(), dbPR.Key(), "Goodbye.txt", "So long")
+	t.Require().NoError(err)
 
-	resKey, resVal, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.Nil(t, err)
-	assert.Equal(t, "Goodbye.txt", resKey)
-	assert.Equal(t, "So long", resVal)
+	resKey, resVal, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().NoError(err)
+	t.Equal("Goodbye.txt", resKey)
+	t.Equal("So long", resVal)
 
-	err = pkgRevResourceWriteToDB(context.TODO(), dbPR.Key(), "Goodbye.txt", "See ya later")
-	assert.Nil(t, err)
+	err = pkgRevResourceWriteToDB(t.Context(), dbPR.Key(), "Goodbye.txt", "See ya later")
+	t.Require().NoError(err)
 
-	resKey, resVal, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Goodbye.txt")
-	assert.Nil(t, err)
-	assert.Equal(t, "Goodbye.txt", resKey)
-	assert.Equal(t, "See ya later", resVal)
+	resKey, resVal, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Goodbye.txt")
+	t.Require().NoError(err)
+	t.Equal("Goodbye.txt", resKey)
+	t.Equal("See ya later", resVal)
 
-	err = pkgRevResourceWriteToDB(context.TODO(), dbPR.Key(), "Grand.txt", "Grand")
-	assert.Nil(t, err)
+	err = pkgRevResourceWriteToDB(t.Context(), dbPR.Key(), "Grand.txt", "Grand")
+	t.Require().NoError(err)
 
-	resKey, resVal, err = pkgRevResourceReadFromDB(context.TODO(), dbPR.Key(), "Grand.txt")
-	assert.Nil(t, err)
-	assert.Equal(t, "Grand.txt", resKey)
-	assert.Equal(t, "Grand", resVal)
+	resKey, resVal, err = pkgRevResourceReadFromDB(t.Context(), dbPR.Key(), "Grand.txt")
+	t.Require().NoError(err)
+	t.Equal("Grand.txt", resKey)
+	t.Equal("Grand", resVal)
 
 	dbPR.pkgRevKey.WorkspaceName = "bad"
-	err = pkgRevResourceWriteToDB(context.TODO(), dbPR.Key(), "Grand.txt", "Grand")
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+	err = pkgRevResourceWriteToDB(t.Context(), dbPR.Key(), "Grand.txt", "Grand")
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 }
 
-func TestPackageRevisionDBSchema(t *testing.T) {
+func (t *DbTestSuite) TestPackageRevisionDBSchema() {
 	dbPR := dbPackageRevision{}
-	err := pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "revision value of 0 is only allowed on when lifecycle is Draft or Proposed"))
+	err := pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "revision value of 0 is only allowed on when lifecycle is Draft or Proposed")
 
 	dbPR.pkgRevKey = repository.PackageRevisionKey{
 		PkgKey: repository.PackageKey{
@@ -324,40 +314,33 @@ func TestPackageRevisionDBSchema(t *testing.T) {
 		},
 	}
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "revision value of 0 is only allowed on when lifecycle is Draft or Proposed"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "revision value of 0 is only allowed on when lifecycle is Draft or Proposed")
 
 	dbPR.lifecycle = v1alpha1.PackageRevisionLifecycleDraft
 	dbPR.pkgRevKey.PkgKey.RepoKey.Name = "my-repo"
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates check constraint"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "violates check constraint")
 
 	dbPR.pkgRevKey.PkgKey.Package = "my-package"
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates check constraint"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "violates check constraint")
 
 	dbPR.pkgRevKey.WorkspaceName = "my-ws"
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
 	dbPR.lifecycle = ""
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "revision value of 0 is only allowed on when lifecycle is Draft or Proposed"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "revision value of 0 is only allowed on when lifecycle is Draft or Proposed")
 
 	dbPR.lifecycle = "StoneDead"
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "revision value of 0 is only allowed on when lifecycle is Draft or Proposed"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "revision value of 0 is only allowed on when lifecycle is Draft or Proposed")
 
 	dbPR.lifecycle = "Draft"
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
 	dbRepo := dbRepository{
 		repoKey: repository.RepositoryKey{
@@ -366,8 +349,8 @@ func TestPackageRevisionDBSchema(t *testing.T) {
 		},
 	}
 
-	err = repoWriteToDB(context.TODO(), &dbRepo)
-	assert.Nil(t, err)
+	err = repoWriteToDB(t.Context(), &dbRepo)
+	t.Require().NoError(err)
 
 	dbPkg := dbPackage{
 		pkgKey: repository.PackageKey{
@@ -376,232 +359,228 @@ func TestPackageRevisionDBSchema(t *testing.T) {
 		},
 	}
 
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.Nil(t, err)
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().NoError(err)
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().NoError(err)
 
 	dbPR.pkgRevKey.WorkspaceName = "my-other-ws"
-	err = pkgRevUpdateDB(context.TODO(), &dbPR, true)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows or multiple rows found for updating"))
+	err = pkgRevUpdateDB(t.Context(), &dbPR, true)
+	t.Require().ErrorContains(err, "no rows or multiple rows found for updating")
 
 	dbPR.pkgRevKey.WorkspaceName = "my-ws"
 	dbPR.updatedBy = "Marge"
-	err = pkgRevUpdateDB(context.TODO(), &dbPR, true)
-	assert.Nil(t, err)
+	err = pkgRevUpdateDB(t.Context(), &dbPR, true)
+	t.Require().NoError(err)
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 
-	_, err = pkgRevReadFromDB(context.TODO(), dbPR.Key(), false)
-	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	t.Require().NotNil(err)
+	t.Equal(sql.ErrNoRows, err)
 }
 
-func TestMultiPackageRevisionRepo(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestMultiPackageRevisionRepo() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo11 := createTestRepo(t, "my-ns1", "my-repo1")
-	dbRepo12 := createTestRepo(t, "my-ns1", "my-repo2")
-	dbRepo21 := createTestRepo(t, "my-ns2", "my-repo1")
-	dbRepo22 := createTestRepo(t, "my-ns2", "my-repo2")
+	dbRepo11 := t.createTestRepo("my-ns1", "my-repo1")
+	dbRepo12 := t.createTestRepo("my-ns1", "my-repo2")
+	dbRepo21 := t.createTestRepo("my-ns2", "my-repo1")
+	dbRepo22 := t.createTestRepo("my-ns2", "my-repo2")
 
-	dbRepo11Pkgs := createTestPkgs(t, dbRepo11.Key(), "my-package", 4)
-	dbRepo12Pkgs := createTestPkgs(t, dbRepo12.Key(), "my-package", 4)
-	dbRepo21Pkgs := createTestPkgs(t, dbRepo21.Key(), "my-package", 4)
-	dbRepo22Pkgs := createTestPkgs(t, dbRepo22.Key(), "my-package", 4)
+	dbRepo11Pkgs := t.createTestPkgs(dbRepo11.Key(), "my-package", 4)
+	dbRepo12Pkgs := t.createTestPkgs(dbRepo12.Key(), "my-package", 4)
+	dbRepo21Pkgs := t.createTestPkgs(dbRepo21.Key(), "my-package", 4)
+	dbRepo22Pkgs := t.createTestPkgs(dbRepo22.Key(), "my-package", 4)
 
-	dbRepo11PkgsPRs := createTestPRs(t, dbRepo11Pkgs, "my-ws", 4)
-	dbRepo12PkgsPRs := createTestPRs(t, dbRepo12Pkgs, "my-ws", 4)
-	dbRepo21PkgsPRs := createTestPRs(t, dbRepo21Pkgs, "my-ws", 4)
-	dbRepo22PkgsPRs := createTestPRs(t, dbRepo22Pkgs, "my-ws", 4)
+	dbRepo11PkgsPRs := t.createTestPRs(dbRepo11Pkgs, "my-ws", 4)
+	dbRepo12PkgsPRs := t.createTestPRs(dbRepo12Pkgs, "my-ws", 4)
+	dbRepo21PkgsPRs := t.createTestPRs(dbRepo21Pkgs, "my-ws", 4)
+	dbRepo22PkgsPRs := t.createTestPRs(dbRepo22Pkgs, "my-ws", 4)
 
-	readRepo11PkgsPRs := readRepoPkgPRs(t, dbRepo11Pkgs)
-	readRepo12PkgsPRs := readRepoPkgPRs(t, dbRepo12Pkgs)
-	readRepo21PkgsPRs := readRepoPkgPRs(t, dbRepo21Pkgs)
-	readRepo22PkgsPRs := readRepoPkgPRs(t, dbRepo22Pkgs)
+	readRepo11PkgsPRs := t.readRepoPkgPRs(dbRepo11Pkgs)
+	readRepo12PkgsPRs := t.readRepoPkgPRs(dbRepo12Pkgs)
+	readRepo21PkgsPRs := t.readRepoPkgPRs(dbRepo21Pkgs)
+	readRepo22PkgsPRs := t.readRepoPkgPRs(dbRepo22Pkgs)
 
-	assertPackageRevListsEqual(t, dbRepo11PkgsPRs, readRepo11PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo12PkgsPRs, readRepo12PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo21PkgsPRs, readRepo21PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo22PkgsPRs, readRepo22PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo11PkgsPRs, readRepo11PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo12PkgsPRs, readRepo12PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo21PkgsPRs, readRepo21PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo22PkgsPRs, readRepo22PkgsPRs, 16)
 
-	assertPackageRevLatestIs(t, 4, readRepo11PkgsPRs)
-	assertPackageRevLatestIs(t, 4, readRepo12PkgsPRs)
-	assertPackageRevLatestIs(t, 4, readRepo21PkgsPRs)
-	assertPackageRevLatestIs(t, 4, readRepo22PkgsPRs)
+	t.assertPackageRevLatestIs(4, readRepo11PkgsPRs)
+	t.assertPackageRevLatestIs(4, readRepo12PkgsPRs)
+	t.assertPackageRevLatestIs(4, readRepo21PkgsPRs)
+	t.assertPackageRevLatestIs(4, readRepo22PkgsPRs)
 
-	deleteTestRepo(t, dbRepo11.Key())
-	deleteTestRepo(t, dbRepo12.Key())
-	deleteTestRepo(t, dbRepo21.Key())
-	deleteTestRepo(t, dbRepo22.Key())
+	t.deleteTestRepo(dbRepo11.Key())
+	t.deleteTestRepo(dbRepo12.Key())
+	t.deleteTestRepo(dbRepo21.Key())
+	t.deleteTestRepo(dbRepo22.Key())
 
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo11Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo12Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo21Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo22Pkgs)))
+	t.Empty(t.readRepoPkgPRs(dbRepo11Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo12Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo21Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo22Pkgs))
 }
 
-func TestPackageRevisionFilter(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestPackageRevisionFilter() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo := createTestRepo(t, "my-ns", "my-repo")
+	dbRepo := t.createTestRepo("my-ns", "my-repo")
 
-	dbRepoPkgs := createTestPkgs(t, dbRepo.Key(), "my-package", 4)
+	dbRepoPkgs := t.createTestPkgs(dbRepo.Key(), "my-package", 4)
 
-	_ = createTestPRs(t, dbRepoPkgs, "my-ws", 4)
+	_ = t.createTestPRs(dbRepoPkgs, "my-ws", 4)
 
 	prFilter := repository.ListPackageRevisionFilter{}
-	listPRs, err := pkgRevListPRsFromDB(context.TODO(), prFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 16, len(listPRs))
+	listPRs, err := pkgRevListPRsFromDB(t.Context(), prFilter)
+	t.Require().NoError(err)
+	t.Equal(16, len(listPRs))
 
 	prFilter.Key.WorkspaceName = "my-ws-2"
-	listPRs, err = pkgRevListPRsFromDB(context.TODO(), prFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(listPRs))
+	listPRs, err = pkgRevListPRsFromDB(t.Context(), prFilter)
+	t.Require().NoError(err)
+	t.Equal(4, len(listPRs))
 
 	prFilter.Key.Revision = 3
-	listPRs, err = pkgRevListPRsFromDB(context.TODO(), prFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(listPRs))
+	listPRs, err = pkgRevListPRsFromDB(t.Context(), prFilter)
+	t.Require().NoError(err)
+	t.Equal(4, len(listPRs))
 
 	prFilter.Key.Revision = 1
-	listPRs, err = pkgRevListPRsFromDB(context.TODO(), prFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(listPRs))
+	listPRs, err = pkgRevListPRsFromDB(t.Context(), prFilter)
+	t.Require().NoError(err)
+	t.Equal(0, len(listPRs))
 
-	deleteTestRepo(t, dbRepo.Key())
+	t.deleteTestRepo(dbRepo.Key())
 
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepoPkgs)))
+	t.Empty(t.readRepoPkgPRs(dbRepoPkgs))
 }
 
-func TestMultiPackageRevisionList(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestMultiPackageRevisionList() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo11 := createTestRepo(t, "my-ns1", "my-repo1")
-	dbRepo12 := createTestRepo(t, "my-ns1", "my-repo2")
-	dbRepo21 := createTestRepo(t, "my-ns2", "my-repo1")
-	dbRepo22 := createTestRepo(t, "my-ns2", "my-repo2")
+	dbRepo11 := t.createTestRepo("my-ns1", "my-repo1")
+	dbRepo12 := t.createTestRepo("my-ns1", "my-repo2")
+	dbRepo21 := t.createTestRepo("my-ns2", "my-repo1")
+	dbRepo22 := t.createTestRepo("my-ns2", "my-repo2")
 
-	dbRepo11Pkgs := createTestPkgs(t, dbRepo11.Key(), "my-package", 4)
-	dbRepo12Pkgs := createTestPkgs(t, dbRepo12.Key(), "my-package", 4)
-	dbRepo21Pkgs := createTestPkgs(t, dbRepo21.Key(), "my-package", 4)
-	dbRepo22Pkgs := createTestPkgs(t, dbRepo22.Key(), "my-package", 4)
+	dbRepo11Pkgs := t.createTestPkgs(dbRepo11.Key(), "my-package", 4)
+	dbRepo12Pkgs := t.createTestPkgs(dbRepo12.Key(), "my-package", 4)
+	dbRepo21Pkgs := t.createTestPkgs(dbRepo21.Key(), "my-package", 4)
+	dbRepo22Pkgs := t.createTestPkgs(dbRepo22.Key(), "my-package", 4)
 
-	dbRepo11PkgsPRs := createTestPRs(t, dbRepo11Pkgs, "my-ws", 4)
-	dbRepo12PkgsPRs := createTestPRs(t, dbRepo12Pkgs, "my-ws", 4)
-	dbRepo21PkgsPRs := createTestPRs(t, dbRepo21Pkgs, "my-ws", 4)
-	dbRepo22PkgsPRs := createTestPRs(t, dbRepo22Pkgs, "my-ws", 4)
+	dbRepo11PkgsPRs := t.createTestPRs(dbRepo11Pkgs, "my-ws", 4)
+	dbRepo12PkgsPRs := t.createTestPRs(dbRepo12Pkgs, "my-ws", 4)
+	dbRepo21PkgsPRs := t.createTestPRs(dbRepo21Pkgs, "my-ws", 4)
+	dbRepo22PkgsPRs := t.createTestPRs(dbRepo22Pkgs, "my-ws", 4)
 
-	listRepo11PkgsPRs := listRepoPkgPRs(t, dbRepo11Pkgs)
-	listRepo12PkgsPRs := listRepoPkgPRs(t, dbRepo12Pkgs)
-	listRepo21PkgsPRs := listRepoPkgPRs(t, dbRepo21Pkgs)
-	listRepo22PkgsPRs := listRepoPkgPRs(t, dbRepo22Pkgs)
+	listRepo11PkgsPRs := t.listRepoPkgPRs(dbRepo11Pkgs)
+	listRepo12PkgsPRs := t.listRepoPkgPRs(dbRepo12Pkgs)
+	listRepo21PkgsPRs := t.listRepoPkgPRs(dbRepo21Pkgs)
+	listRepo22PkgsPRs := t.listRepoPkgPRs(dbRepo22Pkgs)
 
-	assertPackageRevListsEqual(t, dbRepo11PkgsPRs, listRepo11PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo12PkgsPRs, listRepo12PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo21PkgsPRs, listRepo21PkgsPRs, 16)
-	assertPackageRevListsEqual(t, dbRepo22PkgsPRs, listRepo22PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo11PkgsPRs, listRepo11PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo12PkgsPRs, listRepo12PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo21PkgsPRs, listRepo21PkgsPRs, 16)
+	t.assertPackageRevListsEqual(dbRepo22PkgsPRs, listRepo22PkgsPRs, 16)
 
-	assertPackageRevLatestIs(t, 4, listRepo11PkgsPRs)
-	assertPackageRevLatestIs(t, 4, listRepo12PkgsPRs)
-	assertPackageRevLatestIs(t, 4, listRepo21PkgsPRs)
-	assertPackageRevLatestIs(t, 4, listRepo22PkgsPRs)
+	t.assertPackageRevLatestIs(4, listRepo11PkgsPRs)
+	t.assertPackageRevLatestIs(4, listRepo12PkgsPRs)
+	t.assertPackageRevLatestIs(4, listRepo21PkgsPRs)
+	t.assertPackageRevLatestIs(4, listRepo22PkgsPRs)
 
-	deleteTestRepo(t, dbRepo11.Key())
-	deleteTestRepo(t, dbRepo12.Key())
-	deleteTestRepo(t, dbRepo21.Key())
-	deleteTestRepo(t, dbRepo22.Key())
+	t.deleteTestRepo(dbRepo11.Key())
+	t.deleteTestRepo(dbRepo12.Key())
+	t.deleteTestRepo(dbRepo21.Key())
+	t.deleteTestRepo(dbRepo22.Key())
 
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo11Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo12Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo21Pkgs)))
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepo22Pkgs)))
+	t.Empty(t.readRepoPkgPRs(dbRepo11Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo12Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo21Pkgs))
+	t.Empty(t.readRepoPkgPRs(dbRepo22Pkgs))
 }
 
-func pkgRevDBWriteReadTest(t *testing.T, dbRepo *dbRepository, dbPkg dbPackage, dbPR, dbPRUpdate dbPackageRevision) {
-	err := pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+func (t *DbTestSuite) pkgRevDBWriteReadTest(dbRepo *dbRepository, dbPkg dbPackage, dbPR, dbPRUpdate dbPackageRevision) {
+	err := pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
-	err = repoWriteToDB(context.TODO(), dbRepo)
-	assert.Nil(t, err)
+	err = repoWriteToDB(t.Context(), dbRepo)
+	t.Require().NoError(err)
 
 	dbPkg.repo = dbRepo
 	dbPkg.pkgKey.RepoKey = dbRepo.Key()
 
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.Nil(t, err)
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().NoError(err)
 
 	dbPR.repo = dbRepo
 	dbPR.pkgRevKey.PkgKey = dbPkg.Key()
 
-	err = pkgRevWriteToDB(context.TODO(), &dbPR)
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPR)
+	t.Require().NoError(err)
 
-	readPR, err := pkgRevReadFromDB(context.TODO(), dbPR.Key(), false)
-	assert.Nil(t, err)
+	readPR, err := pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	t.Require().NoError(err)
 
-	resources, err := pkgRevResourcesReadFromDB(context.TODO(), readPR.Key())
-	assert.Nil(t, err)
-
-	readPR.resources = resources
-
-	assertPackageRevsEqual(t, &dbPR, readPR)
-
-	err = pkgRevWriteToDB(context.TODO(), &dbPRUpdate)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates unique constraint"))
-
-	err = pkgRevUpdateDB(context.TODO(), &dbPRUpdate, true)
-	assert.Nil(t, err)
-
-	readPR, err = pkgRevReadFromDB(context.TODO(), dbPR.Key(), false)
-	assert.Nil(t, err)
-
-	resources, err = pkgRevResourcesReadFromDB(context.TODO(), readPR.Key())
-	assert.Nil(t, err)
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), readPR.Key())
+	t.Require().NoError(err)
 
 	readPR.resources = resources
 
-	assertPackageRevsEqual(t, &dbPRUpdate, readPR)
+	t.assertPackageRevsEqual(&dbPR, readPR)
 
-	err = pkgRevDeleteFromDB(context.TODO(), dbPR.Key())
-	assert.Nil(t, err)
+	err = pkgRevWriteToDB(t.Context(), &dbPRUpdate)
+	t.Require().ErrorContains(err, "violates unique constraint")
 
-	_, err = pkgRevReadFromDB(context.TODO(), dbPR.Key(), false)
-	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	err = pkgRevUpdateDB(t.Context(), &dbPRUpdate, true)
+	t.Require().NoError(err)
 
-	err = pkgRevUpdateDB(context.TODO(), &dbPRUpdate, false)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows or multiple rows found for updating"))
+	readPR, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	t.Require().NoError(err)
 
-	err = pkgRevDeleteFromDB(context.TODO(), dbPR.Key())
-	assert.Nil(t, err)
+	resources, err = pkgRevResourcesReadFromDB(t.Context(), readPR.Key())
+	t.Require().NoError(err)
 
-	err = pkgDeleteFromDB(context.TODO(), dbPkg.Key())
-	assert.Nil(t, err)
+	readPR.resources = resources
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	t.assertPackageRevsEqual(&dbPRUpdate, readPR)
+
+	err = pkgRevDeleteFromDB(t.Context(), dbPR.Key())
+	t.Require().NoError(err)
+
+	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	t.Require().NotNil(err)
+	t.Equal(sql.ErrNoRows, err)
+
+	err = pkgRevUpdateDB(t.Context(), &dbPRUpdate, false)
+	t.Require().ErrorContains(err, "no rows or multiple rows found for updating")
+
+	err = pkgRevDeleteFromDB(t.Context(), dbPR.Key())
+	t.Require().NoError(err)
+
+	err = pkgDeleteFromDB(t.Context(), dbPkg.Key())
+	t.Require().NoError(err)
+
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 }
 
-func readRepoPkgPRs(t *testing.T, pkgs []dbPackage) []*dbPackageRevision {
+func (t *DbTestSuite) readRepoPkgPRs(pkgs []dbPackage) []*dbPackageRevision {
 	var readRepoPkgsPRs []*dbPackageRevision
 
 	for _, pkg := range pkgs {
-		readPRs, err := pkgRevReadPRsFromDB(context.TODO(), pkg.Key())
-		assert.Nil(t, err)
+		readPRs, err := pkgRevReadPRsFromDB(t.Context(), pkg.Key())
+		t.Require().NoError(err)
 
 		readRepoPkgsPRs = append(readRepoPkgsPRs, readPRs...)
 	}
@@ -609,7 +588,7 @@ func readRepoPkgPRs(t *testing.T, pkgs []dbPackage) []*dbPackageRevision {
 	return readRepoPkgsPRs
 }
 
-func listRepoPkgPRs(t *testing.T, pkgs []dbPackage) []*dbPackageRevision {
+func (t *DbTestSuite) listRepoPkgPRs(pkgs []dbPackage) []*dbPackageRevision {
 	var listRepoPkgsPRs []*dbPackageRevision
 
 	for _, pkg := range pkgs {
@@ -619,8 +598,8 @@ func listRepoPkgPRs(t *testing.T, pkgs []dbPackage) []*dbPackageRevision {
 			},
 		}
 
-		listPRs, err := pkgRevListPRsFromDB(context.TODO(), prFilter)
-		assert.Nil(t, err)
+		listPRs, err := pkgRevListPRsFromDB(t.Context(), prFilter)
+		t.Require().NoError(err)
 
 		listRepoPkgsPRs = append(listRepoPkgsPRs, listPRs...)
 	}
@@ -628,14 +607,14 @@ func listRepoPkgPRs(t *testing.T, pkgs []dbPackage) []*dbPackageRevision {
 	return listRepoPkgsPRs
 }
 
-func assertPackageRevListsEqual(t *testing.T, left []dbPackageRevision, right []*dbPackageRevision, count int) {
-	assert.Equal(t, count, len(left))
-	assert.Equal(t, count, len(right))
+func (t *DbTestSuite) assertPackageRevListsEqual(left []dbPackageRevision, right []*dbPackageRevision, count int) {
+	t.Len(left, count)
+	t.Len(right, count)
 
 	leftMap := make(map[repository.PackageRevisionKey]*dbPackageRevision)
 	for _, leftPr := range left {
-		resources, err := pkgRevResourcesReadFromDB(context.TODO(), leftPr.Key())
-		assert.Nil(t, err)
+		resources, err := pkgRevResourcesReadFromDB(t.Context(), leftPr.Key())
+		t.Require().NoError(err)
 
 		leftPr.resources = resources
 		leftMap[leftPr.Key()] = &leftPr
@@ -645,35 +624,35 @@ func assertPackageRevListsEqual(t *testing.T, left []dbPackageRevision, right []
 	for _, rightPr := range right {
 		rightMap[rightPr.Key()] = rightPr
 
-		resources, err := pkgRevResourcesReadFromDB(context.TODO(), rightPr.Key())
-		assert.Nil(t, err)
+		resources, err := pkgRevResourcesReadFromDB(t.Context(), rightPr.Key())
+		t.Require().NoError(err)
 
 		rightPr.resources = resources
 	}
 
 	for leftKey, leftPr := range leftMap {
 		rightPr, ok := rightMap[leftKey]
-		assert.True(t, ok)
+		t.True(ok)
 
-		assertPackageRevsEqual(t, leftPr, rightPr)
+		t.assertPackageRevsEqual(leftPr, rightPr)
 	}
 }
 
-func assertPackageRevsEqual(t *testing.T, left, right *dbPackageRevision) {
-	assert.Equal(t, left.Key(), right.Key())
-	assert.Equal(t, left.meta.Namespace, right.meta.Namespace)
-	assert.Equal(t, left.meta.Name, right.meta.Name)
-	assert.Equal(t, left.spec, right.spec)
-	assert.Equal(t, left.updatedBy, right.updatedBy)
-	assert.Equal(t, left.lifecycle, right.lifecycle)
-	assert.Equal(t, left.tasks, right.tasks)
-	assert.Equal(t, left.resources, right.resources)
+func (t *DbTestSuite) assertPackageRevsEqual(left, right *dbPackageRevision) {
+	t.Equal(left.Key(), right.Key())
+	t.Equal(left.meta.Namespace, right.meta.Namespace)
+	t.Equal(left.meta.Name, right.meta.Name)
+	t.Equal(left.spec, right.spec)
+	t.Equal(left.updatedBy, right.updatedBy)
+	t.Equal(left.lifecycle, right.lifecycle)
+	t.Equal(left.tasks, right.tasks)
+	t.Equal(left.resources, right.resources)
 }
 
-func assertPackageRevLatestIs(t *testing.T, expectedLatest int, prList []*dbPackageRevision) {
+func (t *DbTestSuite) assertPackageRevLatestIs(expectedLatest int, prList []*dbPackageRevision) {
 	for _, pr := range prList {
-		latestPrRev, err := pkgRevGetlatestRevFromDB(context.TODO(), pr.Key().PkgKey)
-		assert.True(t, err == nil)
-		assert.Equal(t, expectedLatest, latestPrRev)
+		latestPrRev, err := pkgRevGetlatestRevFromDB(t.Context(), pr.Key().PkgKey)
+		t.Require().NoError(err)
+		t.Equal(expectedLatest, latestPrRev)
 	}
 }

--- a/pkg/cache/dbcache/dbpackagesql_test.go
+++ b/pkg/cache/dbcache/dbpackagesql_test.go
@@ -15,23 +15,19 @@
 package dbcache
 
 import (
-	"context"
 	"database/sql"
-	"strings"
-	"testing"
 	"time"
 
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/repository"
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestPackageDBWriteRead(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestPackageDBWriteRead() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
@@ -80,38 +76,34 @@ func TestPackageDBWriteRead(t *testing.T) {
 		updatedBy: "porchuser2",
 	}
 
-	pkgDBWriteReadTest(t, &dbRepo, dbPkg, dbPkgUpdate)
+	t.pkgDBWriteReadTest(&dbRepo, dbPkg, dbPkgUpdate)
 
 	dbPkg.pkgKey.Path = ""
 	dbPkgUpdate.pkgKey.Path = ""
 	dbPkgUpdate.updatedBy = "bart"
-	pkgDBWriteReadTest(t, &dbRepo, dbPkg, dbPkgUpdate)
+	t.pkgDBWriteReadTest(&dbRepo, dbPkg, dbPkgUpdate)
 }
 
-func TestPackageDBSchema(t *testing.T) {
+func (t *DbTestSuite) TestPackageDBSchema() {
 	dbPkg := dbPackage{}
-	err := pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates check constraint"))
+	err := pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "violates check constraint")
 
 	dbPkg.pkgKey = repository.PackageKey{
 		RepoKey: repository.RepositoryKey{
 			Namespace: "my-ns",
 		},
 	}
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates check constraint"))
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "violates check constraint")
 
 	dbPkg.pkgKey.RepoKey.Name = "my-repo"
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates check constraint"))
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "violates check constraint")
 
 	dbPkg.pkgKey.Package = "my-package"
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
 	dbRepo := dbRepository{
 		repoKey: repository.RepositoryKey{
@@ -119,164 +111,159 @@ func TestPackageDBSchema(t *testing.T) {
 			Name:      "my-repo",
 		},
 	}
-	err = repoWriteToDB(context.TODO(), &dbRepo)
-	assert.Nil(t, err)
+	err = repoWriteToDB(t.Context(), &dbRepo)
+	t.Require().NoError(err)
 
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.Nil(t, err)
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().NoError(err)
 
 	dbPkg.pkgKey.Path = "my-path"
-	err = pkgUpdateDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows or multiple rows found for updating"))
+	err = pkgUpdateDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "no rows or multiple rows found for updating")
 
 	dbPkg.pkgKey.Path = ""
 	dbPkg.updatedBy = "Marge"
-	err = pkgUpdateDB(context.TODO(), &dbPkg)
-	assert.Nil(t, err)
+	err = pkgUpdateDB(t.Context(), &dbPkg)
+	t.Require().NoError(err)
 
 	dbPkg.pkgKey.Path = "my-path"
-	err = pkgUpdateDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows or multiple rows found for updating"))
+	err = pkgUpdateDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "no rows or multiple rows found for updating")
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 
-	_, err = pkgReadFromDB(context.TODO(), dbPkg.Key())
-	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	_, err = pkgReadFromDB(t.Context(), dbPkg.Key())
+	t.Require().NotNil(err)
+	t.Equal(sql.ErrNoRows, err)
 }
 
-func TestMultiPackageRepo(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestMultiPackageRepo() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo11 := createTestRepo(t, "my-ns1", "my-repo1")
-	dbRepo12 := createTestRepo(t, "my-ns1", "my-repo2")
-	dbRepo21 := createTestRepo(t, "my-ns2", "my-repo1")
-	dbRepo22 := createTestRepo(t, "my-ns2", "my-repo2")
+	dbRepo11 := t.createTestRepo("my-ns1", "my-repo1")
+	dbRepo12 := t.createTestRepo("my-ns1", "my-repo2")
+	dbRepo21 := t.createTestRepo("my-ns2", "my-repo1")
+	dbRepo22 := t.createTestRepo("my-ns2", "my-repo2")
 
-	dbRepo11Pkgs := createTestPkgs(t, dbRepo11.Key(), "my-package", 4)
-	dbRepo12Pkgs := createTestPkgs(t, dbRepo12.Key(), "my-package", 4)
-	dbRepo21Pkgs := createTestPkgs(t, dbRepo21.Key(), "my-package", 4)
-	dbRepo22Pkgs := createTestPkgs(t, dbRepo22.Key(), "my-package", 4)
+	dbRepo11Pkgs := t.createTestPkgs(dbRepo11.Key(), "my-package", 4)
+	dbRepo12Pkgs := t.createTestPkgs(dbRepo12.Key(), "my-package", 4)
+	dbRepo21Pkgs := t.createTestPkgs(dbRepo21.Key(), "my-package", 4)
+	dbRepo22Pkgs := t.createTestPkgs(dbRepo22.Key(), "my-package", 4)
 
-	readRep11Pkgs, err := pkgReadPkgsFromDB(context.TODO(), dbRepo11.Key())
-	assert.Nil(t, err)
+	readRep11Pkgs, err := pkgReadPkgsFromDB(t.Context(), dbRepo11.Key())
+	t.Require().NoError(err)
 
-	readRep12Pkgs, err := pkgReadPkgsFromDB(context.TODO(), dbRepo12.Key())
-	assert.Nil(t, err)
+	readRep12Pkgs, err := pkgReadPkgsFromDB(t.Context(), dbRepo12.Key())
+	t.Require().NoError(err)
 
-	readRep21Pkgs, err := pkgReadPkgsFromDB(context.TODO(), dbRepo21.Key())
-	assert.Nil(t, err)
+	readRep21Pkgs, err := pkgReadPkgsFromDB(t.Context(), dbRepo21.Key())
+	t.Require().NoError(err)
 
-	readRep22Pkgs, err := pkgReadPkgsFromDB(context.TODO(), dbRepo22.Key())
-	assert.Nil(t, err)
+	readRep22Pkgs, err := pkgReadPkgsFromDB(t.Context(), dbRepo22.Key())
+	t.Require().NoError(err)
 
-	assertPackageListsEqual(t, dbRepo11Pkgs, readRep11Pkgs, 4)
-	assertPackageListsEqual(t, dbRepo12Pkgs, readRep12Pkgs, 4)
-	assertPackageListsEqual(t, dbRepo21Pkgs, readRep21Pkgs, 4)
-	assertPackageListsEqual(t, dbRepo22Pkgs, readRep22Pkgs, 4)
+	t.assertPackageListsEqual(dbRepo11Pkgs, readRep11Pkgs, 4)
+	t.assertPackageListsEqual(dbRepo12Pkgs, readRep12Pkgs, 4)
+	t.assertPackageListsEqual(dbRepo21Pkgs, readRep21Pkgs, 4)
+	t.assertPackageListsEqual(dbRepo22Pkgs, readRep22Pkgs, 4)
 
-	deleteTestRepo(t, dbRepo11.Key())
-	deleteTestRepo(t, dbRepo12.Key())
-	deleteTestRepo(t, dbRepo21.Key())
-	deleteTestRepo(t, dbRepo22.Key())
+	t.deleteTestRepo(dbRepo11.Key())
+	t.deleteTestRepo(dbRepo12.Key())
+	t.deleteTestRepo(dbRepo21.Key())
+	t.deleteTestRepo(dbRepo22.Key())
 }
 
-func TestPackageFilter(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestPackageFilter() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
 
-	dbRepo := createTestRepo(t, "my-ns", "my-repo")
+	dbRepo := t.createTestRepo("my-ns", "my-repo")
 
-	dbRepoPkgs := createTestPkgs(t, dbRepo.Key(), "my-package", 4)
+	dbRepoPkgs := t.createTestPkgs(dbRepo.Key(), "my-package", 4)
 
 	pkgFilter := repository.ListPackageFilter{}
-	listPkgs, err := pkgListPkgsFromDB(context.TODO(), pkgFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(listPkgs))
+	listPkgs, err := pkgListPkgsFromDB(t.Context(), pkgFilter)
+	t.Require().NoError(err)
+	t.Len(listPkgs, 4)
 
 	pkgFilter.Key.RepoKey = dbRepo.repoKey
 	pkgFilter.Key.Package = "my-package-2"
-	listPkgs, err = pkgListPkgsFromDB(context.TODO(), pkgFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(listPkgs))
+	listPkgs, err = pkgListPkgsFromDB(t.Context(), pkgFilter)
+	t.Require().NoError(err)
+	t.Len(listPkgs, 1)
 
 	pkgFilter.Key.Package = "my-package-5"
-	listPkgs, err = pkgListPkgsFromDB(context.TODO(), pkgFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(listPkgs))
+	listPkgs, err = pkgListPkgsFromDB(t.Context(), pkgFilter)
+	t.Require().NoError(err)
+	t.Empty(listPkgs)
 
 	pkgFilter.Key.Package = "my-package-2"
 	pkgFilter.Key.Path = "a/path"
-	listPkgs, err = pkgListPkgsFromDB(context.TODO(), pkgFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(listPkgs))
+	listPkgs, err = pkgListPkgsFromDB(t.Context(), pkgFilter)
+	t.Require().NoError(err)
+	t.Empty(listPkgs)
 
 	pkgFilter.Key.Path = ""
-	listPkgs, err = pkgListPkgsFromDB(context.TODO(), pkgFilter)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(listPkgs))
+	listPkgs, err = pkgListPkgsFromDB(t.Context(), pkgFilter)
+	t.Require().NoError(err)
+	t.Len(listPkgs, 1)
 
-	deleteTestRepo(t, dbRepo.Key())
+	t.deleteTestRepo(dbRepo.Key())
 
-	assert.Equal(t, 0, len(readRepoPkgPRs(t, dbRepoPkgs)))
+	t.Empty(t.readRepoPkgPRs(dbRepoPkgs))
 }
 
-func pkgDBWriteReadTest(t *testing.T, dbRepo *dbRepository, dbPkg, dbPkgUpdate dbPackage) {
-	err := pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates foreign key constraint"))
+func (t *DbTestSuite) pkgDBWriteReadTest(dbRepo *dbRepository, dbPkg, dbPkgUpdate dbPackage) {
+	err := pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().ErrorContains(err, "violates foreign key constraint")
 
-	err = repoWriteToDB(context.TODO(), dbRepo)
-	assert.Nil(t, err)
+	err = repoWriteToDB(t.Context(), dbRepo)
+	t.Require().NoError(err)
 
 	dbPkg.repo = dbRepo
 	dbPkg.pkgKey.RepoKey = dbRepo.Key()
 
-	err = pkgWriteToDB(context.TODO(), &dbPkg)
-	assert.Nil(t, err)
+	err = pkgWriteToDB(t.Context(), &dbPkg)
+	t.Require().NoError(err)
 
-	readPkg, err := pkgReadFromDB(context.TODO(), dbPkg.Key())
-	assert.Nil(t, err)
-	assertPackagesEqual(t, &dbPkg, readPkg)
+	readPkg, err := pkgReadFromDB(t.Context(), dbPkg.Key())
+	t.Require().NoError(err)
+	t.assertPackagesEqual(&dbPkg, readPkg)
 
-	err = pkgWriteToDB(context.TODO(), &dbPkgUpdate)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "violates unique constraint"))
+	err = pkgWriteToDB(t.Context(), &dbPkgUpdate)
+	t.Require().ErrorContains(err, "violates unique constraint")
 
-	err = pkgUpdateDB(context.TODO(), &dbPkgUpdate)
-	assert.Nil(t, err)
+	err = pkgUpdateDB(t.Context(), &dbPkgUpdate)
+	t.Require().NoError(err)
 
-	readPkg, err = pkgReadFromDB(context.TODO(), dbPkg.Key())
-	assert.Nil(t, err)
-	assertPackagesEqual(t, &dbPkgUpdate, readPkg)
+	readPkg, err = pkgReadFromDB(t.Context(), dbPkg.Key())
+	t.Require().NoError(err)
+	t.assertPackagesEqual(&dbPkgUpdate, readPkg)
 
-	err = pkgDeleteFromDB(context.TODO(), dbPkg.Key())
-	assert.Nil(t, err)
+	err = pkgDeleteFromDB(t.Context(), dbPkg.Key())
+	t.Require().NoError(err)
 
-	_, err = pkgReadFromDB(context.TODO(), dbPkg.Key())
-	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	_, err = pkgReadFromDB(t.Context(), dbPkg.Key())
+	t.Require().NotNil(err)
+	t.Equal(sql.ErrNoRows, err)
 
-	err = pkgUpdateDB(context.TODO(), &dbPkgUpdate)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no rows or multiple rows found for updating"))
+	err = pkgUpdateDB(t.Context(), &dbPkgUpdate)
+	t.Require().ErrorContains(err, "no rows or multiple rows found for updating")
 
-	err = pkgDeleteFromDB(context.TODO(), dbPkg.Key())
-	assert.Nil(t, err)
+	err = pkgDeleteFromDB(t.Context(), dbPkg.Key())
+	t.Require().NoError(err)
 
-	err = repoDeleteFromDB(context.TODO(), dbRepo.Key())
-	assert.Nil(t, err)
+	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
+	t.Require().NoError(err)
 }
 
-func assertPackageListsEqual(t *testing.T, left []dbPackage, right []*dbPackage, count int) {
-	assert.Equal(t, count, len(left))
-	assert.Equal(t, count, len(right))
+func (t *DbTestSuite) assertPackageListsEqual(left []dbPackage, right []*dbPackage, count int) {
+	t.Len(left, count)
+	t.Len(right, count)
 
 	leftMap := make(map[repository.PackageKey]*dbPackage)
 	for _, leftPkg := range left {
@@ -290,16 +277,16 @@ func assertPackageListsEqual(t *testing.T, left []dbPackage, right []*dbPackage,
 
 	for leftKey, leftPkg := range leftMap {
 		rightPkg, ok := rightMap[leftKey]
-		assert.True(t, ok)
+		t.True(ok)
 
-		assertPackagesEqual(t, leftPkg, rightPkg)
+		t.assertPackagesEqual(leftPkg, rightPkg)
 	}
 }
 
-func assertPackagesEqual(t *testing.T, left, right *dbPackage) {
-	assert.Equal(t, left.Key(), right.Key())
-	assert.Equal(t, left.meta.Namespace, right.meta.Namespace)
-	assert.Equal(t, left.meta.Name, right.meta.Name)
-	assert.Equal(t, left.spec, right.spec)
-	assert.Equal(t, left.updatedBy, right.updatedBy)
+func (t *DbTestSuite) assertPackagesEqual(left, right *dbPackage) {
+	t.Equal(left.Key(), right.Key())
+	t.Equal(left.meta.Namespace, right.meta.Namespace)
+	t.Equal(left.meta.Name, right.meta.Name)
+	t.Equal(left.spec, right.spec)
+	t.Equal(left.updatedBy, right.updatedBy)
 }

--- a/pkg/cache/dbcache/dbrepository_test.go
+++ b/pkg/cache/dbcache/dbrepository_test.go
@@ -15,10 +15,8 @@
 package dbcache
 
 import (
-	"context"
 	"errors"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
@@ -30,12 +28,11 @@ import (
 	"github.com/nephio-project/porch/pkg/repository"
 	mocksql "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/dbcache"
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestDBRepository(t *testing.T) {
+func (t *DbTestSuite) TestDBRepository() {
 	shellRepo := dbRepository{
 		repoKey: repository.RepositoryKey{
 			Namespace: "my-ns",
@@ -43,33 +40,33 @@ func TestDBRepository(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "my-ns", shellRepo.KubeObjectNamespace())
-	assert.Equal(t, "my-repo-name", shellRepo.KubeObjectName())
-	assert.Equal(t, types.UID("82d3ab92-4a01-5679-8c52-b1c3daf6f016"), shellRepo.UID())
-	assert.Equal(t, repository.RepositoryKey{Namespace: "my-ns", Name: "my-repo-name"}, shellRepo.Key())
+	t.Equal("my-ns", shellRepo.KubeObjectNamespace())
+	t.Equal("my-repo-name", shellRepo.KubeObjectName())
+	t.Equal(types.UID("82d3ab92-4a01-5679-8c52-b1c3daf6f016"), shellRepo.UID())
+	t.Equal(repository.RepositoryKey{Namespace: "my-ns", Name: "my-repo-name"}, shellRepo.Key())
 }
 
-func TestDBRepositoryPRCrud(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestDBRepositoryPRCrud() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 
 	externalrepo.ExternalRepoInUnitTestMode = true
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
-	testRepo := createTestRepo(t, "my-ns", "my-repo-name")
+	testRepo := t.createTestRepo("my-ns", "my-repo-name")
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(testRepo).Maybe()
 
 	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
-	version, err := testRepo.Version(context.TODO())
-	assert.Nil(t, err)
-	assert.Equal(t, "", version)
+	version, err := testRepo.Version(t.Context())
+	t.Require().NoError(err)
+	t.Equal("", version)
 
 	pkgList, err := testRepo.ListPackages(ctx, repository.ListPackageFilter{})
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(pkgList))
+	t.Require().NoError(err)
+	t.Equal(0, len(pkgList))
 
 	newPkgDef := v1alpha1.PorchPackage{
 		Spec: v1alpha1.PackageSpec{
@@ -79,18 +76,18 @@ func TestDBRepositoryPRCrud(t *testing.T) {
 	}
 
 	newPkg, err := testRepo.CreatePackage(ctx, &newPkgDef)
-	assert.Nil(t, err)
-	assert.NotNil(t, newPkg)
+	t.Require().NoError(err)
+	t.Require().NotNil(newPkg)
 
 	pkgDef := newPkg.GetPackage(ctx)
-	assert.NotNil(t, pkgDef)
+	t.Require().NotNil(pkgDef)
 
 	err = testRepo.DeletePackage(ctx, newPkg)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	prList, err := testRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(prList))
+	t.Require().NoError(err)
+	t.Equal(0, len(prList))
 
 	newPRDef := v1alpha1.PackageRevision{
 		Spec: v1alpha1.PackageRevisionSpec{
@@ -100,39 +97,39 @@ func TestDBRepositoryPRCrud(t *testing.T) {
 		},
 	}
 	newPRDraft, err := testRepo.CreatePackageRevisionDraft(ctx, &newPRDef)
-	assert.Nil(t, err)
-	assert.NotNil(t, newPRDraft)
+	t.Require().NoError(err)
+	t.Require().NotNil(newPRDraft)
 
 	newPR, err := testRepo.ClosePackageRevisionDraft(ctx, newPRDraft, -1)
-	assert.Nil(t, err)
-	assert.NotNil(t, newPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(newPR)
 
 	updatedPRDraft, err := testRepo.UpdatePackageRevision(ctx, newPR)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedPRDraft)
+	t.Require().NoError(err)
+	t.Require().NotNil(updatedPRDraft)
 
 	err = updatedPRDraft.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleProposed)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	updatedPR, err := testRepo.ClosePackageRevisionDraft(ctx, updatedPRDraft, -1)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(updatedPR)
 
 	updatedPRDraft, err = testRepo.UpdatePackageRevision(ctx, newPR)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedPRDraft)
+	t.Require().NoError(err)
+	t.Require().NotNil(updatedPRDraft)
 
 	err = updatedPRDraft.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	prMeta := updatedPR.GetMeta()
 	prMeta.Finalizers = []string{"a-finalizer"}
 	err = updatedPR.SetMeta(ctx, prMeta)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	updatedPR, err = testRepo.ClosePackageRevisionDraft(ctx, updatedPRDraft, -1)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedPR)
+	t.Require().NoError(err)
+	t.Require().NotNil(updatedPR)
 
 	fakeRepo := testRepo.externalRepo.(*fake.Repository)
 	fakeExtPR := fake.FakePackageRevision{
@@ -141,36 +138,36 @@ func TestDBRepositoryPRCrud(t *testing.T) {
 	fakeRepo.PackageRevisions = append(fakeRepo.PackageRevisions, &fakeExtPR)
 
 	err = testRepo.DeletePackageRevision(ctx, updatedPR)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	prMeta = updatedPR.GetMeta()
 	prMeta.Finalizers = nil
 	err = updatedPR.SetMeta(ctx, prMeta)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	err = testRepo.DeletePackageRevision(ctx, updatedPR)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	err = testRepo.Close(ctx)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 }
 
-func TestDBRepositorySync(t *testing.T) {
-	mockCache := mockcachetypes.NewMockCache(t)
+func (t *DbTestSuite) TestDBRepositorySync() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 
 	externalrepo.ExternalRepoInUnitTestMode = true
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
-	testRepo := createTestRepo(t, "my-ns", "my-repo-name")
+	testRepo := t.createTestRepo("my-ns", "my-repo-name")
 	testRepo.spec = &configapi.Repository{
 		Spec: configapi.RepositorySpec{},
 	}
 	mockCache.EXPECT().GetRepository(mock.Anything).Return(testRepo).Maybe()
 
 	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 
 	cacheOptions := cachetypes.CacheOptions{
 		RepoSyncFrequency: 2 * time.Second,
@@ -179,14 +176,14 @@ func TestDBRepositorySync(t *testing.T) {
 	testRepo.repositorySync = newRepositorySync(testRepo, cacheOptions)
 
 	err = testRepo.Refresh(ctx)
-	assert.True(t, err == nil || strings.Contains(err.Error(), "already in progress"))
+	t.Require().True(err == nil || strings.Contains(err.Error(), "already in progress"))
 
 	err = testRepo.Close(ctx)
-	assert.Nil(t, err)
+	t.Require().NoError(err)
 }
 
-func TestDBRepositorCorner(t *testing.T) {
-	switchToMockSQL(t)
+func (t *DbTestSuite) TestDBRepositorCorner() {
+	t.switchToMockSQL()
 
 	mockSQL := dbHandler.db.(*mocksql.MockdbSQLInterface)
 	mockSQL.EXPECT().Exec(
@@ -203,12 +200,12 @@ func TestDBRepositorCorner(t *testing.T) {
 
 	mockSQL.EXPECT().Close().Return(errors.New("DB close failed")).Maybe()
 
-	mockCache := mockcachetypes.NewMockCache(t)
+	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache
 
 	externalrepo.ExternalRepoInUnitTestMode = true
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	dbRepo := dbRepository{
 		repoKey: repository.RepositoryKey{
@@ -217,7 +214,7 @@ func TestDBRepositorCorner(t *testing.T) {
 		},
 	}
 	err := repoWriteToDB(ctx, &dbRepo)
-	assert.NotNil(t, err)
+	t.Require().NotNil(err)
 
-	revertToPostgreSQL(t)
+	t.revertToPostgreSQL()
 }

--- a/pkg/cache/dbcache/dbsql_test.go
+++ b/pkg/cache/dbcache/dbsql_test.go
@@ -14,24 +14,18 @@
 
 package dbcache
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-func TestDBSQL(t *testing.T) {
+func (t *DbTestSuite) TestDBSQL() {
 	dbSQL := dbSQL{}
 
 	err := dbSQL.Close()
-	assert.Equal(t, "cannot close database, database is not initialized", err.Error())
+	t.Require().ErrorContains(err, "cannot close database, database is not initialized")
 
 	_, err = dbSQL.Exec("")
-	assert.Equal(t, "cannot execute query on database, database is not initialized", err.Error())
+	t.Require().ErrorContains(err, "cannot execute query on database, database is not initialized")
 
 	_, err = dbSQL.Query("")
-	assert.Equal(t, "cannot query database, database is not initialized", err.Error())
+	t.Require().ErrorContains(err, "cannot query database, database is not initialized")
 
 	nilRow := dbSQL.QueryRow("")
-	assert.Nil(t, nilRow)
+	t.Nil(nilRow)
 }

--- a/pkg/cache/dbcache/util_test.go
+++ b/pkg/cache/dbcache/util_test.go
@@ -15,18 +15,15 @@
 package dbcache
 
 import (
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestUtil(t *testing.T) {
+func (t *DbTestSuite) TestUtil() {
 	// We can't marshal a function into JSON
-	jsonVal := valueAsJSON(TestDBSQL)
-	assert.Equal(t, "", jsonVal)
+	jsonVal := valueAsJSON(t.TestDBSQL)
+	t.Require().Equal("", jsonVal)
 
 	secondValue := time.Second
 	setValueFromJSON("", &secondValue)
-	assert.Equal(t, time.Second, secondValue)
+	t.Equal(time.Second, secondValue)
 }


### PR DESCRIPTION
Rewrote the DB cache tests to use testify rest suite, and to also be skipped if the user is root, because postgres complains in that case. I think this is an improvement to these tests overall.

Reasoning: Had some trouble running the all unit tests on a container that uses the root user, and skipping the DB cache tests seemed problematic the way they were using TestMain.

