### PR TITLE
Add verbose level 3 for listPackageRevision calls

### DIFF
--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -107,7 +107,7 @@ func (r *packageCommon) listPackageRevisions(ctx context.Context, filter reposit
 		workerCount = min(r.MaxConcurrentLists, repoCount)
 	}
 
-	klog.Infof("Listing %d repositories with %d workers", repoCount, workerCount)
+	klog.V(3).Infof("Listing %d repositories with %d workers", repoCount, workerCount)
 
 	resultsCh := make(chan pkgRevResult, workerCount)
 	repoQueue := make(chan *configapi.Repository, repoCount)
@@ -115,14 +115,14 @@ func (r *packageCommon) listPackageRevisions(ctx context.Context, filter reposit
 	for i := 0; i < workerCount; i++ {
 		go func() {
 			for repo := range repoQueue {
-				klog.Infof("[WORKER %d] Processing repository %s", i, repo.Name)
+				klog.V(3).Infof("[WORKER %d] Processing repository %s", i, repo.Name)
 				listCtx := ctx
 				var cancel context.CancelFunc
 				if r.ListTimeoutPerRepository != 0 {
 					listCtx, cancel = context.WithTimeout(ctx, r.ListTimeoutPerRepository)
 				}
 				revisions, err := r.cad.ListPackageRevisions(listCtx, repo, filter)
-				klog.Infof("[WORKER %d] ListPackageRevisions for %s done, len: %d, err: %v", i, repo.Name, len(revisions), err)
+				klog.V(3).Infof("[WORKER %d] ListPackageRevisions for %s done, len: %d, err: %v", i, repo.Name, len(revisions), err)
 				resultsCh <- pkgRevResult{Revisions: revisions, Err: err}
 				if cancel != nil {
 					cancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Add verbose level 3 for listPackageRevision calls

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  verbose level is set for 3 log lines in listPackageRevisions function
- Why it’s needed:  It's needed because for every get/list call, the logs are flooded with these lines. 
- How it works:  It sets the verbosity to 3, so by default it will not be logging them. If porch-server verbosity is set to 3 and above, these logs will be printed. 

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
