### PR TITLE
incrementing porch latest version + README redirect to new documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ project as of December 2023.
 
 ## Documentation
 
-Documentation of Porch is available in the [Nephio documentation page](https://docs.nephio.org/docs/porch/).   
+Documentation of Porch is available in the [Porch documentation page](https://docs.porch.nephio.org/).

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -89,7 +89,7 @@ archived_version = false
 version = "latest"
 
 # The version of the latest code build
-latestTag = "1.5.5"
+latestTag = "1.5.6"
 
 # latest tested versions
 version_docker = "v28.1.1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
incrementing porch latest version + README redirect to new documentation

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  incrementing porch latest version + README redirect to new documentation
- Why it’s needed:  the old readme was pointing to the nephio documentation instead of the new porch one. the version being used in the installation guide was 1.5.5 but 1.5.6 release of porch is now the latest
- How it works:  

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [x] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
