### PR TITLE
Cherry pick of #516 - Allow for connection pool configuration

### DIFF
--- a/pkg/cache/dbcache/dbhandler.go
+++ b/pkg/cache/dbcache/dbhandler.go
@@ -49,6 +49,12 @@ func OpenDB(ctx context.Context, opts cachetypes.CacheOptions) error {
 		return err
 	}
 
+	// Configure connection pool limits
+	db.SetMaxOpenConns(opts.DBCacheOptions.MaxConnections)
+	db.SetMaxIdleConns(opts.DBCacheOptions.MaxIdleConnections)
+	db.SetConnMaxLifetime(opts.DBCacheOptions.MaxConnLifetime)
+	klog.Infof("OpenDB: configured connection pool - MaxOpenConns=%d, MaxIdleConns=%d, MaxConnLifetime=%v",
+		opts.DBCacheOptions.MaxConnections, opts.DBCacheOptions.MaxIdleConnections, opts.DBCacheOptions.MaxConnLifetime)
 	if err := db.Ping(); err != nil {
 		db.Close()
 		klog.V(4).Infof("OpenDB: database open failed")

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -48,8 +48,11 @@ type CacheOptions struct {
 const DefaultDBCacheDriver string = "pgx"
 
 type DBCacheOptions struct {
-	Driver     string
-	DataSource string
+	Driver             string
+	DataSource         string
+	MaxConnections     int
+	MaxIdleConnections int
+	MaxConnLifetime    time.Duration
 }
 
 type Cache interface {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -59,10 +59,14 @@ type PorchServerOptions struct {
 
 	CoreAPIKubeconfigPath string
 
-	CacheDirectory    string
-	CacheType         string
-	DbCacheDriver     string
-	DbCacheDataSource string
+	CacheDirectory       string
+	CacheType            string
+	DbCacheDriver        string
+	DbCacheDataSource    string
+	DbMaxConnections     int
+	DbMaxIdleConnections int
+	DbMaxConnLifetime    time.Duration
+	DbPushDrafsToGit     bool
 
 	DefaultImagePrefix       string
 	FunctionRunnerAddress    string
@@ -181,6 +185,33 @@ func (o *PorchServerOptions) Complete() error {
 	if o.CacheType == string(cachetypes.DBCacheType) {
 		if err := o.setupDBCacheConn(); err != nil {
 			return err
+		}
+		// Set connection pool defaults from environment variables
+		if maxConns := os.Getenv("DB_MAX_CONNECTIONS"); maxConns != "" {
+			if n, err := fmt.Sscanf(maxConns, "%d", &o.DbMaxConnections); err != nil || n != 1 {
+				klog.Warningf("Invalid DB_MAX_CONNECTIONS value %q, using default 300", maxConns)
+				o.DbMaxConnections = 300
+			}
+		} else {
+			o.DbMaxConnections = 300
+		}
+		if maxIdle := os.Getenv("DB_MAX_IDLE_CONNECTIONS"); maxIdle != "" {
+			if n, err := fmt.Sscanf(maxIdle, "%d", &o.DbMaxIdleConnections); err != nil || n != 1 {
+				klog.Warningf("Invalid DB_MAX_IDLE_CONNECTIONS value %q, using default 100", maxIdle)
+				o.DbMaxIdleConnections = 100
+			}
+		} else {
+			o.DbMaxIdleConnections = 100
+		}
+		if maxLifetime := os.Getenv("DB_MAX_CONN_LIFETIME"); maxLifetime != "" {
+			if d, err := time.ParseDuration(maxLifetime); err != nil {
+				klog.Warningf("Invalid DB_MAX_CONN_LIFETIME value %q, using default 3m", maxLifetime)
+				o.DbMaxConnLifetime = 3 * time.Minute
+			} else {
+				o.DbMaxConnLifetime = d
+			}
+		} else {
+			o.DbMaxConnLifetime = 3 * time.Minute
 		}
 	}
 
@@ -304,8 +335,11 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 				RepoOperationRetryAttempts: o.RepoOperationRetryAttempts,
 				CacheType:                  cachetypes.CacheType(o.CacheType),
 				DBCacheOptions: cachetypes.DBCacheOptions{
-					Driver:     o.DbCacheDriver,
-					DataSource: o.DbCacheDataSource,
+					Driver:             o.DbCacheDriver,
+					DataSource:         o.DbCacheDataSource,
+					MaxConnections:     o.DbMaxConnections,
+					MaxIdleConnections: o.DbMaxIdleConnections,
+					MaxConnLifetime:    o.DbMaxConnLifetime,
 				},
 			},
 			ListTimeoutPerRepository: o.ListTimeoutPerRepository,

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"os"
-	"strings"
 	"testing"
 	"time"
 

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -79,39 +79,150 @@ func TestComplete(t *testing.T) {
 }
 
 func TestSetupDBCacheConn(t *testing.T) {
-	opts := NewPorchServerOptions(os.Stdout, os.Stderr)
+	// Default expected connection pooling values
+	defaultMaxConns := 300
+	defaultMaxIdleConns := 100
+	defaultMaxConnLifetime := 3 * time.Minute
 
-	err := opts.setupDBCacheConn()
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "missing required environment variables"))
+	tests := []struct {
+		name                    string
+		envVars                 map[string]string
+		expectError             bool
+		errorContains           string
+		expectedDriver          string
+		expectedDataSource      string
+		expectedMaxConns        int
+		expectedMaxIdleConns    int
+		expectedMaxConnLifetime time.Duration
+	}{
+		{
+			name: "missing required environment variables",
+			envVars: map[string]string{
+				"DB_HOST": "", // Empty value should trigger missing var error
+				"DB_PORT": "",
+				"DB_NAME": "",
+			},
+			expectError:   true,
+			errorContains: "missing required environment variables",
+		},
+		{
+			name: "unsupported DB driver",
+			envVars: map[string]string{
+				"DB_DRIVER": "db-driver",
+			},
+			expectError:   true,
+			errorContains: "unsupported DB driver: db-driver",
+		},
+		{
+			name:                    "pgx driver with defaults",
+			envVars:                 map[string]string{},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "mysql driver",
+			envVars: map[string]string{
+				"DB_DRIVER": "mysql",
+			},
+			expectError:             false,
+			expectedDriver:          "mysql",
+			expectedDataSource:      "db-user:db-password@tcp(db-host:db-port)/db-name",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "pgx with SSL mode",
+			envVars: map[string]string{
+				"DB_SSL_MODE": "verify-full",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user@db-host:db-port/db-name?sslmode=verify-full",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "custom connection pooling values",
+			envVars: map[string]string{
+				"DB_MAX_CONNECTIONS":      "50",
+				"DB_MAX_IDLE_CONNECTIONS": "25",
+				"DB_MAX_CONN_LIFETIME":    "5m",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        50,
+			expectedMaxIdleConns:    25,
+			expectedMaxConnLifetime: 5 * time.Minute,
+		},
+		{
+			name: "invalid connection pooling values use defaults",
+			envVars: map[string]string{
+				"DB_MAX_CONNECTIONS":      "invalid",
+				"DB_MAX_IDLE_CONNECTIONS": "not-a-number",
+				"DB_MAX_CONN_LIFETIME":    "bad-duration",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+	}
 
-	os.Setenv("DB_DRIVER", "db-driver")
-	os.Setenv("DB_HOST", "db-host")
-	os.Setenv("DB_PORT", "db-port")
-	os.Setenv("DB_NAME", "db-name")
-	os.Setenv("DB_USER", "db-user")
-	os.Setenv("DB_PASSWORD", "db-password")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all DB-related environment variables
+			dbEnvVars := []string{
+				"DB_DRIVER", "DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_SSL_MODE",
+				"DB_MAX_CONNECTIONS", "DB_MAX_IDLE_CONNECTIONS", "DB_MAX_CONN_LIFETIME",
+			}
+			for _, envVar := range dbEnvVars {
+				os.Unsetenv(envVar)
+			}
 
-	err = opts.setupDBCacheConn()
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "unsupported DB driver: db-driver"))
+			// Set default required environment variables
+			os.Setenv("DB_HOST", "db-host")
+			os.Setenv("DB_PORT", "db-port")
+			os.Setenv("DB_NAME", "db-name")
+			os.Setenv("DB_USER", "db-user")
+			os.Setenv("DB_PASSWORD", "db-password")
 
-	os.Setenv("DB_DRIVER", "pgx")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "pgx", opts.DbCacheDriver)
-	assert.Equal(t, "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable", opts.DbCacheDataSource)
+			// Set test-specific environment variables (can override defaults)
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
 
-	os.Setenv("DB_DRIVER", "mysql")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "mysql", opts.DbCacheDriver)
-	assert.Equal(t, "db-user:db-password@tcp(db-host:db-port)/db-name", opts.DbCacheDataSource)
+			opts := NewPorchServerOptions(os.Stdout, os.Stderr)
+			opts.CacheType = "DB"
 
-	os.Setenv("DB_SSL_MODE", "verify-full")
-	os.Setenv("DB_DRIVER", "pgx")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "pgx", opts.DbCacheDriver)
-	assert.Equal(t, "postgres://db-user@db-host:db-port/db-name?sslmode=verify-full", opts.DbCacheDataSource)
+			err := opts.Complete()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedDriver, opts.DbCacheDriver)
+				assert.Equal(t, tt.expectedDataSource, opts.DbCacheDataSource)
+				assert.Equal(t, tt.expectedMaxConns, opts.DbMaxConnections)
+				assert.Equal(t, tt.expectedMaxIdleConns, opts.DbMaxIdleConnections)
+				assert.Equal(t, tt.expectedMaxConnLifetime, opts.DbMaxConnLifetime)
+			}
+
+			// Clean up
+			for _, envVar := range dbEnvVars {
+				os.Unsetenv(envVar)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Allow for connection pool configuration.

---

## Description
<!-- Describe what this PR does and why -->
What changed: Added connection pool configuration (max connections, idle connections, lifetime) to database cache options and handler.

Why it's needed: Prevents connection overhead and exhaustion, improves database performance under load.

How it works: Configures Go's sql.DB connection pool with limits, automatically reuses connections across database operations.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  
