### PR TITLE
Fix watch recovery after connection failures

### DIFF
--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -94,6 +94,7 @@ func (b *background) run(ctx context.Context) {
 	var events <-chan watch.Event
 	var watcher watch.Interface
 	var bookmark string
+	var consecutiveFailures int
 	defer func() {
 		if watcher != nil {
 			watcher.Stop()
@@ -112,6 +113,12 @@ loop:
 		select {
 		case <-reconnect.channel():
 			var err error
+			// Reset bookmark if too many consecutive failures (stale resource version)
+			if consecutiveFailures >= 3 {
+				klog.Warningf("Resetting bookmark after %d consecutive failures, was %q", consecutiveFailures, bookmark)
+				bookmark = ""
+				consecutiveFailures = 0
+			}
 			klog.Infof("Starting watch ... ")
 			var obj configapi.RepositoryList
 			watcher, err = b.coreClient.Watch(ctx, &obj, &client.ListOptions{
@@ -121,10 +128,21 @@ loop:
 				},
 			})
 			if err != nil {
-				klog.Errorf("Cannot start watch: %v; will retry", err)
+				consecutiveFailures++
+				// Check for specific API server errors
+				if apierrors.IsResourceExpired(err) {
+					klog.Warningf("Watch start failed: expired resource version (bookmark: %q). Resetting bookmark to empty", bookmark)
+					bookmark = ""           // Clear stale bookmark immediately
+					consecutiveFailures = 0 // Reset since we're handling the root cause
+				} else if apierrors.IsGone(err) {
+					klog.Warningf("Watch start failed: gone resource (bookmark: %q). Resetting bookmark to empty: %v", bookmark, err)
+					bookmark = ""           // Clear bookmark for gone resources
+					consecutiveFailures = 0 // Reset since we're handling the root cause
+				} else {
+					klog.Errorf("Cannot start watch: %v; will retry", err)
+				}
 				reconnect.backoff()
 			} else {
-				klog.Infof("Watch successfully started.")
 				events = watcher.ResultChan()
 			}
 
@@ -134,10 +152,34 @@ loop:
 				watcher.Stop()
 				events = nil
 				watcher = nil
+				consecutiveFailures++
 
-				// Initiate reconnect
-				reconnect.reset()
+				// Use exponential backoff for repeated failures
+				if consecutiveFailures == 1 {
+					reconnect.reset()
+				} else {
+					reconnect.backoff()
+				}
+			} else if event.Type == watch.Error {
+				// Handle watch error events
+				if status, ok := event.Object.(*v1.Status); ok {
+					if status.Reason == v1.StatusReasonExpired || status.Reason == v1.StatusReasonGone {
+						klog.Warningf("Watch error: %s (code: %d) - %s. Resetting stale bookmark from %q to empty", status.Reason, status.Code, status.Message, bookmark)
+						bookmark = ""           // Reset bookmark immediately for these errors
+						consecutiveFailures = 0 // Reset failure count since we're handling the root cause
+					} else {
+						klog.Errorf("Watch error: %s (code: %d) - %s", status.Reason, status.Code, status.Message)
+						consecutiveFailures++
+					}
+				} else {
+					klog.Errorf("Watch error event with unexpected object type: %T", event.Object)
+					consecutiveFailures++
+				}
+				reconnect.reset() // Restart quickly after error events
 			} else if repository, ok := event.Object.(*configapi.Repository); ok {
+				// Reset consecutive failures on successful event processing
+				klog.Infof("Watch started successfully")
+				consecutiveFailures = 0
 				if event.Type == watch.Bookmark {
 					bookmark = repository.ResourceVersion
 					klog.V(2).Infof("Bookmark: %q", bookmark)
@@ -342,6 +384,7 @@ func newBackoffTimer(min, max time.Duration) *backoffTimer {
 	return &backoffTimer{
 		min:   min,
 		max:   max,
+		curr:  min,
 		timer: time.NewTimer(min),
 	}
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -153,13 +153,9 @@ loop:
 				events = nil
 				watcher = nil
 				consecutiveFailures++
-
 				// Use exponential backoff for repeated failures
-				if consecutiveFailures == 1 {
-					reconnect.reset()
-				} else {
-					reconnect.backoff()
-				}
+				reconnect.backoff()
+
 			} else if event.Type == watch.Error {
 				// Handle watch error events
 				if status, ok := event.Object.(*v1.Status); ok {

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -112,7 +112,6 @@ loop:
 	for {
 		select {
 		case <-reconnect.channel():
-			var err error
 			// Reset bookmark if too many consecutive failures (stale resource version)
 			if consecutiveFailures >= 3 {
 				klog.Warningf("Resetting bookmark after %d consecutive failures, was %q", consecutiveFailures, bookmark)
@@ -121,6 +120,7 @@ loop:
 			}
 			klog.Infof("Starting watch ... ")
 			var obj configapi.RepositoryList
+			var err error
 			watcher, err = b.coreClient.Watch(ctx, &obj, &client.ListOptions{
 				Raw: &v1.ListOptions{
 					AllowWatchBookmarks: true,
@@ -131,7 +131,7 @@ loop:
 				consecutiveFailures++
 				// Check for specific API server errors
 				if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
-					klog.Warningf("Watch start failed: %v (bookmark: %q). Resetting bookmark to empty.", err, bookmark)
+					klog.Warningf("Watch start failed: %v (bookmark: %q). Resetting bookmark.", err, bookmark)
 					bookmark = ""           // Clear stale bookmark immediately
 					consecutiveFailures = 0 // Reset since we're handling the root cause
 				} else {
@@ -139,11 +139,14 @@ loop:
 				}
 				reconnect.backoff()
 			} else {
+				klog.Infof("Watch successfully started.")
 				events = watcher.ResultChan()
 			}
 
 		case event, eventOk := <-events:
-			if !eventOk {
+			if eventOk {
+				b.handleWatchEvent(ctx, event, &bookmark, &consecutiveFailures, reconnect)
+			} else {
 				klog.Errorf("Watch event stream closed. Will restart watch from bookmark %q", bookmark)
 				watcher.Stop()
 				events = nil
@@ -151,37 +154,6 @@ loop:
 				consecutiveFailures++
 				// Use exponential backoff for repeated failures
 				reconnect.backoff()
-
-			} else if event.Type == watch.Error {
-				// Handle watch error events
-				if status, ok := event.Object.(*v1.Status); ok {
-					if status.Reason == v1.StatusReasonExpired || status.Reason == v1.StatusReasonGone {
-						klog.Warningf("Watch error: %s (code: %d) - %s. Resetting stale bookmark from %q to empty", status.Reason, status.Code, status.Message, bookmark)
-						bookmark = ""           // Reset bookmark immediately for these errors
-						consecutiveFailures = 0 // Reset failure count since we're handling the root cause
-					} else {
-						klog.Errorf("Watch error: %s (code: %d) - %s", status.Reason, status.Code, status.Message)
-						consecutiveFailures++
-					}
-				} else {
-					klog.Errorf("Watch error event with unexpected object type: %T", event.Object)
-					consecutiveFailures++
-				}
-				reconnect.reset() // Restart quickly after error events
-			} else if repository, ok := event.Object.(*configapi.Repository); ok {
-				// Reset consecutive failures on successful event processing
-				klog.Infof("Watch started successfully")
-				consecutiveFailures = 0
-				if event.Type == watch.Bookmark {
-					bookmark = repository.ResourceVersion
-					klog.V(2).Infof("Bookmark: %q", bookmark)
-				} else {
-					if err := b.updateCache(ctx, event.Type, repository); err != nil {
-						klog.Warningf("error updating cache: %v", err)
-					}
-				}
-			} else {
-				klog.V(5).Infof("Received unexpected watch event Object: %T", event.Object)
 			}
 
 		case t := <-ticker.C:
@@ -197,6 +169,43 @@ loop:
 				klog.Infof("Background routine exiting; context done")
 			}
 			break loop
+		}
+	}
+}
+
+// handleWatchEvent processes individual watch events
+func (b *background) handleWatchEvent(ctx context.Context, event watch.Event, bookmark *string, consecutiveFailures *int, reconnect *backoffTimer) {
+	switch event.Type {
+	case watch.Bookmark: // BOOKMARK events indicate watch stream health
+		if repository, ok := event.Object.(*configapi.Repository); ok {
+			*consecutiveFailures = 0
+			*bookmark = repository.ResourceVersion
+			klog.V(2).Infof("Bookmark: %q", *bookmark)
+		}
+	case watch.Error: // ERROR events indicate watch stream issues
+		// Handle watch error events
+		if status, ok := event.Object.(*v1.Status); ok {
+			if status.Reason == v1.StatusReasonExpired || status.Reason == v1.StatusReasonGone {
+				klog.Warningf("Watch error: %s (code: %d) - %s. Resetting bookmark and restarting watch", status.Reason, status.Code, status.Message)
+				*bookmark = ""           // Reset bookmark immediately for these errors
+				*consecutiveFailures = 0 // Reset failure count since we're handling the root cause
+			} else {
+				klog.Errorf("Watch error: %s (code: %d) - %s", status.Reason, status.Code, status.Message)
+				(*consecutiveFailures)++
+			}
+		} else {
+			klog.Errorf("Watch error event with unexpected object type: %T", event.Object)
+			(*consecutiveFailures)++
+		}
+		reconnect.reset() // Restart quickly after error events
+	default: // ADDED, MODIFIED, DELETED events for repository operations
+		if repository, ok := event.Object.(*configapi.Repository); ok {
+			*consecutiveFailures = 0
+			if err := b.updateCache(ctx, event.Type, repository); err != nil {
+				klog.Warningf("error updating cache: %v", err)
+			}
+		} else {
+			klog.V(5).Infof("Received unexpected watch event Object: %T", event.Object)
 		}
 	}
 }

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -130,13 +130,9 @@ loop:
 			if err != nil {
 				consecutiveFailures++
 				// Check for specific API server errors
-				if apierrors.IsResourceExpired(err) {
-					klog.Warningf("Watch start failed: expired resource version (bookmark: %q). Resetting bookmark to empty", bookmark)
+				if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
+					klog.Warningf("Watch start failed: %v (bookmark: %q). Resetting bookmark to empty.", err, bookmark)
 					bookmark = ""           // Clear stale bookmark immediately
-					consecutiveFailures = 0 // Reset since we're handling the root cause
-				} else if apierrors.IsGone(err) {
-					klog.Warningf("Watch start failed: gone resource (bookmark: %q). Resetting bookmark to empty: %v", bookmark, err)
-					bookmark = ""           // Clear bookmark for gone resources
 					consecutiveFailures = 0 // Reset since we're handling the root cause
 				} else {
 					klog.Errorf("Cannot start watch: %v; will retry", err)

--- a/pkg/registry/porch/background_test.go
+++ b/pkg/registry/porch/background_test.go
@@ -43,14 +43,21 @@ func TestBackgroundOptions(t *testing.T) {
 			expected: background{listTimeoutPerRepo: 10 * time.Second},
 		},
 		{
+			name:     "With repo operation retry attempts",
+			options:  []BackgroundOption{WithRepoOperationRetryAttempts(5)},
+			expected: background{repoOperationRetryAttempts: 5},
+		},
+		{
 			name: "With multiple options",
 			options: []BackgroundOption{
 				WithPeriodicRepoSyncFrequency(5 * time.Second),
 				WithListTimeoutPerRepo(10 * time.Second),
+				WithRepoOperationRetryAttempts(3),
 			},
 			expected: background{
-				periodicRepoSyncFrequency: 5 * time.Second,
-				listTimeoutPerRepo:        10 * time.Second,
+				periodicRepoSyncFrequency:  5 * time.Second,
+				listTimeoutPerRepo:         10 * time.Second,
+				repoOperationRetryAttempts: 3,
 			},
 		},
 	}
@@ -63,6 +70,7 @@ func TestBackgroundOptions(t *testing.T) {
 			}
 			assert.Equal(t, tt.expected.periodicRepoSyncFrequency, b.periodicRepoSyncFrequency)
 			assert.Equal(t, tt.expected.listTimeoutPerRepo, b.listTimeoutPerRepo)
+			assert.Equal(t, tt.expected.repoOperationRetryAttempts, b.repoOperationRetryAttempts)
 		})
 	}
 }
@@ -636,3 +644,45 @@ func createRepo(gen int64, observedGen int64, conditionsNil bool) *configapi.Rep
 		},
 	}
 }
