### PR TITLE
chore: Cleanup error logging when can't delete webhook

### DIFF
--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -331,7 +331,7 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 	}
 
 	if err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, validationCfgName, metav1.DeleteOptions{}); err != nil {
-		klog.Error("failed to delete existing webhook: %w", err)
+		klog.Warningf("failed to delete existing webhook: %v", err)
 	}
 
 	if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, validateConfig,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
chore: Cleanup error logging when can't delete webhook

---

## Description
<!-- Describe what this PR does and why -->
- What changed: Webhook deletion logging message dialed back to a warning
- Why it’s needed:  Log was too verbose
- How it works:  Just a log level change

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Transfer of PR  https://github.com/kptdev/kpt/pull/4117 from kptdev/kpt

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated (N/A)
- [x] Documentation added/updated  (N/A)
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
