### PR TITLE
adding install-porch make target

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -34,6 +34,17 @@ endif
 
 ##@ Build and deploy porch for development and testing
 
+.PHONY: install-porch
+install-porch: IMAGE_REPO=porch-kind## Setup dev environment and deploy porch into a kind cluster
+install-porch: IMAGE_TAG=test
+install-porch: deploy-cluster load-images-to-kind deployment-config deploy-current-config
+	@echo "Registering porch-test repository..."
+	$(BUILDDIR)/porchctl repo reg http://172.18.255.200:3000/nephio/porch-test.git --name=porch-test --repo-basic-username=nephio --repo-basic-password=secret
+
+.PHONY: deploy-cluster
+deploy-cluster: ## Setup development environment with kind cluster, gitea, and load balancing
+	./scripts/setup-dev-env.sh
+
 .PHONY: run-in-kind
 run-in-kind: IMAGE_REPO=porch-kind## Build and deploy porch into a kind cluster
 run-in-kind: IMAGE_TAG=test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->


## Title
<!-- Short, descriptive title for the PR -->
Just an additional make target for a 1 touch deploy porch command.

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  a new make target is added
- Why it’s needed:  deploying porch should only need a new user to do 1 cmd
- How it works:  basically the (./scripts/setup-dev-env + make run-in-kind + setup porch-test repository)

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  Just run the make target `make install-porch`

