### PR TITLE
Prevent edit, clone, and upgrade of placeholder package revisions

### DIFF
--- a/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller_test.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller_test.go
@@ -1615,11 +1615,11 @@ func TestIsValidUpstram(t *testing.T) {
 }
 
 func TestGetUpstreamPr(t *testing.T) {
-	pvReconcier := PackageVariantReconciler{}
+	pvReconciler := PackageVariantReconciler{}
 	upstream := api.Upstream{}
 	prList := porchapi.PackageRevisionList{}
 
-	_, err := pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err := pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
 	upstream.Repo = "my-repo"
@@ -1627,7 +1627,7 @@ func TestGetUpstreamPr(t *testing.T) {
 	upstream.WorkspaceName = "my-workspace"
 
 	prList.Items = append(prList.Items, porchapi.PackageRevision{})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
 	prList.Items = append(prList.Items, porchapi.PackageRevision{
@@ -1638,7 +1638,7 @@ func TestGetUpstreamPr(t *testing.T) {
 			Revision:       1,
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
 	prList.Items = append(prList.Items, porchapi.PackageRevision{
@@ -1649,10 +1649,10 @@ func TestGetUpstreamPr(t *testing.T) {
 			Revision:       1,
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 	prList.Items = append(prList.Items, porchapi.PackageRevision{
 		Spec: porchapi.PackageRevisionSpec{
@@ -1662,14 +1662,14 @@ func TestGetUpstreamPr(t *testing.T) {
 			Revision:       1,
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, err == nil)
 
 	upstream.WorkspaceName = ""
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, strings.HasPrefix(err.Error(), "could not find upstream package revision"))
 
 	prList.Items = append(prList.Items, porchapi.PackageRevision{
@@ -1679,11 +1679,11 @@ func TestGetUpstreamPr(t *testing.T) {
 			WorkspaceName:  "main",
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, err == nil)
 
 	upstream.Revision = -1
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, err == nil)
 
 	upstream.Repo = "my-repo2"
@@ -1713,7 +1713,7 @@ func TestGetUpstreamPr(t *testing.T) {
 			Revision:       -1,
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, err != nil)
 
 	prList.Items = append(prList.Items, porchapi.PackageRevision{
@@ -1724,7 +1724,7 @@ func TestGetUpstreamPr(t *testing.T) {
 			Revision:       -1,
 		},
 	})
-	_, err = pvReconcier.getUpstreamPR(&upstream, &prList)
+	_, err = pvReconciler.getUpstreamPR(&upstream, &prList)
 	assert.True(t, err == nil)
 }
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
@@ -163,6 +163,13 @@ Common issues when working with PackageRevisions and their solutions:
 - Verify service account has proper roles for PackageRevision operations
 - Ensure repository authentication is configured correctly
 
+**Errors about "placeholder package revision"?**
+
+- Clone, edit/copy, and upgrade operations cannot be performed on or using placeholder PackageRevisions
+  - (identified by revision number -1 and workspace name matching the repository's Git branch, typically 'main')
+- Use published PackageRevisions with specific version numbers in these operations
+- For more information on placeholder PackageRevisions, see [Core Concepts]({{% relref "/docs/2_concepts#core-concepts" %}})
+
 **Pipeline functions failing?**
 
 - Check function image availability and version

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/cloning-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/cloning-packages.md
@@ -269,6 +269,12 @@ Common issues when cloning PackageRevisions and how to resolve them.
 - Check the exact name including repository, package, and workspace
 - Ensure you have permission to read the source PackageRevision
 
+**Clone fails with "upstream revision may not be the placeholder package revision":**
+
+- Using the upstream package's placeholder PackageRevision as the upstream PackageRevision is not supported
+- See [Core Concepts]({{% relref "/docs/2_concepts#core-concepts" %}}) for the rules which identify a placeholder PackageRevision
+- Choose a different PackageRevision from the same package to use as the upstream PackageRevision
+
 **Clone fails with "workspace already exists"?**
 
 - The workspace name must be unique within the package in the target repository

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/copying-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/copying-packages.md
@@ -272,6 +272,12 @@ Common issues when copying PackageRevisions and how to resolve them.
 - Ensure you have permission to read the source PackageRevision
 - Ensure the source is in the same repository (copy only works within the same repository)
 
+**Copy fails with "source revision may not be the placeholder package revision":**
+
+- Using the package's placeholder PackageRevision as the source PackageRevision is not supported
+- See [Core Concepts]({{% relref "/docs/2_concepts#core-concepts" %}}) for the rules which identify a placeholder PackageRevision
+- Choose a different PackageRevision from the same package to use as the source PackageRevision
+
 **Copied PackageRevision has unexpected content:**
 
 - The copy includes all resources from the source at the time of copying

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
@@ -329,6 +329,7 @@ For more details, run `porchctl rpkg upgrade --help`.
 
 *   **Separate Repositories:** For better organization and access control, keep blueprint packages and deployment packages in separate Git repositories.
 *   **Understand Your Strategy:** Before upgrading, be certain which merge strategy fits your use case to avoid accidentally losing important local customizations. When in doubt, the default `resource-merge` is the safest and most intelligent option.
+*   **Use Fixed Revisions:** Do not upgrade packages' placeholder/main package revisions or attempt to use them as upstream for an upgrade - this is not supported. Select defined package revisions instead - see [Core Concepts]({{% relref "/docs/2_concepts#core-concepts" %}}) for the rules which identify a placeholder package revision
 
 ### Cleanup
 

--- a/docs/content/en/docs/5_architecture_and_components/engine/functionality/validation-business-rules.md
+++ b/docs/content/en/docs/5_architecture_and_components/engine/functionality/validation-business-rules.md
@@ -312,8 +312,8 @@ The new package revision must be from the same package as the source package rev
 **Validation process:**
 1. **Fetch source revision** from specified reference
 2. **Verify same package** (same repository and package name)
-5. **Check if published** (only published revisions can be edited)
-6. **Allow if all checks pass**
+3. **Check if published** (only published revisions can be edited)
+4. **Allow if all checks pass**
 
 **Error messages:**
 - "source revision must be from same package {repo}/{package}"
@@ -438,7 +438,7 @@ Neither the target upstream package revision (the new revision being upgraded to
 - Placeholder package revisions represent unstable main branch state
 - Using placeholder revisions would produce non-deterministic upgrade results
 - Prevents upgrading to non-fixed revision states
-      - Validation on clone and edit operations precludes possibilty of old upstream being a placeholder
+      - Validation on clone and edit operations precludes possibility of old upstream being a placeholder
 
 
 ## Package Path Overlap Validation

--- a/docs/content/en/docs/5_architecture_and_components/engine/functionality/validation-business-rules.md
+++ b/docs/content/en/docs/5_architecture_and_components/engine/functionality/validation-business-rules.md
@@ -209,9 +209,7 @@ CreatePackageRevision
 
 ## Clone Task Validation
 
-The Engine validates clone tasks to prevent creating duplicate packages:
-
-### Clone Constraint Check
+The Engine validates clone tasks to prevent creating invalid packages:
 
 ```
 Clone Task Validation
@@ -226,8 +224,18 @@ Clone Task Validation
         ↓
   Continue
         ↓
+  Resolve Repository Containing Proposed Upstream
+        ↓
+  Upstream is Placeholder? ──Yes──> Reject
+        │
+        No
+        ↓
   Allow Clone
 ```
+
+### Clone Constraint Check: Package Uniqueness In Repository
+
+The package name must be unique in the repository to avoid creating duplicate packages.
 
 **Validation process:**
 1. **List all revisions** in the repository
@@ -243,6 +251,24 @@ Clone Task Validation
 - Existing packages should use `edit` or `copy` for new revisions
 - Prevents accidental overwriting of existing packages
 
+### Clone Constraint Check: Exclude Placeholder Package Revision
+
+The upstream package revision cannot be a placeholder package revision (identified by `Revision == -1` and `WorkspaceName` matching the Git repository's branch)
+
+**Validation process:**
+1. **Resolve repository details** for the upstream package revision
+2. **Check if placeholder** (revision == -1 and WorkspaceName matches repo Git branch)
+3. **Reject if placeholder** package revision
+4. **Allow if not placeholder**
+
+**Error message:**
+- "upstream revision may not be the placeholder package revision {repo}/{name}"
+
+**Rationale:**
+- Placeholder package revisions represent the main/branch-HEAD state
+      - they are not fixed revisions, making them unsuitable for cloning
+- Operations would fail in later lifecycle stages
+
 ### Clone vs Edit/Copy
 
 **When to use clone:**
@@ -255,9 +281,72 @@ Clone Task Validation
 - Package already exists in repository
 - Iterating on existing package
 
+## Edit Task Validation
+
+The Engine validates edit tasks to ensure source revisions meet requirements:
+
+```
+Edit Task Validation
+        ↓
+  Fetch Source Revision
+        ↓
+  Check Same Package? ──No──> Reject
+        │
+       Yes
+        ↓
+  Check if Placeholder? ──Yes──> Reject
+        │
+        No
+        ↓
+  Check Published? ──No──> Reject
+        │
+       Yes
+        ↓
+  Allow Edit
+```
+
+### Edit Constraint Check: Source Package Revision Validation
+
+The new package revision must be from the same package as the source package revision since we are iterating on the existing package.
+
+**Validation process:**
+1. **Fetch source revision** from specified reference
+2. **Verify same package** (same repository and package name)
+5. **Check if published** (only published revisions can be edited)
+6. **Allow if all checks pass**
+
+**Error messages:**
+- "source revision must be from same package {repo}/{package}"
+- "source revision must be published"
+
+**Rationale:**
+- Edit creates new revisions from existing packages in the same repository
+- Placeholder package revisions represent unstable main branch state
+- Only published revisions provide stable source for editing
+
+### Edit Constraint Check: Exclude Placeholder Package Revision
+
+The source package revision cannot be a placeholder package revision (identified by `Revision == -1` and `WorkspaceName` matching the Git repository's branch)
+
+
+**Validation process:**
+1. **Fetch source revision** from specified reference
+2. **Resolve repository details** for the source package revision
+3. **Check if placeholder** (Revision == -1 and WorkspaceName matches repo Git branch)
+4. **Reject if placeholder** package revision
+5. **Allow if not placeholder**
+
+**Error message:**
+- "source revision may not be the placeholder package revision {repo}/{name}"
+
+**Rationale:**
+- Placeholder package revisions are not fixed revisions
+- Editing from unstable main/branch-HEAD state is not supported
+- Prevents creating revisions from non-deterministic sources
+
 ## Upgrade Task Validation
 
-The Engine validates upgrade tasks to ensure source revisions are published:
+The Engine validates upgrade tasks to ensure the three source revisions meet requirements:
 
 ### Upgrade Source Validation
 
@@ -279,6 +368,18 @@ Upgrade Task Validation
        Yes
         ↓
   Continue
+        ↓
+  Resolve Repository Containing Proposed New Upstream
+        ↓
+  Upstream is Placeholder? ──Yes──> Reject
+        │
+        No
+        ↓
+  Resolve Repository Containing Local Revision
+        ↓
+  Local Revision is Placeholder? ──Yes──> Reject
+        │
+        No
         ↓
   Allow Upgrade
 ```
@@ -304,14 +405,41 @@ Upgrade Task Validation
 ### Upgrade Source Requirements
 
 **Required sources:**
-- **OldUpstream**: The upstream version currently used
-- **NewUpstream**: The upstream version to upgrade to
+- **OldUpstream**: The package's current upstream version
+- **NewUpstream**: The upstream version to which to upgrade
 - **LocalPackageRevision**: The local package revision to upgrade
 
 **All sources must be:**
 - Published lifecycle state
 - Accessible in repository
 - Valid package revisions
+
+### Placeholder Package Revision Check
+
+Neither the target upstream package revision (the new revision being upgraded to) nor the package revision specified for upgrade can be a placeholder package revision (identified by `Revision == -1` and `WorkspaceName` matching the repository's Git branch)
+
+**Validation process:**
+1. **Fetch target upstream revision** (NewUpstream)
+2. **Resolve repository details** for the target upstream package revision
+3. **Check if placeholder** (revision == -1 and workspaceName matches repo Git branch)
+4. **Reject if target upstream is placeholder**
+5. **Fetch local package revision** to be upgraded
+6. **Resolve repository details** for the local package revision
+7. **Check if placeholder** (revision == -1 and workspaceName matches repo Git branch)
+8. **Reject if local revision is placeholder**
+9. **Allow if neither is placeholder**
+
+**Error messages:**
+- "target upstream revision may not be the placeholder package revision {repo}/{name}"
+- "the placeholder package revision {repo}/{name} may not be upgraded"
+
+**Rationale:**
+- Upgrade performs three-way merge requiring stable source revisions
+- Placeholder package revisions represent unstable main branch state
+- Using placeholder revisions would produce non-deterministic upgrade results
+- Prevents upgrading to non-fixed revision states
+      - Validation on clone and edit operations precludes possibilty of old upstream being a placeholder
+
 
 ## Package Path Overlap Validation
 

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -24,6 +24,7 @@ import (
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/util"
+	pkgerrors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -199,7 +200,7 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 	var upstreamRepo configapi.Repository
 	err := referenceResolver.ResolveReference(ctx, namespace, packageRevision.Key().RKey().Name, &upstreamRepo)
 	if err != nil {
-		return false, fmt.Errorf("failed to resolve repository reference for %q when checking placeholder revision: %v", packageRevision.Key().RKey().Name, err)
+		return false, pkgerrors.Wrapf(err, "failed to resolve repository reference for %q when checking placeholder revision: %v", packageRevision.Key().RKey().Name, err)
 	}
 
 	if upstreamRepo.Spec.Git != nil && packageRevision.Key().WorkspaceName == upstreamRepo.Spec.Git.Branch {

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -15,12 +15,14 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -187,4 +189,23 @@ func PathsOverlap(path1, path2 string) bool {
 		return true
 	}
 	return false
+}
+
+func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referenceResolver ReferenceResolver, packageRevision PackageRevision) (bool, error) {
+	if packageRevision.Key().Revision != -1 {
+		return false, nil
+	}
+
+	var upstreamRepo configapi.Repository
+	err := referenceResolver.ResolveReference(ctx, namespace, packageRevision.Key().RKey().Name, &upstreamRepo)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve repository reference for %q when checking placeholder revision: %v", packageRevision.Key().RKey().Name, err)
+	}
+
+	if upstreamRepo.Spec.Git != nil && packageRevision.Key().WorkspaceName == upstreamRepo.Spec.Git.Branch {
+		// We don't allow many operations on placeholder package revisions - return an error alongside true to emphasise its nature
+		return true, fmt.Errorf("%s/%s is a placeholder package revision", packageRevision.Key().RKey().Name, packageRevision.KubeObjectName())
+	}
+
+	return false, nil
 }

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -203,8 +203,7 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 	}
 
 	if upstreamRepo.Spec.Git != nil && packageRevision.Key().WorkspaceName == upstreamRepo.Spec.Git.Branch {
-		// We don't allow many operations on placeholder package revisions - return an error alongside true to emphasise its nature
-		return true, fmt.Errorf("%s/%s is a placeholder package revision", packageRevision.Key().RKey().Name, packageRevision.KubeObjectName())
+		return true, nil
 	}
 
 	return false, nil

--- a/pkg/repository/util_test.go
+++ b/pkg/repository/util_test.go
@@ -15,10 +15,13 @@
 package repository
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -245,4 +248,81 @@ func TestValidatePackagePathOverlap(t *testing.T) {
 		packageName: "new",
 	}
 	assert.NoError(t, ValidatePackagePathOverlap(newPr, []PackageRevision{differentRepoRev}))
+}
+
+type fakeReferenceResolver struct {
+	repo *configapi.Repository
+	err  error
+}
+
+func (f *fakeReferenceResolver) ResolveReference(_ context.Context, _, _ string, result Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if repo, ok := result.(*configapi.Repository); ok {
+		*repo = *f.repo
+	}
+	return nil
+}
+
+func TestPackageRevisionIsPlaceholder(t *testing.T) {
+	tests := []struct {
+		name     string
+		pr       PackageRevision
+		resolver ReferenceResolver
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name: "published revision is not placeholder",
+			pr:   &fakePackageRevision{revision: 1, workspaceName: "main", repoName: "repo"},
+			want: false,
+		},
+		{
+			name: "draft with matching git branch is placeholder",
+			pr:   &fakePackageRevision{revision: -1, workspaceName: "main", repoName: "repo"},
+			resolver: &fakeReferenceResolver{repo: &configapi.Repository{
+				Spec: configapi.RepositorySpec{Git: &configapi.GitRepository{Branch: "main"}},
+			}},
+			want: true,
+		},
+		{
+			name: "draft with non-matching git branch is not placeholder",
+			pr:   &fakePackageRevision{revision: -1, workspaceName: "dev", repoName: "repo"},
+			resolver: &fakeReferenceResolver{repo: &configapi.Repository{
+				Spec: configapi.RepositorySpec{Git: &configapi.GitRepository{Branch: "main"}},
+			}},
+			want: false,
+		},
+		{
+			name: "draft with no git config is not placeholder",
+			pr:   &fakePackageRevision{revision: -1, workspaceName: "main", repoName: "repo"},
+			resolver: &fakeReferenceResolver{repo: &configapi.Repository{
+				Spec: configapi.RepositorySpec{},
+			}},
+			want: false,
+		},
+		{
+			name:     "resolver error returns error",
+			pr:       &fakePackageRevision{revision: -1, workspaceName: "main", repoName: "repo"},
+			resolver: &fakeReferenceResolver{err: fmt.Errorf("not found")},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := tt.resolver
+			if resolver == nil {
+				resolver = &fakeReferenceResolver{repo: &configapi.Repository{}}
+			}
+			got, err := PackageRevisionIsPlaceholder(context.Background(), "ns", resolver, tt.pr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
 }

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -125,7 +125,7 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 	// reasonable to assume no error: we would not have reached this point
 	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
 	// encountered an error
-	m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
+	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
 	// We only allow clone to create new revisions from non-placeholder package revisions
 	if upstreamKey.Revision == -1 && upstreamKey.WorkspaceName == upstreamRepo.Spec.Git.Branch {
 		return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", repoName, upstreamRevision.KubeObjectName())

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -118,6 +118,19 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, fmt.Errorf("failed to fetch package revision %q: %w", ref.Name, err)
 	}
 
+	upstreamKey := upstreamRevision.Key()
+	repoName := upstreamKey.RKey().Name
+
+	var upstreamRepo configapi.Repository
+	// reasonable to assume no error: we would not have reached this point
+	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
+	// encountered an error
+	m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
+	// We only allow clone to create new revisions from non-placeholder package revisions
+	if upstreamKey.Revision == -1 && upstreamKey.WorkspaceName == upstreamRepo.Spec.Git.Branch {
+		return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", repoName, upstreamRevision.KubeObjectName())
+	}
+
 	resources, err := upstreamRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, fmt.Errorf("cannot read contents of package %q: %w", ref.Name, err)

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -122,13 +122,15 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 	repoName := upstreamKey.RKey().Name
 
 	var upstreamRepo configapi.Repository
-	// reasonable to assume no error: we would not have reached this point
-	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
-	// encountered an error
-	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
-	// We only allow clone to create new revisions from non-placeholder package revisions
-	if upstreamKey.Revision == -1 && upstreamKey.WorkspaceName == upstreamRepo.Spec.Git.Branch {
-		return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", repoName, upstreamRevision.KubeObjectName())
+	err = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
+	if err == nil {
+		if upstreamKey.Revision == -1 &&
+			upstreamRepo.Spec.Git != nil && upstreamKey.WorkspaceName == upstreamRepo.Spec.Git.Branch {
+			// We only allow clone to create new revisions from non-placeholder package revisions
+			return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", repoName, upstreamRevision.KubeObjectName())
+		}
+	} else {
+		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", repoName, err)
 	}
 
 	resources, err := upstreamRevision.GetResources(ctx)

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -119,12 +119,12 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 	}
 
 	upstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, upstreamRevision)
-	if upstreamIsPlaceholder {
-		// We only allow clone to create new revisions from non-placeholder package revisions
-		return repository.PackageResources{}, fmt.Errorf("upstream revision %s", err)
-	}
 	if err != nil {
 		return repository.PackageResources{}, err
+	}
+	if upstreamIsPlaceholder {
+		// We only allow clone to create new revisions from non-placeholder package revisions
+		return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", upstreamRevision.Key().RKey().Name, upstreamRevision.KubeObjectName())
 	}
 
 	resources, err := upstreamRevision.GetResources(ctx)

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -118,19 +118,13 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, fmt.Errorf("failed to fetch package revision %q: %w", ref.Name, err)
 	}
 
-	upstreamKey := upstreamRevision.Key()
-	repoName := upstreamKey.RKey().Name
-
-	var upstreamRepo configapi.Repository
-	err = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &upstreamRepo)
-	if err == nil {
-		if upstreamKey.Revision == -1 &&
-			upstreamRepo.Spec.Git != nil && upstreamKey.WorkspaceName == upstreamRepo.Spec.Git.Branch {
-			// We only allow clone to create new revisions from non-placeholder package revisions
-			return repository.PackageResources{}, fmt.Errorf("upstream revision may not be the placeholder package revision %s/%s", repoName, upstreamRevision.KubeObjectName())
-		}
-	} else {
-		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", repoName, err)
+	upstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, upstreamRevision)
+	if upstreamIsPlaceholder {
+		// We only allow clone to create new revisions from non-placeholder package revisions
+		return repository.PackageResources{}, fmt.Errorf("upstream revision %s", err)
+	}
+	if err != nil {
+		return repository.PackageResources{}, err
 	}
 
 	resources, err := upstreamRevision.GetResources(ctx)

--- a/pkg/task/clone.go
+++ b/pkg/task/clone.go
@@ -120,7 +120,7 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 
 	upstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, upstreamRevision)
 	if err != nil {
-		return repository.PackageResources{}, err
+		return repository.PackageResources{}, pkgerrors.Wrap(err, "error checking for placeholder package revision")
 	}
 	if upstreamIsPlaceholder {
 		// We only allow clone to create new revisions from non-placeholder package revisions

--- a/pkg/task/clone_test.go
+++ b/pkg/task/clone_test.go
@@ -380,7 +380,11 @@ func TestCloneReferenceBasicAuth(t *testing.T) {
 	assert.NoErrorf(t, err, "task apply failed: %+v", err)
 
 	cpm.task.Clone.Upstream.UpstreamRef.Name = placeholderPackageName
+	origWorkspaceName := packageRevision.PrKey.WorkspaceName
 	packageRevision.PrKey.WorkspaceName = "main"
+	t.Cleanup(func() {
+		packageRevision.PrKey.WorkspaceName = origWorkspaceName
+	})
 
 	_, _, err = cpm.apply(context.Background(), repository.PackageResources{})
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")

--- a/pkg/task/clone_test.go
+++ b/pkg/task/clone_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,9 +36,82 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
+	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
 	gitserver "github.com/nephio-project/porch/test/git/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	repositoryNamespace    = "test-namespace"
+	repositoryName         = "repo"
+	pkg                    = "1234567890"
+	revision               = -1
+	workspace              = "ws"
+	packageName            = "repo.1234567890.ws"
+	placeholderPackageName = "repo.1234567890.main"
+	packageRevision        = &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: repositoryNamespace,
+					Name:      repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecyclePublished,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+		Kptfile: kptfilev1.KptFile{
+			Upstream: &kptfilev1.Upstream{
+				Type: "git",
+				Git: &kptfilev1.Git{
+					Repo:      "dummy",
+					Directory: "dummy",
+					Ref:       "dummy",
+				},
+			},
+			UpstreamLock: &kptfilev1.UpstreamLock{
+				Type: "git",
+				Git: &kptfilev1.GitLock{
+					Repo:      "dummy",
+					Directory: "dummy",
+					Ref:       "dummy",
+					Commit:    "dummy",
+				},
+			},
+		},
+	}
+	repo = &fake.Repository{
+		PackageRevisions: []repository.PackageRevision{
+			packageRevision,
+		},
+	}
+	repoOpener = &fakeRepositoryOpener{
+		repository: repo,
+	}
 )
 
 func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
@@ -266,4 +340,48 @@ func TestCloneGitBasicAuth(t *testing.T) {
 	}
 
 	t.Logf("%v", r)
+}
+
+func TestCloneReferenceBasicAuth(t *testing.T) {
+	testdata, err := filepath.Abs(filepath.Join(".", "testdata", "clone"))
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %+v", err)
+	}
+
+	auth := randomCredentials()
+	gogitRepo := createRepoWithContents(t, testdata)
+
+	repo, err := gitserver.NewRepo(gogitRepo, gitserver.WithBasicAuth(auth.username, auth.password))
+	if err != nil {
+		t.Fatalf("NewRepo failed: %+v", err)
+	}
+
+	addr := startGitServer(t, repo)
+	res := &fakeReferenceResolver{address: addr}
+
+	cpm := clonePackageMutation{
+		task: &porchapi.Task{
+			Type: "clone",
+			Clone: &porchapi.PackageCloneTaskSpec{
+				Upstream: porchapi.UpstreamPackage{
+					UpstreamRef: &porchapi.PackageRevisionRef{Name: packageName},
+				},
+			},
+		},
+		namespace:                  repositoryNamespace,
+		name:                       "test-configmap",
+		repoOperationRetryAttempts: 3,
+		credentialResolver:         auth,
+		referenceResolver:          res,
+		repoOpener:                 repoOpener,
+	}
+
+	_, _, err = cpm.apply(context.Background(), repository.PackageResources{})
+	assert.NoErrorf(t, err, "task apply failed: %+v", err)
+
+	cpm.task.Clone.Upstream.UpstreamRef.Name = placeholderPackageName
+	packageRevision.PrKey.WorkspaceName = "main"
+
+	_, _, err = cpm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
 }

--- a/pkg/task/clone_test.go
+++ b/pkg/task/clone_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
 	gitserver "github.com/nephio-project/porch/test/git/pkg"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -379,6 +380,12 @@ func TestCloneReferenceBasicAuth(t *testing.T) {
 	_, _, err = cpm.apply(context.Background(), repository.PackageResources{})
 	assert.NoErrorf(t, err, "task apply failed: %+v", err)
 
+	cpm.referenceResolver = (&errorAfterNReferenceResolver{r: res, err: errors.New("error resolving reference")}).startAt(1)
+
+	_, _, err = cpm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "failed to resolve repository reference")
+
+	cpm.referenceResolver = res
 	cpm.task.Clone.Upstream.UpstreamRef.Name = placeholderPackageName
 	origWorkspaceName := packageRevision.PrKey.WorkspaceName
 	packageRevision.PrKey.WorkspaceName = "main"

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -40,7 +41,7 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 
 	sourceRef := m.task.Edit.Source
 
-	revision, err := (&repository.PackageFetcher{
+	sourceRevision, err := (&repository.PackageFetcher{
 		RepoOpener:        m.repoOpener,
 		ReferenceResolver: m.referenceResolver,
 	}).FetchRevision(ctx, sourceRef, m.namespace)
@@ -48,18 +49,31 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 		return repository.PackageResources{}, nil, fmt.Errorf("failed to fetch package %q: %w", sourceRef.Name, err)
 	}
 
+	sourceRevisionKey := sourceRevision.Key()
+	repoName := sourceRevisionKey.RKey().Name
+
 	// We only allow edit to create new revision from the same package.
-	if revision.Key().PkgKey.ToPkgPathname() != m.packageName ||
-		revision.Key().PkgKey.RKey().Name != m.repositoryName {
+	if sourceRevisionKey.PkgKey.ToPkgPathname() != m.packageName ||
+		repoName != m.repositoryName {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be from same package %s/%s", m.repositoryName, m.packageName)
 	}
 
-	// We only allow edit to create new revisions from published packages.
-	if !porchapi.LifecycleIsPublished(revision.Lifecycle(ctx)) {
+	var sourceRepo configapi.Repository
+	// reasonable to assume no error: we would not have reached this point
+	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
+	// encountered an error
+	m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
+	// We only allow edit to create new revisions from non-placeholder package revisions
+	if sourceRevisionKey.Revision == -1 && sourceRevisionKey.WorkspaceName == sourceRepo.Spec.Git.Branch {
+		return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", repoName, sourceRevision.KubeObjectName())
+	}
+
+	// We only allow edit to create new revisions from published package revisions.
+	if !porchapi.LifecycleIsPublished(sourceRevision.Lifecycle(ctx)) {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be published")
 	}
 
-	sourceResources, err := revision.GetResources(ctx)
+	sourceResources, err := sourceRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, nil, fmt.Errorf("cannot read contents of package %q: %w", sourceRef.Name, err)
 	}

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -22,6 +22,7 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/klog/v2"
 )
 
 type editPackageMutation struct {
@@ -59,13 +60,15 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	}
 
 	var sourceRepo configapi.Repository
-	// reasonable to assume no error: we would not have reached this point
-	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
-	// encountered an error
-	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
-	// We only allow edit to create new revisions from non-placeholder package revisions
-	if sourceRevisionKey.Revision == -1 && sourceRevisionKey.WorkspaceName == sourceRepo.Spec.Git.Branch {
-		return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", repoName, sourceRevision.KubeObjectName())
+	err = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
+	if err == nil {
+		if sourceRevisionKey.Revision == -1 &&
+			sourceRepo.Spec.Git != nil && sourceRevisionKey.WorkspaceName == sourceRepo.Spec.Git.Branch {
+			// We only allow edit to create new revisions from non-placeholder package revisions
+			return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", repoName, sourceRevision.KubeObjectName())
+		}
+	} else {
+		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", repoName, err)
 	}
 
 	// We only allow edit to create new revisions from published package revisions.

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -62,7 +62,7 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	// reasonable to assume no error: we would not have reached this point
 	// if the previous ResolveReference call in PackageFetcher.FetchRevision had
 	// encountered an error
-	m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
+	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
 	// We only allow edit to create new revisions from non-placeholder package revisions
 	if sourceRevisionKey.Revision == -1 && sourceRevisionKey.WorkspaceName == sourceRepo.Spec.Git.Branch {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", repoName, sourceRevision.KubeObjectName())

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -55,12 +55,12 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 	}
 
 	sourceIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, sourceRevision)
-	if sourceIsPlaceholder {
-		// We only allow edit to create new revisions from non-placeholder package revisions
-		return repository.PackageResources{}, nil, fmt.Errorf("source revision %s", err)
-	}
 	if err != nil {
 		return repository.PackageResources{}, nil, err
+	}
+	if sourceIsPlaceholder {
+		// We only allow edit to create new revisions from non-placeholder package revisions
+		return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", sourceRevision.Key().RKey().Name, sourceRevision.KubeObjectName())
 	}
 
 	// We only allow edit to create new revisions from published package revisions.

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -20,6 +20,7 @@ import (
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
+	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -56,7 +57,7 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 
 	sourceIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, sourceRevision)
 	if err != nil {
-		return repository.PackageResources{}, nil, err
+		return repository.PackageResources{}, nil, pkgerrors.Wrap(err, "error checking for placeholder package revision")
 	}
 	if sourceIsPlaceholder {
 		// We only allow edit to create new revisions from non-placeholder package revisions

--- a/pkg/task/edit.go
+++ b/pkg/task/edit.go
@@ -19,10 +19,8 @@ import (
 	"fmt"
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
-	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel/trace"
-	"k8s.io/klog/v2"
 )
 
 type editPackageMutation struct {
@@ -50,25 +48,19 @@ func (m *editPackageMutation) apply(ctx context.Context, resources repository.Pa
 		return repository.PackageResources{}, nil, fmt.Errorf("failed to fetch package %q: %w", sourceRef.Name, err)
 	}
 
-	sourceRevisionKey := sourceRevision.Key()
-	repoName := sourceRevisionKey.RKey().Name
-
 	// We only allow edit to create new revision from the same package.
-	if sourceRevisionKey.PkgKey.ToPkgPathname() != m.packageName ||
-		repoName != m.repositoryName {
+	if sourceRevision.Key().PkgKey.ToPkgPathname() != m.packageName ||
+		sourceRevision.Key().RKey().Name != m.repositoryName {
 		return repository.PackageResources{}, nil, fmt.Errorf("source revision must be from same package %s/%s", m.repositoryName, m.packageName)
 	}
 
-	var sourceRepo configapi.Repository
-	err = m.referenceResolver.ResolveReference(ctx, m.namespace, repoName, &sourceRepo)
-	if err == nil {
-		if sourceRevisionKey.Revision == -1 &&
-			sourceRepo.Spec.Git != nil && sourceRevisionKey.WorkspaceName == sourceRepo.Spec.Git.Branch {
-			// We only allow edit to create new revisions from non-placeholder package revisions
-			return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", repoName, sourceRevision.KubeObjectName())
-		}
-	} else {
-		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", repoName, err)
+	sourceIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, sourceRevision)
+	if sourceIsPlaceholder {
+		// We only allow edit to create new revisions from non-placeholder package revisions
+		return repository.PackageResources{}, nil, fmt.Errorf("source revision %s", err)
+	}
+	if err != nil {
+		return repository.PackageResources{}, nil, err
 	}
 
 	// We only allow edit to create new revisions from published package revisions.

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -25,6 +25,8 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEdit(t *testing.T) {
@@ -78,7 +80,7 @@ info:
 
 	epm := editPackageMutation{
 		task: &porchapi.Task{
-			Type: "edit",
+			Type: porchapi.TaskTypeEdit,
 			Edit: &porchapi.PackageEditTaskSpec{
 				Source: &porchapi.PackageRevisionRef{
 					Name: packageName,
@@ -114,10 +116,104 @@ info:
 	}
 }
 
+func TestEditPlaceholder(t *testing.T) {
+	repositoryNamespace := "test-namespace"
+	repositoryName := "repo"
+	pkg := "1234567890"
+	revision := -1
+	workspace := "main"
+	placeholderPackageName := "repo.1234567890.main"
+	packageRevision := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: repositoryNamespace,
+					Name:      repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecyclePublished,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+	repo := &fake.Repository{
+		PackageRevisions: []repository.PackageRevision{
+			packageRevision,
+		},
+	}
+	repoOpener := &fakeRepositoryOpener{
+		repository: repo,
+	}
+
+	epm := editPackageMutation{
+		task: &porchapi.Task{
+			Type: porchapi.TaskTypeEdit,
+			Edit: &porchapi.PackageEditTaskSpec{
+				Source: &porchapi.PackageRevisionRef{
+					Name: placeholderPackageName,
+				},
+			},
+		},
+
+		namespace:         "test-namespace",
+		packageName:       pkg,
+		repositoryName:    repositoryName,
+		referenceResolver: &fakeReferenceResolver{},
+		repoOpener:        repoOpener,
+	}
+	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+}
+
 // Implementation of the ReferenceResolver interface for testing.
-type fakeReferenceResolver struct{}
+type fakeReferenceResolver struct {
+	address string
+}
 
 func (f *fakeReferenceResolver) ResolveReference(ctx context.Context, namespace, name string, result repository.Object) error {
+	repo, ok := result.(*configapi.Repository)
+	if ok {
+		*repo = configapi.Repository{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       configapi.TypeRepository.Kind,
+				APIVersion: configapi.TypeRepository.APIVersion(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			},
+			Spec: configapi.RepositorySpec{
+				Deployment: false,
+				Type:       configapi.RepositoryTypeGit,
+				Git: &configapi.GitRepository{
+					Repo:      f.address,
+					Branch:    "main",
+					Directory: "configmap",
+				},
+			},
+		}
+		result = repo
+	}
 	return nil
 }
 

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -182,7 +182,7 @@ info:
 		repoOpener:        repoOpener,
 	}
 	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
-	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error editing the placeholder package revision")
 }
 
 // Implementation of the ReferenceResolver interface for testing.

--- a/pkg/task/edit_test.go
+++ b/pkg/task/edit_test.go
@@ -17,6 +17,7 @@ package task
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,6 +26,7 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -165,6 +167,7 @@ info:
 		repository: repo,
 	}
 
+	res := &fakeReferenceResolver{}
 	epm := editPackageMutation{
 		task: &porchapi.Task{
 			Type: porchapi.TaskTypeEdit,
@@ -178,11 +181,18 @@ info:
 		namespace:         "test-namespace",
 		packageName:       pkg,
 		repositoryName:    repositoryName,
-		referenceResolver: &fakeReferenceResolver{},
+		referenceResolver: res,
 		repoOpener:        repoOpener,
 	}
 	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error editing the placeholder package revision")
+
+	epm.referenceResolver = (&errorAfterNReferenceResolver{r: res, err: errors.New("error resolving reference")}).startAt(1)
+
+	_, _, err = epm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "failed to resolve repository reference")
+
+	epm.referenceResolver = res
 }
 
 // Implementation of the ReferenceResolver interface for testing.
@@ -215,6 +225,28 @@ func (f *fakeReferenceResolver) ResolveReference(ctx context.Context, namespace,
 		result = repo
 	}
 	return nil
+}
+
+// Implementation of the ReferenceResolver interface for testing.
+// For the first N calls to ResolveReference, it delegates to the provided, working resolver.
+// On the N+1th call, it returns the provided error.
+type errorAfterNReferenceResolver struct {
+	r                  repository.ReferenceResolver
+	err                error
+	successesRemaining atomic.Int64
+}
+
+func (f *errorAfterNReferenceResolver) startAt(successesRemaining int64) *errorAfterNReferenceResolver {
+	f.successesRemaining.Store(successesRemaining)
+	return f
+}
+
+func (f *errorAfterNReferenceResolver) ResolveReference(ctx context.Context, namespace, name string, result repository.Object) error {
+	if f.successesRemaining.Load() > 0 {
+		f.successesRemaining.Add(-1)
+		return f.r.ResolveReference(ctx, namespace, name, result)
+	}
+	return f.err
 }
 
 type fakeRepositoryOpener struct {

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -16,9 +16,11 @@ package task
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kptdev/kpt/pkg/lib/kptops"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
@@ -58,11 +60,37 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision for target upstream %q", targetUpstreamRef.Name)
 	}
+	targetUpstreamKey := targetUpstreamRevision.Key()
+	targetUpstreamRepoName := targetUpstreamKey.RKey().Name
+	var targetUpstreamRepo configapi.Repository
+	// reasonable to assume no error: we would not have reached this point
+	// if the previous ResolveReference call in packageFetcher.FetchRevision had
+	// encountered an error
+	m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
+	// We only allow upgrade to upgrade to non-placeholder package revisions
+	if targetUpstreamKey.Revision == -1 && targetUpstreamKey.WorkspaceName == targetUpstreamRepo.Spec.Git.Branch {
+		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRepoName, targetUpstreamRevision.KubeObjectName())
+	}
 	targetUpstreamResources, err := targetUpstreamRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching resources for target upstream %q", targetUpstreamRef.Name)
 	}
 
+	localRevision, err := packageFetcher.FetchRevision(ctx, &localRef, m.namespace)
+	if err != nil {
+		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision %q to be upgraded", targetUpstreamRef.Name)
+	}
+	localRevisionKey := localRevision.Key()
+	localRevisionRepoName := localRevisionKey.RKey().Name
+	var localRevisionRepo configapi.Repository
+	// reasonable to assume no error: we would not have reached this point
+	// if the previous ResolveReference call in packageFetcher.FetchRevision had
+	// encountered an error
+	m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
+	// We only allow upgrade to upgrade to non-placeholder package revisions
+	if localRevisionKey.Revision == -1 && localRevisionKey.WorkspaceName == localRevisionRepo.Spec.Git.Branch {
+		return repository.PackageResources{}, nil, fmt.Errorf("the placeholder package revision %s/%s may not be upgraded", localRevisionRepoName, localRevision.KubeObjectName())
+	}
 	localResources, err := packageFetcher.FetchResources(ctx, &localRef, m.namespace)
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching resources for local revision %q", localRef.Name)

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -63,13 +63,15 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	targetUpstreamKey := targetUpstreamRevision.Key()
 	targetUpstreamRepoName := targetUpstreamKey.RKey().Name
 	var targetUpstreamRepo configapi.Repository
-	// reasonable to assume no error: we would not have reached this point
-	// if the previous ResolveReference call in packageFetcher.FetchRevision had
-	// encountered an error
-	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
-	// We only allow upgrade to upgrade to non-placeholder package revisions
-	if targetUpstreamKey.Revision == -1 && targetUpstreamKey.WorkspaceName == targetUpstreamRepo.Spec.Git.Branch {
-		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRepoName, targetUpstreamRevision.KubeObjectName())
+	err = m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
+	if err == nil {
+		if targetUpstreamKey.Revision == -1 &&
+			targetUpstreamRepo.Spec.Git != nil && targetUpstreamKey.WorkspaceName == targetUpstreamRepo.Spec.Git.Branch {
+			// We only allow clone to create new revisions from non-placeholder package revisions
+			return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRepoName, targetUpstreamRevision.KubeObjectName())
+		}
+	} else {
+		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", targetUpstreamRepoName, err)
 	}
 	targetUpstreamResources, err := targetUpstreamRevision.GetResources(ctx)
 	if err != nil {
@@ -78,20 +80,22 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 
 	localRevision, err := packageFetcher.FetchRevision(ctx, &localRef, m.namespace)
 	if err != nil {
-		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision %q to be upgraded", targetUpstreamRef.Name)
+		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision %q to be upgraded", localRef.Name)
 	}
 	localRevisionKey := localRevision.Key()
 	localRevisionRepoName := localRevisionKey.RKey().Name
 	var localRevisionRepo configapi.Repository
-	// reasonable to assume no error: we would not have reached this point
-	// if the previous ResolveReference call in packageFetcher.FetchRevision had
-	// encountered an error
-	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
-	// We only allow upgrade to upgrade to non-placeholder package revisions
-	if localRevisionKey.Revision == -1 && localRevisionKey.WorkspaceName == localRevisionRepo.Spec.Git.Branch {
-		return repository.PackageResources{}, nil, fmt.Errorf("the placeholder package revision %s/%s may not be upgraded", localRevisionRepoName, localRevision.KubeObjectName())
+	err = m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
+	if err == nil {
+		if localRevisionKey.Revision == -1 &&
+			localRevisionRepo.Spec.Git != nil && localRevisionKey.WorkspaceName == localRevisionRepo.Spec.Git.Branch {
+			// We only allow edit to create new revisions from non-placeholder package revisions
+			return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", localRevisionRepoName, localRevision.KubeObjectName())
+		}
+	} else {
+		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", localRevisionRepoName, err)
 	}
-	localResources, err := packageFetcher.FetchResources(ctx, &localRef, m.namespace)
+	localResources, err := localRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching resources for local revision %q", localRef.Name)
 	}

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -66,7 +66,7 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	// reasonable to assume no error: we would not have reached this point
 	// if the previous ResolveReference call in packageFetcher.FetchRevision had
 	// encountered an error
-	m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
+	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
 	// We only allow upgrade to upgrade to non-placeholder package revisions
 	if targetUpstreamKey.Revision == -1 && targetUpstreamKey.WorkspaceName == targetUpstreamRepo.Spec.Git.Branch {
 		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRepoName, targetUpstreamRevision.KubeObjectName())
@@ -86,7 +86,7 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	// reasonable to assume no error: we would not have reached this point
 	// if the previous ResolveReference call in packageFetcher.FetchRevision had
 	// encountered an error
-	m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
+	_ = m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
 	// We only allow upgrade to upgrade to non-placeholder package revisions
 	if localRevisionKey.Revision == -1 && localRevisionKey.WorkspaceName == localRevisionRepo.Spec.Git.Branch {
 		return repository.PackageResources{}, nil, fmt.Errorf("the placeholder package revision %s/%s may not be upgraded", localRevisionRepoName, localRevision.KubeObjectName())

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -62,7 +62,7 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 
 	targetUpstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, targetUpstreamRevision)
 	if err != nil {
-		return repository.PackageResources{}, nil, err
+		return repository.PackageResources{}, nil, pkgerrors.Wrap(err, "error checking for placeholder package revision")
 	}
 	if targetUpstreamIsPlaceholder {
 		// We only allow upgrade to create new revisions with non-placeholder package revisions as target upstream
@@ -81,7 +81,7 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 
 	localIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, localRevision)
 	if err != nil {
-		return repository.PackageResources{}, nil, err
+		return repository.PackageResources{}, nil, pkgerrors.Wrap(err, "error checking for placeholder package revision")
 	}
 	if localIsPlaceholder {
 		// We only allow upgrade to upgrade non-placeholder package revisions

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -61,12 +61,12 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	}
 
 	targetUpstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, targetUpstreamRevision)
-	if targetUpstreamIsPlaceholder {
-		// We only allow upgrade to create new revisions with non-placeholder package revisions as target upstream
-		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision %s", err)
-	}
 	if err != nil {
 		return repository.PackageResources{}, nil, err
+	}
+	if targetUpstreamIsPlaceholder {
+		// We only allow upgrade to create new revisions with non-placeholder package revisions as target upstream
+		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRevision.Key().RKey().Name, targetUpstreamRevision.KubeObjectName())
 	}
 
 	targetUpstreamResources, err := targetUpstreamRevision.GetResources(ctx)
@@ -80,12 +80,12 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	}
 
 	localIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, localRevision)
-	if localIsPlaceholder {
-		// We only allow upgrade to upgrade non-placeholder package revisions
-		return repository.PackageResources{}, nil, fmt.Errorf("source revision %s", err)
-	}
 	if err != nil {
 		return repository.PackageResources{}, nil, err
+	}
+	if localIsPlaceholder {
+		// We only allow upgrade to upgrade non-placeholder package revisions
+		return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", localRevision.Key().RKey().Name, localRevision.KubeObjectName())
 	}
 
 	localResources, err := localRevision.GetResources(ctx)

--- a/pkg/task/upgrade.go
+++ b/pkg/task/upgrade.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/kptdev/kpt/pkg/lib/kptops"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
-	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
@@ -60,19 +59,16 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision for target upstream %q", targetUpstreamRef.Name)
 	}
-	targetUpstreamKey := targetUpstreamRevision.Key()
-	targetUpstreamRepoName := targetUpstreamKey.RKey().Name
-	var targetUpstreamRepo configapi.Repository
-	err = m.referenceResolver.ResolveReference(ctx, m.namespace, targetUpstreamRepoName, &targetUpstreamRepo)
-	if err == nil {
-		if targetUpstreamKey.Revision == -1 &&
-			targetUpstreamRepo.Spec.Git != nil && targetUpstreamKey.WorkspaceName == targetUpstreamRepo.Spec.Git.Branch {
-			// We only allow clone to create new revisions from non-placeholder package revisions
-			return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision may not be the placeholder package revision %s/%s", targetUpstreamRepoName, targetUpstreamRevision.KubeObjectName())
-		}
-	} else {
-		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", targetUpstreamRepoName, err)
+
+	targetUpstreamIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, targetUpstreamRevision)
+	if targetUpstreamIsPlaceholder {
+		// We only allow upgrade to create new revisions with non-placeholder package revisions as target upstream
+		return repository.PackageResources{}, nil, fmt.Errorf("target upstream revision %s", err)
 	}
+	if err != nil {
+		return repository.PackageResources{}, nil, err
+	}
+
 	targetUpstreamResources, err := targetUpstreamRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching resources for target upstream %q", targetUpstreamRef.Name)
@@ -82,19 +78,16 @@ func (m *upgradePackageMutation) apply(ctx context.Context, _ repository.Package
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching revision %q to be upgraded", localRef.Name)
 	}
-	localRevisionKey := localRevision.Key()
-	localRevisionRepoName := localRevisionKey.RKey().Name
-	var localRevisionRepo configapi.Repository
-	err = m.referenceResolver.ResolveReference(ctx, m.namespace, localRevisionRepoName, &localRevisionRepo)
-	if err == nil {
-		if localRevisionKey.Revision == -1 &&
-			localRevisionRepo.Spec.Git != nil && localRevisionKey.WorkspaceName == localRevisionRepo.Spec.Git.Branch {
-			// We only allow edit to create new revisions from non-placeholder package revisions
-			return repository.PackageResources{}, nil, fmt.Errorf("source revision may not be the placeholder package revision %s/%s", localRevisionRepoName, localRevision.KubeObjectName())
-		}
-	} else {
-		klog.Warningf("failed to resolve repository reference for %q when checking placeholder revision: %v", localRevisionRepoName, err)
+
+	localIsPlaceholder, err := repository.PackageRevisionIsPlaceholder(ctx, m.namespace, m.referenceResolver, localRevision)
+	if localIsPlaceholder {
+		// We only allow upgrade to upgrade non-placeholder package revisions
+		return repository.PackageResources{}, nil, fmt.Errorf("source revision %s", err)
 	}
+	if err != nil {
+		return repository.PackageResources{}, nil, err
+	}
+
 	localResources, err := localRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, nil, pkgerrors.Wrapf(err, "error fetching resources for local revision %q", localRef.Name)

--- a/pkg/task/upgrade_test.go
+++ b/pkg/task/upgrade_test.go
@@ -142,7 +142,7 @@ info:
 		repoOpener:        repoOpener,
 	}
 	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
-	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision as new upstream")
 }
 
 func TestUpgradePlaceholderAsLocal(t *testing.T) {
@@ -227,5 +227,5 @@ info:
 		repoOpener:        repoOpener,
 	}
 	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
-	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading the placeholder package revision")
 }

--- a/pkg/task/upgrade_test.go
+++ b/pkg/task/upgrade_test.go
@@ -16,9 +16,12 @@ package task
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 )
@@ -60,4 +63,169 @@ func TestApplyErrorInvalidUpstreamUprade(t *testing.T) {
 	_, _, err := mutation.apply(ctx, resources)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error fetching the resources for package")
+}
+
+func TestUpgradeToPlaceholderAsNewUpstream(t *testing.T) {
+	repositoryNamespace := "test-namespace"
+	repositoryName := "repo"
+	pkg := "1234567890"
+	revision := -1
+	workspace := "main"
+	placeholderPackageName := "repo.1234567890.main"
+	placeholderPackageRevision := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: repositoryNamespace,
+					Name:      repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecyclePublished,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+
+	oldRev := *placeholderPackageRevision
+	oldPackageRevision := &oldRev
+	oldPackageRevision.PrKey.WorkspaceName = "old"
+
+	repo := &fake.Repository{
+		PackageRevisions: []repository.PackageRevision{
+			oldPackageRevision,
+			placeholderPackageRevision,
+		},
+	}
+	repoOpener := &fakeRepositoryOpener{
+		repository: repo,
+	}
+
+	epm := upgradePackageMutation{
+		upgradeTask: &porchapi.Task{
+			Type: porchapi.TaskTypeUpgrade,
+			Upgrade: &porchapi.PackageUpgradeTaskSpec{
+				OldUpstream: porchapi.PackageRevisionRef{
+					Name: "repo.1234567890.old",
+				},
+				NewUpstream: porchapi.PackageRevisionRef{
+					Name: placeholderPackageName,
+				},
+				LocalPackageRevisionRef: porchapi.PackageRevisionRef{
+					Name: "destination",
+				},
+			},
+		},
+
+		namespace:         "test-namespace",
+		pkgName:           pkg,
+		referenceResolver: &fakeReferenceResolver{},
+		repoOpener:        repoOpener,
+	}
+	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+}
+
+func TestUpgradePlaceholderAsLocal(t *testing.T) {
+	repositoryNamespace := "test-namespace"
+	repositoryName := "repo"
+	pkg := "1234567890"
+	revision := -1
+	workspace := "main"
+	placeholderPackageName := "repo.1234567890.main"
+	placeholderPackageRevision := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: repositoryNamespace,
+					Name:      repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecyclePublished,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+
+	oldRev := *placeholderPackageRevision
+	oldPackageRevision := &oldRev
+	oldPackageRevision.PrKey.WorkspaceName = "old"
+
+	newRev := *placeholderPackageRevision
+	newPackageRevision := &newRev
+	newPackageRevision.PrKey.WorkspaceName = "new"
+
+	repo := &fake.Repository{
+		PackageRevisions: []repository.PackageRevision{
+			oldPackageRevision,
+			newPackageRevision,
+			placeholderPackageRevision,
+		},
+	}
+	repoOpener := &fakeRepositoryOpener{
+		repository: repo,
+	}
+
+	epm := upgradePackageMutation{
+		upgradeTask: &porchapi.Task{
+			Type: porchapi.TaskTypeUpgrade,
+			Upgrade: &porchapi.PackageUpgradeTaskSpec{
+				OldUpstream: porchapi.PackageRevisionRef{
+					Name: "repo.1234567890.old",
+				},
+				NewUpstream: porchapi.PackageRevisionRef{
+					Name: "repo.1234567890.new",
+				},
+				LocalPackageRevisionRef: porchapi.PackageRevisionRef{
+					Name: placeholderPackageName,
+				},
+			},
+		},
+
+		namespace:         "test-namespace",
+		pkgName:           pkg,
+		referenceResolver: &fakeReferenceResolver{},
+		repoOpener:        repoOpener,
+	}
+	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
 }

--- a/pkg/task/upgrade_test.go
+++ b/pkg/task/upgrade_test.go
@@ -23,7 +23,12 @@ import (
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/externalrepo/fake"
 	"github.com/nephio-project/porch/pkg/repository"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	res = &fakeReferenceResolver{}
 )
 
 func createMockedResources() repository.PackageResources {
@@ -120,7 +125,7 @@ info:
 		repository: repo,
 	}
 
-	epm := upgradePackageMutation{
+	mutation := upgradePackageMutation{
 		upgradeTask: &porchapi.Task{
 			Type: porchapi.TaskTypeUpgrade,
 			Upgrade: &porchapi.PackageUpgradeTaskSpec{
@@ -138,11 +143,18 @@ info:
 
 		namespace:         "test-namespace",
 		pkgName:           pkg,
-		referenceResolver: &fakeReferenceResolver{},
+		referenceResolver: res,
 		repoOpener:        repoOpener,
 	}
-	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
+	_, _, err := mutation.apply(context.Background(), repository.PackageResources{})
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision as new upstream")
+
+	mutation.referenceResolver = (&errorAfterNReferenceResolver{r: res, err: errors.New("error resolving reference")}).startAt(2)
+
+	_, _, err = mutation.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "failed to resolve repository reference")
+
+	mutation.referenceResolver = res
 }
 
 func TestUpgradePlaceholderAsLocal(t *testing.T) {
@@ -205,7 +217,7 @@ info:
 		repository: repo,
 	}
 
-	epm := upgradePackageMutation{
+	mutation := upgradePackageMutation{
 		upgradeTask: &porchapi.Task{
 			Type: porchapi.TaskTypeUpgrade,
 			Upgrade: &porchapi.PackageUpgradeTaskSpec{
@@ -223,9 +235,16 @@ info:
 
 		namespace:         "test-namespace",
 		pkgName:           pkg,
-		referenceResolver: &fakeReferenceResolver{},
+		referenceResolver: res,
 		repoOpener:        repoOpener,
 	}
-	_, _, err := epm.apply(context.Background(), repository.PackageResources{})
+	_, _, err := mutation.apply(context.Background(), repository.PackageResources{})
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading the placeholder package revision")
+
+	mutation.referenceResolver = (&errorAfterNReferenceResolver{r: res, err: errors.New("error resolving reference")}).startAt(4)
+
+	_, _, err = mutation.apply(context.Background(), repository.PackageResources{})
+	assert.ErrorContains(t, err, "failed to resolve repository reference")
+
+	mutation.referenceResolver = res
 }

--- a/test/e2e/api/rpkg_clone_test.go
+++ b/test/e2e/api/rpkg_clone_test.go
@@ -263,11 +263,9 @@ data:
 	upgradePr = t.UpdateApprovalF(upgradePr)
 
 	basensMain := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: suiteutils.TestBlueprintsRepoName}, Package: basensPackage}, Revision: -1})
-	upgradePr.ObjectMeta.Labels = nil
-	upgradePr.Spec.Lifecycle = ""
-	upgradePr.Spec.WorkspaceName = testWorkspace + "-main-upgrade"
+	upgradePrTwo := t.CreatePackageSkeleton(gitRepository, "testns", testWorkspace+"-main-upgrade")
 
-	upgradePr.Spec.Tasks = []porchapi.Task{{
+	upgradePrTwo.Spec.Tasks = []porchapi.Task{{
 		Type: porchapi.TaskTypeUpgrade,
 		Upgrade: &porchapi.PackageUpgradeTaskSpec{
 			OldUpstream: porchapi.PackageRevisionRef{
@@ -282,10 +280,10 @@ data:
 		},
 	}}
 
-	err := t.Client.Create(t.GetContext(), upgradePr)
+	err := t.Client.Create(t.GetContext(), upgradePrTwo)
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision")
 
-	upgradePr.Spec.Tasks = []porchapi.Task{{
+	upgradePrTwo.Spec.Tasks = []porchapi.Task{{
 		Type: porchapi.TaskTypeUpgrade,
 		Upgrade: &porchapi.PackageUpgradeTaskSpec{
 			OldUpstream: porchapi.PackageRevisionRef{
@@ -300,7 +298,7 @@ data:
 		},
 	}}
 
-	err = t.Client.Create(t.GetContext(), upgradePr)
+	err = t.Client.Create(t.GetContext(), upgradePrTwo)
 	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision")
 }
 

--- a/test/e2e/api/rpkg_clone_test.go
+++ b/test/e2e/api/rpkg_clone_test.go
@@ -20,6 +20,7 @@ import (
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	suiteutils "github.com/nephio-project/porch/test/e2e/suiteutils"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,7 +41,17 @@ func (t *PorchSuite) TestCloneFromUpstream() {
 	var list porchapi.PackageRevisionList
 	t.ListE(&list, client.InNamespace(t.Namespace))
 
-	upstreamPr := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{
+	placeholderUpstreamPr := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			RepoKey: repository.RepositoryKey{
+				Name: suiteutils.TestBlueprintsRepoName,
+			},
+			Package: basensPackage,
+		},
+		WorkspaceName: "main",
+		Revision:      -1})
+
+	realUpstreamPr := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{
 		PkgKey: repository.PackageKey{
 			RepoKey: repository.RepositoryKey{
 				Name: suiteutils.TestBlueprintsRepoName,
@@ -51,20 +62,26 @@ func (t *PorchSuite) TestCloneFromUpstream() {
 	// Register the repository as 'downstream'
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), suiteutils.PorchTestRepoName, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
-	// Create PackageRevision from upstream repo
-	clonedPr := t.CreatePackageSkeleton(suiteutils.PorchTestRepoName, istionsPackage, "clone-upstream-workspace")
+	// Attempt to create PackageRevision from placeholder package revision in upstream repo
+	clonedPr := t.CreatePackageSkeleton(suiteutils.PorchTestRepoName, istionsPackage, testWorkspace)
 	clonedPr.Spec.Tasks = []porchapi.Task{
 		{
 			Type: porchapi.TaskTypeClone,
 			Clone: &porchapi.PackageCloneTaskSpec{
 				Upstream: porchapi.UpstreamPackage{
 					UpstreamRef: &porchapi.PackageRevisionRef{
-						Name: upstreamPr.Name,
+						Name: placeholderUpstreamPr.Name,
 					},
 				},
 			},
 		},
 	}
+
+	err := t.Client.Create(t.GetContext(), clonedPr)
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error cloning from the placeholder package revision")
+
+	// Create PackageRevision properly from upstream repo
+	clonedPr.Spec.Tasks[0].Clone.Upstream.UpstreamRef.Name = realUpstreamPr.Name
 
 	t.CreateF(clonedPr)
 
@@ -237,6 +254,54 @@ data:
 	if _, found := revisionResources.Spec.Resources["resourcequota.yaml"]; !found {
 		t.Errorf("Updated package should contain 'resourcequota.yaml` file")
 	}
+
+	// publish upgraded PackageRevision
+	t.GetF(client.ObjectKeyFromObject(upgradePr), upgradePr)
+	upgradePr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
+	t.UpdateF(upgradePr)
+	upgradePr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
+	upgradePr = t.UpdateApprovalF(upgradePr)
+
+	basensMain := t.MustFindPackageRevision(&list, repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repository.RepositoryKey{Name: suiteutils.TestBlueprintsRepoName}, Package: basensPackage}, Revision: -1})
+	upgradePr.ObjectMeta.Labels = nil
+	upgradePr.Spec.Lifecycle = ""
+	upgradePr.Spec.WorkspaceName = testWorkspace + "-main-upgrade"
+
+	upgradePr.Spec.Tasks = []porchapi.Task{{
+		Type: porchapi.TaskTypeUpgrade,
+		Upgrade: &porchapi.PackageUpgradeTaskSpec{
+			OldUpstream: porchapi.PackageRevisionRef{
+				Name: basensV2.Name,
+			},
+			NewUpstream: porchapi.PackageRevisionRef{
+				Name: basensMain.Name,
+			},
+			LocalPackageRevisionRef: porchapi.PackageRevisionRef{
+				Name: upgradePr.Name,
+			},
+		},
+	}}
+
+	err := t.Client.Create(t.GetContext(), upgradePr)
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision")
+
+	upgradePr.Spec.Tasks = []porchapi.Task{{
+		Type: porchapi.TaskTypeUpgrade,
+		Upgrade: &porchapi.PackageUpgradeTaskSpec{
+			OldUpstream: porchapi.PackageRevisionRef{
+				Name: basensV1.Name,
+			},
+			NewUpstream: porchapi.PackageRevisionRef{
+				Name: basensV2.Name,
+			},
+			LocalPackageRevisionRef: porchapi.PackageRevisionRef{
+				Name: basensMain.Name,
+			},
+		},
+	}}
+
+	err = t.Client.Create(t.GetContext(), upgradePr)
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error upgrading to the placeholder package revision")
 }
 
 func (t *PorchSuite) validateKptfileBasics(kptfile *kptfilev1.KptFile, expectedName string) {

--- a/test/e2e/api/rpkg_edit_test.go
+++ b/test/e2e/api/rpkg_edit_test.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"strings"
+
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	suiteutils "github.com/nephio-project/porch/test/e2e/suiteutils"
@@ -103,6 +105,23 @@ func (t *PorchSuite) TestEditPackageRevision() {
 	assert.Equal(t, porchapi.TaskTypeEdit, tasks[0].Type)
 	assert.NotNil(t, tasks[0].Edit)
 	assert.Equal(t, pr.Name, tasks[0].Edit.Source.Name)
+
+	// Create a new revision with a placeholder package revision as the source.
+	// This is not allowed.
+	editPlaceholderPR := t.CreatePackageSkeleton(repository, packageName, workspace2)
+	editPlaceholderPR.Spec.Tasks = []porchapi.Task{
+		{
+			Type: porchapi.TaskTypeEdit,
+			Edit: &porchapi.PackageEditTaskSpec{
+				Source: &porchapi.PackageRevisionRef{
+					Name: strings.ReplaceAll(editPR.Name, workspaceToAvoidCreationClash, "main"),
+				},
+			},
+		},
+	}
+
+	err := t.Client.Create(t.GetContext(), editPlaceholderPR)
+	assert.ErrorContains(t, err, "placeholder package revision", "Expected error editing the placeholder package revision")
 }
 
 func (t *PorchSuite) TestUpdateResources() {

--- a/test/mockery/mocks/porch/pkg/repository/mock_PackageRevision.go
+++ b/test/mockery/mocks/porch/pkg/repository/mock_PackageRevision.go
@@ -7,7 +7,7 @@ package repository
 import (
 	"context"
 
-	v1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	"github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
 	mock "github.com/stretchr/testify/mock"
@@ -158,8 +158,8 @@ func (_c *MockPackageRevision_GetLock_Call) Run(run func(ctx context.Context)) *
 	return _c
 }
 
-func (_c *MockPackageRevision_GetLock_Call) Return(upstream v1.Upstream, upstreamLock v1.Locator, err error) *MockPackageRevision_GetLock_Call {
-	_c.Call.Return(upstream, upstreamLock, err)
+func (_c *MockPackageRevision_GetLock_Call) Return(upstream v1.Upstream, locator v1.Locator, err error) *MockPackageRevision_GetLock_Call {
+	_c.Call.Return(upstream, locator, err)
 	return _c
 }
 
@@ -392,8 +392,8 @@ func (_c *MockPackageRevision_GetUpstreamLock_Call) Run(run func(ctx context.Con
 	return _c
 }
 
-func (_c *MockPackageRevision_GetUpstreamLock_Call) Return(upstream v1.Upstream, upstreamLock v1.Locator, err error) *MockPackageRevision_GetUpstreamLock_Call {
-	_c.Call.Return(upstream, upstreamLock, err)
+func (_c *MockPackageRevision_GetUpstreamLock_Call) Return(upstream v1.Upstream, locator v1.Locator, err error) *MockPackageRevision_GetUpstreamLock_Call {
+	_c.Call.Return(upstream, locator, err)
 	return _c
 }
 


### PR DESCRIPTION
## Description
- What changed:
    - added validation in the `clone`, `edit`, and `upgrade` task mutations to reject operations that target placeholder/main package revisions.
        - identifying placeholder package revisions by the condition `revision == -1 && workspaceName == repo.Spec.Git.Branch`.
    - each handler now resolves the details of the Porch repository containing the configured source/upstream package revision and checks this condition before proceeding
- Why it's needed:
    - placeholder package revisions discovered in remote Git repositories are not valid targets for `edit`, `clone`, or `upgrade`
    - previously, create operations would succeed, but the package revision lifecycle on the resulting package revisions would fail in later stages
    - validation now rejects their creation with a clear error message
- How it works:
    - in each of `clone.go`, `edit.go`, and `upgrade.go`
        - we fetch the source/upstream revision and resolve its corresponding Repository resource
        - we check whether the revision is a placeholder
            - (`revision == -1` and `workspaceName` matches the repo's configured Git branch)
        - if so, we return an error and fail the operation.
        - the `upgrade` task has several package revisions involved - it checks both the target upstream revision and the local revision being upgraded

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Fixes https://github.com/nephio-project/porch/issues/757

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [x] Documentation added/updated
- [ ] All tests and gating checks pass