+func TestBackoffTimer(t *testing.T) {
+	tests := []struct {
+		name     string
+		min      time.Duration
+		max      time.Duration
+		expected []time.Duration
+	}{
+		{
+			name:     "Basic backoff progression",
+			min:      100 * time.Millisecond,
+			max:      800 * time.Millisecond,
+			expected: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond, 800 * time.Millisecond, 800 * time.Millisecond},
+		},
+		{
+			name:     "Single step to max",
+			min:      1 * time.Second,
+			max:      2 * time.Second,
+			expected: []time.Duration{1 * time.Second, 2 * time.Second, 2 * time.Second},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timer := newBackoffTimer(tt.min, tt.max)
+			defer timer.Stop()
+
+			// Test initial value
+			assert.Equal(t, tt.expected[0], timer.curr)
+
+			// Test backoff progression
+			for i := 1; i < len(tt.expected); i++ {
+				timer.backoff()
+				assert.Equal(t, tt.expected[i], timer.curr)
+			}
+
+			// Test reset
+			timer.reset()
+			assert.Equal(t, tt.min, timer.curr)
+		})
+	}
+}
+

--- a/pkg/registry/porch/background_test.go
+++ b/pkg/registry/porch/background_test.go
@@ -100,6 +100,141 @@ func TestBackgroundUpdateCache(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestBackgroundHandleWatchEvent(t *testing.T) {
+	tests := []struct {
+		name                        string
+		event                       watch.Event
+		initialBookmark             string
+		initialConsecutiveFailures  int
+		expectedBookmark            string
+		expectedConsecutiveFailures int
+		expectedReconnectReset      bool
+	}{
+		{
+			name: "Repository bookmark event",
+			event: watch.Event{
+				Type: watch.Bookmark,
+				Object: &configapi.Repository{
+					ObjectMeta: v1.ObjectMeta{
+						ResourceVersion: "12345",
+					},
+				},
+			},
+			initialBookmark:             "old-bookmark",
+			initialConsecutiveFailures:  3,
+			expectedBookmark:            "12345",
+			expectedConsecutiveFailures: 0,
+			expectedReconnectReset:      false,
+		},
+		{
+			name: "Watch error - expired status",
+			event: watch.Event{
+				Type: watch.Error,
+				Object: &v1.Status{
+					Reason:  v1.StatusReasonExpired,
+					Code:    410,
+					Message: "Resource version expired",
+				},
+			},
+			initialBookmark:             "old-bookmark",
+			initialConsecutiveFailures:  2,
+			expectedBookmark:            "",
+			expectedConsecutiveFailures: 0,
+			expectedReconnectReset:      true,
+		},
+		{
+			name: "Watch error - gone status",
+			event: watch.Event{
+				Type: watch.Error,
+				Object: &v1.Status{
+					Reason:  v1.StatusReasonGone,
+					Code:    410,
+					Message: "Resource gone",
+				},
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  1,
+			expectedBookmark:            "",
+			expectedConsecutiveFailures: 0,
+			expectedReconnectReset:      true,
+		},
+		{
+			name: "Watch error - other status",
+			event: watch.Event{
+				Type: watch.Error,
+				Object: &v1.Status{
+					Reason:  "InternalError",
+					Code:    500,
+					Message: "Internal server error",
+				},
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  1,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 2,
+			expectedReconnectReset:      true,
+		},
+		{
+			name: "Watch error - unexpected object type",
+			event: watch.Event{
+				Type:   watch.Error,
+				Object: &configapi.Repository{}, // Wrong object type for error event
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  1,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 2,    // consecutiveFailures incremented because it's an error event with unexpected object type
+			expectedReconnectReset:      true, // reconnect.reset() called because it's an error event
+		},
+		{
+			name: "Unexpected event object type",
+			event: watch.Event{
+				Type:   watch.Added,
+				Object: &v1.Status{}, // Wrong object type for non-error event
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  1,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 1,
+			expectedReconnectReset:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockclient.MockWithWatch{}
+			mockCache := &mockcache.MockCache{}
+
+			b := &background{
+				coreClient:                 mockClient,
+				cache:                      mockCache,
+				repoOperationRetryAttempts: 3,
+			}
+
+			// Initialize test variables
+			bookmark := tt.initialBookmark
+			consecutiveFailures := tt.initialConsecutiveFailures
+			reconnect := newBackoffTimer(minReconnectDelay, maxReconnectDelay)
+			defer reconnect.Stop()
+
+			// Track if reconnect.reset() was called
+			initialCurr := reconnect.curr
+			reconnect.backoff() // Change current value to detect reset
+
+			// Call the function under test
+			b.handleWatchEvent(context.Background(), tt.event, &bookmark, &consecutiveFailures, reconnect)
+
+			// Verify results
+			assert.Equal(t, tt.expectedBookmark, bookmark)
+			assert.Equal(t, tt.expectedConsecutiveFailures, consecutiveFailures)
+
+			if tt.expectedReconnectReset {
+				assert.Equal(t, initialCurr, reconnect.curr, "Expected reconnect timer to be reset")
+			}
+		})
+	}
+}
+
 func TestBackgroundHandleRepositoryEvent(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -685,4 +820,3 @@ func TestBackoffTimer(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Fix watch recovery after connection failures

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  
Added bookmark event handling in watch loop
Added failure counter and recovery logging

- Why it’s needed:  
Prevents the watch from becoming irrecoverable after connection failures
Ensures no repository events are missed during reconnections

- How it works:  
Bookmarks provide resume points with resource versions
Watch restarts from the last bookmark instead of the beginning
Tracks failures and logs successful recovery

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes # https://github.com/nephio-project/porch/issues/803

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Amazon Q was used 
- Known issues:  
- Further improvements:  
- Review notes:  
