### PR TITLE
Fix porch release gh actions

### DIFF
--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -28,14 +28,14 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Build
         run: make porchctl
       - name: Pack binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,15 +28,15 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Download kpt CLI
         run: mkdir -p bin && wget -O bin/kpt https://github.com/kptdev/kpt/releases/download/v1.0.0-beta.55/kpt_linux_amd64 && chmod +x bin/kpt


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Fix release GH actions failing to find missing go.mod

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Move code checkout before setup-go action
- Why it’s needed:  setup-go fails to find go.mod
- How it works:  

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
