### PR TITLE
Remove --repo-sync-frequency from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,6 @@
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
                 "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
-                "--repo-sync-frequency=60s"
             ],
             "cwd": "${workspaceFolder}",
             "env": {
@@ -53,7 +52,6 @@
                 "--kubeconfig=${env:KUBECONFIG}",
                 "--cache-directory=${workspaceFolder}/.cache",
                 "--function-runner=${env:FUNCTION_RUNNER_IP}:9445",
-                "--repo-sync-frequency=60s",
                 "--cache-type=db",
             ],
             "cwd": "${workspaceFolder}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Remove --repo-sync-frequency from launch.json as it's redundant

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  removed redundant parameter from launch.json
- Why it’s needed: the parameter doesn't exist anymore in Porch and will crash the code at startup when running in vscode
- How it works:  N/A

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
