### PR TITLE
Postgres image update to new Bitnami repository

### DIFF
--- a/deployments/local/postgres/postgres-statefulset.yaml
+++ b/deployments/local/postgres/postgres-statefulset.yaml
@@ -66,9 +66,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          # Latest Postgres image from https://hub.docker.com/r/bitnamisecure/postgresql/tags
-          #   as of 2025-09-18
-          image: docker.io/bitnamisecure/postgresql:sha256-1adcafe30e74d396e9fb55670a53722b8e84d7f3b410edcdc325ee0e97f3e238
+          image: docker.io/bitnamisecure/postgresql:latest
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001

--- a/deployments/local/postgres/postgres-statefulset.yaml
+++ b/deployments/local/postgres/postgres-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnami/postgresql:17.5.0-debian-12-r4
+          # Latest Postgres image from https://hub.docker.com/r/bitnamisecure/postgresql/tags
+          #   as of 2025-09-18
+          image: docker.io/bitnamisecure/postgresql:sha256-1adcafe30e74d396e9fb55670a53722b8e84d7f3b410edcdc325ee0e97f3e238
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001

--- a/deployments/local/postgres/postgres-statefulset.yaml
+++ b/deployments/local/postgres/postgres-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamisecure/postgresql:latest
+          image: docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001


### PR DESCRIPTION
Bitnami are shifting to a new image registry model which entails cutting off several Docker images they provide. Postgres (used in Porch for deploying the DB cache in local/development environments) is still available, but requires changing the image tag in the StatefulSet manifest. Without this, the end-to-end test runs using the DB Cache will fail, with the porch-server microservice getting stuck in a crash loop, unable to connect to Postgres, until the run times out and is auto-cancelled after 6 hours.