### PR TITLE
503 backport

### DIFF
--- a/pkg/cache/crcache/cache_test.go
+++ b/pkg/cache/crcache/cache_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/nephio-project/porch/pkg/cache/repomap"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/externalrepo/fake"
-	"github.com/nephio-project/porch/pkg/externalrepo/git"
 	externalrepotypes "github.com/nephio-project/porch/pkg/externalrepo/types"
 	"github.com/nephio-project/porch/pkg/repository"
+	gitserver "github.com/nephio-project/porch/test/git/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,7 +247,7 @@ func openRepositoryFromArchive(t *testing.T, ctx context.Context, testPath, name
 
 	tempdir := t.TempDir()
 	tarfile := filepath.Join(testPath, fmt.Sprintf("%s-repository.tar", name))
-	_, address := git.ServeGitRepository(t, tarfile, tempdir)
+	_, address := gitserver.ServeGitRepository(t, tarfile, tempdir)
 	metadataStore := createMetadataStoreFromArchive(t, fmt.Sprintf("%s-metadata.yaml", name), name)
 
 	apiRepo := &v1alpha1.Repository{

--- a/pkg/externalrepo/git/annotation.go
+++ b/pkg/externalrepo/git/annotation.go
@@ -46,10 +46,10 @@ type gitAnnotation struct {
 	Task *porchapi.Task `json:"task,omitempty"`
 }
 
-// ExtractGitAnnotations reads the gitAnnotations from the given commit.
+// extractGitAnnotations reads the gitAnnotations from the given commit.
 // If no annotation are found, it returns [], nil
 // If an invalid annotation is found, it returns an error.
-func ExtractGitAnnotations(commit *object.Commit) ([]gitAnnotation, error) {
+func extractGitAnnotations(commit *object.Commit) ([]gitAnnotation, error) {
 	annotations := []gitAnnotation{}
 	ec := errors.NewErrorCollector().WithSeparator(";").WithFormat("{%s}")
 
@@ -69,8 +69,8 @@ func ExtractGitAnnotations(commit *object.Commit) ([]gitAnnotation, error) {
 	return annotations, ec.Join()
 }
 
-// AnnotateCommitMessage adds the gitAnnotation to the commit message.
-func AnnotateCommitMessage(message string, annotation *gitAnnotation) (string, error) {
+// annotateCommitMessage adds the gitAnnotation to the commit message.
+func annotateCommitMessage(message string, annotation *gitAnnotation) (string, error) {
 	b, err := json.Marshal(annotation)
 	if err != nil {
 		return "", pkgerrors.Wrap(err, "error marshaling annotation")

--- a/pkg/externalrepo/git/cachedir_pool.go
+++ b/pkg/externalrepo/git/cachedir_pool.go
@@ -24,28 +24,28 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// DirectoryPool manages shared access to cached git directories
-type DirectoryPool struct {
+// directoryPool manages shared access to cached git directories
+type directoryPool struct {
 	directories sync.Map
 	mutex       sync.Mutex
 }
 
-type SharedDirectory struct {
+type sharedDirectory struct {
 	repo     *git.Repository
 	mutex    sync.RWMutex
 	refCount int // number of gitRepository instances using this directory
 }
 
-var globalDirectoryPool = &DirectoryPool{
+var globalDirectoryPool = &directoryPool{
 	directories: sync.Map{},
 }
 
-// GetOrCreateSharedRepository safely initializes or reuses a cached git directory
-func (p *DirectoryPool) GetOrCreateSharedRepository(dir, reponame string) (*SharedDirectory, error) {
+// getOrCreateSharedRepository safely initializes or reuses a cached git directory
+func (p *directoryPool) getOrCreateSharedRepository(dir, reponame string) (*sharedDirectory, error) {
 	// Fast path: check if directory already exists
 	if sharedDir, exists := p.directories.Load(dir); exists {
 		p.mutex.Lock()
-		shared := sharedDir.(*SharedDirectory)
+		shared := sharedDir.(*sharedDirectory)
 		shared.refCount++
 		klog.V(2).Infof("Repo %s is reusing shared directory %s, refCount now: %d", reponame, dir, shared.refCount)
 		p.mutex.Unlock()
@@ -58,7 +58,7 @@ func (p *DirectoryPool) GetOrCreateSharedRepository(dir, reponame string) (*Shar
 
 	// Double-check after acquiring lock
 	if sharedDir, exists := p.directories.Load(dir); exists {
-		shared := sharedDir.(*SharedDirectory)
+		shared := sharedDir.(*sharedDirectory)
 		shared.refCount++
 		klog.V(2).Infof("Repo %s is reusing shared directory %s, refCount now: %d", reponame, dir, shared.refCount)
 		return shared, nil
@@ -93,7 +93,7 @@ func (p *DirectoryPool) GetOrCreateSharedRepository(dir, reponame string) (*Shar
 		}
 	}
 
-	shared := &SharedDirectory{
+	shared := &sharedDirectory{
 		repo:     repo,
 		refCount: 1,
 	}
@@ -102,13 +102,13 @@ func (p *DirectoryPool) GetOrCreateSharedRepository(dir, reponame string) (*Shar
 	return shared, nil
 }
 
-// ReleaseSharedRepository decrements reference count and cleans up cached git directory if needed
-func (p *DirectoryPool) ReleaseSharedRepository(dir, reponame string) {
+// releaseSharedRepository decrements reference count and cleans up cached git directory if needed
+func (p *directoryPool) releaseSharedRepository(dir, reponame string) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	if sharedDir, exists := p.directories.Load(dir); exists {
-		shared := sharedDir.(*SharedDirectory)
+		shared := sharedDir.(*sharedDirectory)
 		shared.refCount--
 		klog.V(2).Infof("Released repo %s from %s, refCount now: %d", reponame, filepath.Base(dir), shared.refCount)
 
@@ -131,15 +131,15 @@ func (p *DirectoryPool) ReleaseSharedRepository(dir, reponame string) {
 	}
 }
 
-// WithLock executes function with exclusive access to the cached git directory
-func (s *SharedDirectory) WithLock(fn func(*git.Repository) error) error {
+// withLock executes function with exclusive access to the cached git directory
+func (s *sharedDirectory) withLock(fn func(*git.Repository) error) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	return fn(s.repo)
 }
 
-// WithRLock executes function with read-only access to the cached git directory
-func (s *SharedDirectory) WithRLock(fn func(*git.Repository) error) error {
+// withRLock executes function with read-only access to the cached git directory
+func (s *sharedDirectory) withRLock(fn func(*git.Repository) error) error {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	return fn(s.repo)

--- a/pkg/externalrepo/git/cachedir_pool_test.go
+++ b/pkg/externalrepo/git/cachedir_pool_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestDirectoryPool_GetOrCreateSharedRepository(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -34,20 +34,20 @@ func TestDirectoryPool_GetOrCreateSharedRepository(t *testing.T) {
 	repoDir := filepath.Join(tempDir, "test-repo")
 
 	// First call should create new shared directory
-	shared1, err := pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	shared1, err := pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	require.NoError(t, err)
 	require.NotNil(t, shared1)
 	assert.Equal(t, 1, shared1.refCount)
 
 	// Second call should reuse existing directory
-	shared2, err := pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	shared2, err := pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	require.NoError(t, err)
 	assert.Same(t, shared1, shared2)
 	assert.Equal(t, 2, shared2.refCount)
 }
 
 func TestDirectoryPool_ReleaseSharedRepository(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -55,19 +55,19 @@ func TestDirectoryPool_ReleaseSharedRepository(t *testing.T) {
 	repoDir := filepath.Join(tempDir, "test-repo")
 
 	// Create shared repository
-	shared, err := pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	shared, err := pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	require.NoError(t, err)
 
 	// Add another reference
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	require.NoError(t, err)
 
 	// First release should decrement refCount
-	pool.ReleaseSharedRepository(repoDir, "test-repo")
+	pool.releaseSharedRepository(repoDir, "test-repo")
 	assert.Equal(t, 1, shared.refCount)
 
 	// Second release should remove from pool and cleanup directory
-	pool.ReleaseSharedRepository(repoDir, "test-repo")
+	pool.releaseSharedRepository(repoDir, "test-repo")
 	_, exists := pool.directories.Load(repoDir)
 	assert.False(t, exists)
 	_, err = os.Stat(repoDir)
@@ -79,13 +79,13 @@ func TestSharedDirectory_WithLock(t *testing.T) {
 	repo, err := initEmptyRepository(tempDir)
 	require.NoError(t, err)
 
-	shared := &SharedDirectory{
+	shared := &sharedDirectory{
 		repo:     repo,
 		refCount: 1,
 	}
 
 	called := false
-	err = shared.WithLock(func(r *git.Repository) error {
+	err = shared.withLock(func(r *git.Repository) error {
 		called = true
 		assert.Same(t, repo, r)
 		return nil
@@ -100,13 +100,13 @@ func TestSharedDirectory_WithRLock(t *testing.T) {
 	repo, err := initEmptyRepository(tempDir)
 	require.NoError(t, err)
 
-	shared := &SharedDirectory{
+	shared := &sharedDirectory{
 		repo:     repo,
 		refCount: 1,
 	}
 
 	called := false
-	err = shared.WithRLock(func(r *git.Repository) error {
+	err = shared.withRLock(func(r *git.Repository) error {
 		called = true
 		assert.Same(t, repo, r)
 		return nil
@@ -117,7 +117,7 @@ func TestSharedDirectory_WithRLock(t *testing.T) {
 }
 
 func TestDirectoryPool_ConcurrentAccess(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -132,7 +132,7 @@ func TestDirectoryPool_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			_, err := pool.GetOrCreateSharedRepository(repoDir, "concurrent-repo")
+			_, err := pool.getOrCreateSharedRepository(repoDir, "concurrent-repo")
 			assert.NoError(t, err)
 		}(i)
 	}
@@ -140,7 +140,7 @@ func TestDirectoryPool_ConcurrentAccess(t *testing.T) {
 
 	// Check final refCount
 	sharedDir, _ := pool.directories.Load(repoDir)
-	shared := sharedDir.(*SharedDirectory)
+	shared := sharedDir.(*sharedDirectory)
 
 	assert.Equal(t, numGoroutines, shared.refCount)
 
@@ -149,7 +149,7 @@ func TestDirectoryPool_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			pool.ReleaseSharedRepository(repoDir, "concurrent-repo")
+			pool.releaseSharedRepository(repoDir, "concurrent-repo")
 		}()
 	}
 	wg.Wait()
@@ -160,7 +160,7 @@ func TestDirectoryPool_ConcurrentAccess(t *testing.T) {
 }
 
 func TestDirectoryPool_InitEmptyRepositoryFailure(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -174,7 +174,7 @@ func TestDirectoryPool_InitEmptyRepositoryFailure(t *testing.T) {
 	repoDir := filepath.Join(filePath, "subdir") // This will fail because parent is a file
 
 	// Should fail to create repository
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	assert.Error(t, err)
 
 	// Should not be in pool
@@ -183,12 +183,12 @@ func TestDirectoryPool_InitEmptyRepositoryFailure(t *testing.T) {
 
 	// Retry should work if we fix the issue
 	os.Remove(filePath)
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	assert.NoError(t, err)
 }
 
 func TestDirectoryPool_OpenRepositoryFailure(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -203,7 +203,7 @@ func TestDirectoryPool_OpenRepositoryFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should fail to open corrupted repository
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "corrupted cache was removed")
 
@@ -216,12 +216,12 @@ func TestDirectoryPool_OpenRepositoryFailure(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	// Retry should work now that corrupted dir is removed
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	assert.NoError(t, err)
 }
 
 func TestDirectoryPool_OpenRepositoryCleanupFailure(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -242,7 +242,7 @@ func TestDirectoryPool_OpenRepositoryCleanupFailure(t *testing.T) {
 	defer os.Chmod(repoDir, 0755)
 
 	// Should fail to open and also fail to cleanup
-	_, err = pool.GetOrCreateSharedRepository(repoDir, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(repoDir, "test-repo")
 	assert.Error(t, err)
 	// When cleanup fails, error message should mention checking local cache
 	assert.Contains(t, err.Error(), "check the local git cache")
@@ -257,7 +257,7 @@ func TestDirectoryPool_OpenRepositoryCleanupFailure(t *testing.T) {
 }
 
 func TestDirectoryPool_PathIsFile(t *testing.T) {
-	pool := &DirectoryPool{
+	pool := &directoryPool{
 		directories: sync.Map{},
 	}
 
@@ -269,7 +269,7 @@ func TestDirectoryPool_PathIsFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should fail because path is a file, not a directory
-	_, err = pool.GetOrCreateSharedRepository(filePath, "test-repo")
+	_, err = pool.getOrCreateSharedRepository(filePath, "test-repo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
 

--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -92,7 +92,7 @@ func TestPackageCommitToMain(t *testing.T) {
 
 	// Commit `bucket`` package from drafts/bucket/v1 into main
 
-	main := resolveReference(t, gitRepo, DefaultMainReferenceName)
+	main := resolveReference(t, gitRepo, defaultMainReferenceName)
 	packagePath := "bucket"
 
 	// Confirm no 'bucket' package in main
@@ -143,7 +143,7 @@ func TestCommitWithUser(t *testing.T) {
 	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "trivial-repository.tar"), tempdir)
 
 	ctx := context.Background()
-	main := resolveReference(t, gitRepo, DefaultMainReferenceName)
+	main := resolveReference(t, gitRepo, defaultMainReferenceName)
 
 	{
 		const testEmail = "porch-test@porch-domain.com"

--- a/pkg/externalrepo/git/commitopsbuilder.go
+++ b/pkg/externalrepo/git/commitopsbuilder.go
@@ -18,35 +18,35 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-type CommitOperation struct {
-	Type string
-	Data interface{}
+type commitOperation struct {
+	opType string
+	data interface{}
 }
 
-type CommitOperationBuilder struct {
-	operations []CommitOperation
+type commitOperationBuilder struct {
+	operations []commitOperation
 }
 
-func NewCommitOperationBuilder() *CommitOperationBuilder {
-	return &CommitOperationBuilder{
-		operations: []CommitOperation{},
+func newCommitOperationBuilder() *commitOperationBuilder {
+	return &commitOperationBuilder{
+		operations: []commitOperation{},
 	}
 }
 
-func (c *CommitOperationBuilder) AddPackageApproval(draft interface{}, tag plumbing.ReferenceName) {
-	c.operations = append(c.operations, CommitOperation{
-		Type: "approval",
-		Data: map[string]interface{}{"draft": draft, "tag": tag},
+func (c *commitOperationBuilder) addPackageApproval(draft interface{}, tag plumbing.ReferenceName) {
+	c.operations = append(c.operations, commitOperation{
+		opType: "approval",
+		data: map[string]interface{}{"draft": draft, "tag": tag},
 	})
 }
 
-func (c *CommitOperationBuilder) AddPackageDeletion(branch plumbing.ReferenceName, prKey interface{}) {
-	c.operations = append(c.operations, CommitOperation{
-		Type: "deletion",
-		Data: map[string]interface{}{"branch": branch, "prKey": prKey},
+func (c *commitOperationBuilder) addPackageDeletion(branch plumbing.ReferenceName, prKey interface{}) {
+	c.operations = append(c.operations, commitOperation{
+		opType: "deletion",
+		data: map[string]interface{}{"branch": branch, "prKey": prKey},
 	})
 }
 
-func (c *CommitOperationBuilder) GetOperations() []CommitOperation {
+func (c *commitOperationBuilder) getOperations() []commitOperation {
 	return c.operations
 }

--- a/pkg/externalrepo/git/commitopsbuilder_test.go
+++ b/pkg/externalrepo/git/commitopsbuilder_test.go
@@ -23,58 +23,58 @@ import (
 )
 
 func TestNewCommitOperationBuilder(t *testing.T) {
-	builder := NewCommitOperationBuilder()
+	builder := newCommitOperationBuilder()
 	require.NotNil(t, builder)
 	assert.Empty(t, builder.operations)
 }
 
 func TestAddPackageApproval(t *testing.T) {
-	builder := NewCommitOperationBuilder()
+	builder := newCommitOperationBuilder()
 	draft := "test-draft"
 	tag := plumbing.ReferenceName("refs/tags/test-tag")
 
-	builder.AddPackageApproval(draft, tag)
+	builder.addPackageApproval(draft, tag)
 
-	ops := builder.GetOperations()
+	ops := builder.getOperations()
 	require.Len(t, ops, 1)
 
 	op := ops[0]
-	assert.Equal(t, "approval", op.Type)
+	assert.Equal(t, "approval", op.opType)
 
-	data := op.Data.(map[string]interface{})
+	data := op.data.(map[string]interface{})
 	assert.Equal(t, draft, data["draft"])
 	assert.Equal(t, tag, data["tag"])
 }
 
 func TestAddPackageDeletion(t *testing.T) {
-	builder := NewCommitOperationBuilder()
+	builder := newCommitOperationBuilder()
 	branch := plumbing.ReferenceName("refs/heads/test-branch")
 	prKey := "test-key"
 
-	builder.AddPackageDeletion(branch, prKey)
+	builder.addPackageDeletion(branch, prKey)
 
-	ops := builder.GetOperations()
+	ops := builder.getOperations()
 	require.Len(t, ops, 1)
 
 	op := ops[0]
-	assert.Equal(t, "deletion", op.Type)
+	assert.Equal(t, "deletion", op.opType)
 
-	data := op.Data.(map[string]interface{})
+	data := op.data.(map[string]interface{})
 	assert.Equal(t, branch, data["branch"])
 	assert.Equal(t, prKey, data["prKey"])
 }
 
 func TestMultipleOperations(t *testing.T) {
-	builder := NewCommitOperationBuilder()
+	builder := newCommitOperationBuilder()
 
-	builder.AddPackageApproval("draft1", plumbing.ReferenceName("refs/tags/tag1"))
-	builder.AddPackageDeletion(plumbing.ReferenceName("refs/heads/branch1"), "key1")
-	builder.AddPackageApproval("draft2", plumbing.ReferenceName("refs/tags/tag2"))
+	builder.addPackageApproval("draft1", plumbing.ReferenceName("refs/tags/tag1"))
+	builder.addPackageDeletion(plumbing.ReferenceName("refs/heads/branch1"), "key1")
+	builder.addPackageApproval("draft2", plumbing.ReferenceName("refs/tags/tag2"))
 
-	ops := builder.GetOperations()
+	ops := builder.getOperations()
 	require.Len(t, ops, 3)
 
-	assert.Equal(t, "approval", ops[0].Type)
-	assert.Equal(t, "deletion", ops[1].Type)
-	assert.Equal(t, "approval", ops[2].Type)
+	assert.Equal(t, "approval", ops[0].opType)
+	assert.Equal(t, "deletion", ops[1].opType)
+	assert.Equal(t, "approval", ops[2].opType)
 }

--- a/pkg/externalrepo/git/draft.go
+++ b/pkg/externalrepo/git/draft.go
@@ -39,7 +39,7 @@ type gitPackageRevisionDraft struct {
 	base *plumbing.Reference
 
 	// name of the branch where the changes will be pushed
-	branch BranchName
+	branch branchName
 
 	// Current HEAD of the package changes (commit sha)
 	commit plumbing.Hash

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1557,7 +1557,7 @@ func visitCommitsCollectErrors(iterator object.CommitIter, callback commitCallba
 	return ec.Join()
 }
 
-func (r *gitRepository) GetResource(hash plumbing.Hash, filePath string) (string, error) {
+func (r *gitRepository) getResource(hash plumbing.Hash, filePath string) (string, error) {
 	var content string
 	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		tree, err := repo.TreeObject(hash)
@@ -1576,7 +1576,7 @@ func (r *gitRepository) GetResource(hash plumbing.Hash, filePath string) (string
 	return content, err
 }
 
-func (r *gitRepository) GetResources(hash plumbing.Hash) (map[string]string, error) {
+func (r *gitRepository) getResources(hash plumbing.Hash) (map[string]string, error) {
 	resources := map[string]string{}
 
 	err := r.sharedDir.withLock(func(repo *git.Repository) error {

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -51,8 +51,8 @@ import (
 var tracer = otel.Tracer("git")
 
 const (
-	DefaultMainReferenceName plumbing.ReferenceName = "refs/heads/main"
-	OriginName               string                 = "origin"
+	defaultMainReferenceName plumbing.ReferenceName = "refs/heads/main"
+	originName               string                 = "origin"
 	fileContent                                     = "Created by porch"
 	fileName                                        = "README.md"
 	commitMessage                                   = "Initial commit: Creating main branch"
@@ -159,27 +159,27 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 	}
 
 	// Get or create shared repository - let SharedDirectory handle cleanup
-	sharedDir, err := globalDirectoryPool.GetOrCreateSharedRepository(dir, name)
+	sharedDir, err := globalDirectoryPool.getOrCreateSharedRepository(dir, name)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v", spec.Repo)
 	}
 
 	// Create Remote
 	if err := initializeOrigin(sharedDir.repo, spec.Repo); err != nil {
-		globalDirectoryPool.ReleaseSharedRepository(dir, name)
+		globalDirectoryPool.releaseSharedRepository(dir, name)
 		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, cannot create remote", spec.Repo)
 	}
 
 	// NOTE: the spec.git.branch field in the Repository CRD (OpenAPI schema) is defined with
 	//		 MinLength=1 validation and its default value is set to "main". This means that
 	// 		 it should never be empty at this point. The following code is left here as a last resort failsafe.
-	branch := MainBranch
+	branch := mainBranch
 	if spec.Branch != "" {
-		branch = BranchName(spec.Branch)
+		branch = branchName(spec.Branch)
 	}
 
 	if err := util.ValidateDirectoryName(string(branch), false); err != nil {
-		globalDirectoryPool.ReleaseSharedRepository(dir, name)
+		globalDirectoryPool.releaseSharedRepository(dir, name)
 		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, branch name %q invalid", spec.Repo, branch)
 	}
 
@@ -209,12 +209,12 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 	}
 
 	if err := repository.fetchRemoteRepositoryWithRetry(ctx); err != nil {
-		globalDirectoryPool.ReleaseSharedRepository(dir, name)
+		globalDirectoryPool.releaseSharedRepository(dir, name)
 		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, fetch of remote repository failed", spec.Repo)
 	}
 
 	if err := repository.verifyRepository(ctx, &opts); err != nil {
-		globalDirectoryPool.ReleaseSharedRepository(dir, name)
+		globalDirectoryPool.releaseSharedRepository(dir, name)
 		return nil, pkgerrors.Wrapf(err, "error cloning git repository %+v, fetch of remote repository failed", spec.Repo)
 	}
 
@@ -243,8 +243,8 @@ func makeUserInfoProvider(spec *configapi.GitRepository, def repository.UserInfo
 type gitRepository struct {
 	key                repository.RepositoryKey
 	secret             string           // Name of the k8s Secret resource containing credentials
-	branch             BranchName       // The main branch from repository registration (defaults to 'main' if unspecified)
-	sharedDir          *SharedDirectory // For thread-safe access to git repository - Holds *git.Repository
+	branch             branchName       // The main branch from repository registration (defaults to 'main' if unspecified)
+	sharedDir          *sharedDirectory // For thread-safe access to git repository - Holds *git.Repository
 	credentialResolver repository.CredentialResolver
 	userInfoProvider   repository.UserInfoProvider
 
@@ -263,7 +263,7 @@ type gitRepository struct {
 	// deletionProposedCache contains the deletionProposed branches that
 	// exist in the repo so that we can easily check them without iterating
 	// through all the refs each time
-	deletionProposedCache map[BranchName]bool
+	deletionProposedCache map[branchName]bool
 
 	mutex sync.Mutex
 
@@ -288,7 +288,7 @@ func (r *gitRepository) Key() repository.RepositoryKey {
 
 func (r *gitRepository) Close(context.Context) error {
 	// Release shared directory reference instead of removing it
-	globalDirectoryPool.ReleaseSharedRepository(r.cacheDir, r.Key().Name)
+	globalDirectoryPool.releaseSharedRepository(r.cacheDir, r.Key().Name)
 	klog.Infof("gitRepository:Close: completed cleanup for repo %+v", r.Key())
 	return nil
 }
@@ -303,7 +303,7 @@ func (r *gitRepository) Version(ctx context.Context) (string, error) {
 	}
 
 	var b bytes.Buffer
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		refs, err := repo.References()
 		if err != nil {
 			return err
@@ -361,7 +361,7 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 	}
 
 	var refs storer.ReferenceIter
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var err error
 		refs, err = repo.References()
 		return err
@@ -375,7 +375,7 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 	var drafts []*gitPackageRevision
 	var result []*gitPackageRevision
 
-	mainBranch := r.branch.RefInLocal() // Looking for the registered branch
+	mainBranch := r.branch.refInLocal() // Looking for the registered branch
 
 	for ref, err := refs.Next(); err == nil; ref, err = refs.Next() {
 		switch name := ref.Name(); {
@@ -446,8 +446,8 @@ func (r *gitRepository) CreatePackageRevisionDraft(ctx context.Context, obj *por
 	}()
 
 	var base plumbing.Hash
-	refName := r.branch.RefInLocal()
-	err := r.sharedDir.WithRLock(func(repo *git.Repository) error {
+	refName := r.branch.refInLocal()
+	err := r.sharedDir.withRLock(func(repo *git.Repository) error {
 		switch main, err := repo.Reference(refName, true); err {
 		case nil:
 			base = main.Hash()
@@ -506,7 +506,7 @@ func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repositor
 	}
 
 	var head *plumbing.Reference
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var err error
 		head, err = repo.Reference(ref.Name(), true)
 		return err
@@ -582,7 +582,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, pr2Delete rep
 			}
 
 			refSpecs := newPushRefSpecBuilder()
-			var commitOps *CommitOperationBuilder
+			var commitOps *commitOperationBuilder
 			deletionProposedBranch := createDeletionProposedName(pr2Delete.Key())
 
 			switch {
@@ -592,7 +592,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, pr2Delete rep
 					return fmt.Errorf("cannot delete package tagged with a tag that is not specific to the package: %s", referenceName)
 				}
 				var ref *plumbing.Reference
-				err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+				err := r.sharedDir.withLock(func(repo *git.Repository) error {
 					var err error
 					ref, err = repo.Reference(referenceName, true)
 					return err
@@ -600,12 +600,12 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, pr2Delete rep
 				if err != nil {
 					return err
 				}
-				refSpecs.AddRefToDelete(ref)
-				refSpecs.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
+				refSpecs.addRefToDelete(ref)
+				refSpecs.addRefToDelete(plumbing.NewHashReference(deletionProposedBranch.refInLocal(), plumbing.ZeroHash))
 
 			case isDraftBranchNameInLocal(referenceName), isProposedBranchNameInLocal(referenceName):
 				var ref *plumbing.Reference
-				err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+				err := r.sharedDir.withLock(func(repo *git.Repository) error {
 					var err error
 					ref, err = repo.Reference(referenceName, true)
 					return err
@@ -613,12 +613,12 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, pr2Delete rep
 				if err != nil {
 					return err
 				}
-				refSpecs.AddRefToDelete(ref)
+				refSpecs.addRefToDelete(ref)
 
 			case isBranchInLocalRepo(referenceName):
-				commitOps = NewCommitOperationBuilder()
-				commitOps.AddPackageDeletion(referenceName, pr2Delete.Key())
-				refSpecs.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
+				commitOps = newCommitOperationBuilder()
+				commitOps.addPackageDeletion(referenceName, pr2Delete.Key())
+				refSpecs.addRefToDelete(plumbing.NewHashReference(deletionProposedBranch.refInLocal(), plumbing.ZeroHash))
 
 			default:
 				return fmt.Errorf("cannot delete package with the ref name %s", referenceName)
@@ -711,7 +711,7 @@ func (r *gitRepository) GetPackageRevision(ctx context.Context, version, path st
 		klog.Warningf("Failed to fetch latest references: %v", err)
 	}
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		for _, ref := range refNames {
 			if resolved, err := repo.ResolveRevision(plumbing.Revision(ref)); err != nil {
 				if pkgerrors.Is(err, plumbing.ErrReferenceNotFound) {
@@ -749,7 +749,7 @@ func (r *gitRepository) loadPackageRevision(ctx context.Context, version, path s
 	var lock kptfilev1.GitLock
 	var commit *object.Commit
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		origin, err := repo.Remote("origin")
 		if err != nil {
 			return pkgerrors.Wrap(err, "cannot determine repository origin")
@@ -814,7 +814,7 @@ func (r *gitRepository) discoverFinalizedPackages(ctx context.Context, ref *plum
 	defer span.End()
 
 	var commit *object.Commit
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var err error
 		commit, err = repo.CommitObject(ref.Hash())
 		return err
@@ -833,7 +833,7 @@ func (r *gitRepository) discoverFinalizedPackages(ctx context.Context, ref *plum
 		return nil, pkgerrors.Errorf("cannot determine revision from ref: %q", rev)
 	}
 
-	krmPackages, err := r.discoverPackagesInTree(commit, DiscoverPackagesOptions{FilterPrefix: r.Key().Path, Recurse: true})
+	krmPackages, err := r.discoverPackagesInTree(commit, discoverPackagesOptions{filterPrefix: r.Key().Path, recurse: true})
 	if err != nil {
 		return nil, err
 	}
@@ -872,7 +872,7 @@ func (r *gitRepository) loadDraft(ctx context.Context, ref *plumbing.Reference) 
 	}
 
 	var commit *object.Commit
-	err = r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err = r.sharedDir.withLock(func(repo *git.Repository) error {
 		var err error
 		commit, err = repo.CommitObject(ref.Hash())
 		return err
@@ -912,9 +912,9 @@ func (r *gitRepository) UpdateDeletionProposedCache(ctx context.Context) error {
 
 func (r *gitRepository) updateDeletionProposedCache() error {
 	// Collect deletion proposed branches
-	deletionProposed := make(map[BranchName]bool)
+	deletionProposed := make(map[branchName]bool)
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		refs, err := repo.References()
 		if err != nil {
 			return err
@@ -990,7 +990,7 @@ func (r *gitRepository) loadTaggedPackage(ctx context.Context, tag *plumbing.Ref
 
 	var resolvedHash *plumbing.Hash
 	var commit *object.Commit
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var err error
 		resolvedHash, err = repo.ResolveRevision(plumbing.Revision(tag.Hash().String()))
 		if err != nil {
@@ -1034,7 +1034,7 @@ func (r *gitRepository) loadTaggedPackage(ctx context.Context, tag *plumbing.Ref
 }
 
 func (r *gitRepository) dumpAllRefs() {
-	if err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	if err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		refs, err := repo.References()
 		if err != nil {
 			klog.Warningf("failed to get references: %v", err)
@@ -1117,9 +1117,9 @@ func (r *gitRepository) fetchRemoteRepository(ctx context.Context) error {
 	}
 
 	err := r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
-		return r.sharedDir.WithLock(func(repo *git.Repository) error {
+		return r.sharedDir.withLock(func(repo *git.Repository) error {
 			return repo.FetchContext(ctx, &git.FetchOptions{
-				RemoteName: OriginName,
+				RemoteName: originName,
 				Auth:       auth,
 				Prune:      true,
 				CABundle:   r.caBundle,
@@ -1151,8 +1151,8 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 
 	var needsCreation bool
 	var commitHash plumbing.Hash
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
-		_, err := repo.Reference(r.branch.RefInLocal(), false)
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
+		_, err := repo.Reference(r.branch.refInLocal(), false)
 		if err != nil {
 			switch opts.MainBranchStrategy {
 			case ErrorIfMissing:
@@ -1163,7 +1163,7 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 					return err
 				}
 				// Get the commit hash for pushing
-				ref, err := repo.Reference(r.branch.RefInLocal(), false)
+				ref, err := repo.Reference(r.branch.refInLocal(), false)
 				if err != nil {
 					return err
 				}
@@ -1182,7 +1182,7 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 	// Push the branch outside of the lock to avoid race conditions
 	if needsCreation {
 		refSpecs := newPushRefSpecBuilder()
-		refSpecs.AddRefToPush(commitHash, r.branch.RefInLocal())
+		refSpecs.addRefToPush(commitHash, r.branch.refInLocal())
 		if err := r.pushAndCleanup(ctx, refSpecs, nil); err != nil {
 			return fmt.Errorf("error pushing main branch %q: %v", r.branch, err)
 		}
@@ -1192,7 +1192,7 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 
 // createBranch creates the provided branch by creating a commit containing
 // a README.md file on the root of the repo and then pushing it to the branch.
-func (r *gitRepository) createBranch(repo *git.Repository, branch BranchName) error {
+func (r *gitRepository) createBranch(repo *git.Repository, branch branchName) error {
 	fileHash, err := storeBlob(repo, fileContent)
 	if err != nil {
 		return err
@@ -1236,13 +1236,13 @@ func (r *gitRepository) createBranch(repo *git.Repository, branch BranchName) er
 	}
 
 	// Create local reference
-	ref := plumbing.NewHashReference(branch.RefInLocal(), commitHash)
+	ref := plumbing.NewHashReference(branch.refInLocal(), commitHash)
 	return repo.Storer.SetReference(ref)
 }
 
 func (r *gitRepository) commitPackageToMainInRepo(ctx context.Context, repo *git.Repository, d *gitPackageRevisionDraft) (commitHash, newPackageTreeHash plumbing.Hash, err error) {
 	branch := r.branch
-	localRef := branch.RefInLocal()
+	localRef := branch.refInLocal()
 
 	// Find localTarget branch - get latest state
 	localTarget, err := repo.Reference(localRef, true)
@@ -1274,7 +1274,7 @@ func (r *gitRepository) commitPackageToMainInRepo(ctx context.Context, repo *git
 		return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed to initialize commit of package %s to %s: %w", packagePath, localRef, err)
 	}
 
-	message, err := AnnotateCommitMessage(fmt.Sprintf(commitMessageApproveTemplate, d.Key().PkgKey.ToFullPathname(), d.Key().Revision), &gitAnnotation{
+	message, err := annotateCommitMessage(fmt.Sprintf(commitMessageApproveTemplate, d.Key().PkgKey.ToFullPathname(), d.Key().Revision), &gitAnnotation{
 		PackagePath:   d.Key().PkgKey.ToFullPathname(),
 		WorkspaceName: d.Key().WorkspaceName,
 		Revision:      repository.Revision2Str(d.Key().Revision),
@@ -1344,11 +1344,11 @@ func (r *gitRepository) createPackageDeleteCommitInRepo(ctx context.Context, rep
 	return hash, nil
 }
 
-func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.Repository, ph *pushRefSpecBuilder, commitOps *CommitOperationBuilder) error {
-	for _, op := range commitOps.GetOperations() {
-		switch op.Type {
+func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.Repository, ph *pushRefSpecBuilder, commitOps *commitOperationBuilder) error {
+	for _, op := range commitOps.getOperations() {
+		switch op.opType {
 		case "approval":
-			data := op.Data.(map[string]interface{})
+			data := op.data.(map[string]interface{})
 			d := data["draft"].(*gitPackageRevisionDraft)
 			tag := data["tag"].(plumbing.ReferenceName)
 
@@ -1357,14 +1357,14 @@ func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.R
 				return err
 			}
 
-			ph.AddRefToPush(commitHash, r.branch.RefInLocal())
-			ph.AddRefToPush(commitHash, tag)
+			ph.addRefToPush(commitHash, r.branch.refInLocal())
+			ph.addRefToPush(commitHash, tag)
 
 			d.commit = commitHash
 			d.tree = newTreeHash
 
 		case "deletion":
-			data := op.Data.(map[string]interface{})
+			data := op.data.(map[string]interface{})
 			branch := data["branch"].(plumbing.ReferenceName)
 			prKey := data["prKey"].(repository.PackageRevisionKey)
 
@@ -1374,14 +1374,14 @@ func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.R
 			}
 
 			if !commitHash.IsZero() {
-				ph.AddRefToPush(commitHash, branch)
+				ph.addRefToPush(commitHash, branch)
 			}
 		}
 	}
 	return nil
 }
 
-func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuilder, commitOps *CommitOperationBuilder) error {
+func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuilder, commitOps *commitOperationBuilder) error {
 	ctx, span := tracer.Start(ctx, "gitRepository::pushAndCleanup", trace.WithAttributes())
 	defer span.End()
 
@@ -1395,9 +1395,9 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 	maxRetries := r.repoOperationRetryAttempts
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		if err := r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
-			return r.sharedDir.WithLock(func(repo *git.Repository) error {
+			return r.sharedDir.withLock(func(repo *git.Repository) error {
 				if fetchErr := repo.Fetch(&git.FetchOptions{
-					RemoteName: OriginName,
+					RemoteName: originName,
 					Auth:       auth,
 					CABundle:   r.caBundle,
 				}); fetchErr != nil && fetchErr != git.NoErrAlreadyUpToDate {
@@ -1414,20 +1414,20 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 
 				ph.updateRequiredRefs(repo)
 
-				specs, require, err := ph.BuildRefSpecs()
+				specs, require, err := ph.buildRefSpecs()
 				if err != nil {
 					return err
 				}
 
 				pushStart := time.Now()
 				if len(require) > 0 {
-					klog.Infof("git push attempt %d: pushing %v to %s/%s, requiring %v", attempt, specs, OriginName, r.key.Name, require)
+					klog.Infof("git push attempt %d: pushing %v to %s/%s, requiring %v", attempt, specs, originName, r.key.Name, require)
 				} else {
-					klog.Infof("git push attempt %d: pushing %v to %s/%s", attempt, specs, OriginName, r.key.Name)
+					klog.Infof("git push attempt %d: pushing %v to %s/%s", attempt, specs, originName, r.key.Name)
 				}
 
 				pushErr := repo.Push(&git.PushOptions{
-					RemoteName: OriginName,
+					RemoteName: originName,
 					RefSpecs:   specs,
 					Auth:       auth,
 					Force:      false,
@@ -1436,7 +1436,7 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 				if pushErr != nil {
 					klog.Warningf("git push failed attempt %d: %v", attempt, pushErr)
 				} else {
-					klog.Infof("git push completed: pushed %v to %s/%s in %s", specs, OriginName, r.key.Name, time.Since(pushStart))
+					klog.Infof("git push completed: pushed %v to %s/%s in %s", specs, originName, r.key.Name, time.Since(pushStart))
 				}
 				return pushErr
 			})
@@ -1476,7 +1476,7 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 
 func (r *gitRepository) loadTasks(_ context.Context, startCommit *object.Commit, key repository.PackageRevisionKey) ([]porchapi.Task, error) {
 	var tasks []porchapi.Task
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var logOptions = git.LogOptions{
 			From:  startCommit.Hash,
 			Order: git.LogOrderCommitterTime,
@@ -1493,7 +1493,7 @@ func (r *gitRepository) loadTasks(_ context.Context, startCommit *object.Commit,
 				return nil
 			}
 
-			gitAnnotations, err := ExtractGitAnnotations(commit)
+			gitAnnotations, err := extractGitAnnotations(commit)
 			if err != nil {
 				klog.Warningf("Error extracting (some) git annotations from commit %q: %s", commit.Hash, err)
 			}
@@ -1559,7 +1559,7 @@ func visitCommitsCollectErrors(iterator object.CommitIter, callback commitCallba
 
 func (r *gitRepository) GetResource(hash plumbing.Hash, filePath string) (string, error) {
 	var content string
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		tree, err := repo.TreeObject(hash)
 		if err != nil {
 			return err
@@ -1579,7 +1579,7 @@ func (r *gitRepository) GetResource(hash plumbing.Hash, filePath string) (string
 func (r *gitRepository) GetResources(hash plumbing.Hash) (map[string]string, error) {
 	resources := map[string]string{}
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		tree, err := repo.TreeObject(hash)
 		if err != nil {
 			return err
@@ -1618,7 +1618,7 @@ func (r *gitRepository) GetResources(hash plumbing.Hash) (map[string]string, err
 // to the package given by the packagePath. If no commit is found, it will return nil and an error.
 func (r *gitRepository) findLatestPackageCommit(startCommit *object.Commit, key repository.PackageKey) (*object.Commit, error) {
 	var result *object.Commit
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		var logOptions = git.LogOptions{
 			From:  startCommit.Hash,
 			Order: git.LogOrderCommitterTime,
@@ -1630,7 +1630,7 @@ func (r *gitRepository) findLatestPackageCommit(startCommit *object.Commit, key 
 		}
 
 		for c, err := commits.Next(); err == nil; c, err = commits.Next() {
-			gitAnnotations, err := ExtractGitAnnotations(c)
+			gitAnnotations, err := extractGitAnnotations(c)
 			if err != nil {
 				klog.Warningf("Error extracting (some) annotations from commit %q: %s", c.Hash, err)
 			}
@@ -1725,7 +1725,7 @@ func (r *gitRepository) UpdateLifecycle(ctx context.Context, pkgRev *gitPackageR
 		}
 		// Push the package revision into a deletionProposed branch.
 		r.deletionProposedCache[deletionProposedBranch] = true
-		refSpecs.AddRefToPush(pkgRev.commit, deletionProposedBranch.RefInLocal())
+		refSpecs.addRefToPush(pkgRev.commit, deletionProposedBranch.refInLocal())
 	case porchapi.PackageRevisionLifecycleDeletionProposed:
 		if newLifecycle != porchapi.PackageRevisionLifecyclePublished {
 			r.mutex.Unlock()
@@ -1733,8 +1733,8 @@ func (r *gitRepository) UpdateLifecycle(ctx context.Context, pkgRev *gitPackageR
 		}
 		// Delete the deletionProposed branch
 		delete(r.deletionProposedCache, deletionProposedBranch)
-		ref := plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), pkgRev.commit)
-		refSpecs.AddRefToDelete(ref)
+		ref := plumbing.NewHashReference(deletionProposedBranch.refInLocal(), pkgRev.commit)
+		refSpecs.addRefToDelete(ref)
 	}
 	r.mutex.Unlock() // Release mutex before git operations
 
@@ -1751,7 +1751,7 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 	ctx, span := tracer.Start(ctx, "gitRepository::UpdateResources", trace.WithAttributes())
 	defer span.End()
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		ch, err := newCommitHelper(repo, r.userInfoProvider, draft.commit, draft.Key().PkgKey.ToFullPathname(), plumbing.ZeroHash)
 		if err != nil {
 			return pkgerrors.Wrap(err, "failed to commit package:")
@@ -1791,7 +1791,7 @@ func (r *gitRepository) UpdateDraftResources(ctx context.Context, draft *gitPack
 		}
 		message += "\n"
 
-		message, err = AnnotateCommitMessage(message, annotation)
+		message, err = annotateCommitMessage(message, annotation)
 		if err != nil {
 			return err
 		}
@@ -1821,7 +1821,7 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 	}()
 
 	refSpecs := newPushRefSpecBuilder()
-	commitOps := NewCommitOperationBuilder()
+	commitOps := newCommitOperationBuilder()
 	draftBranch := createDraftName(d.Key())
 	proposedBranch := createProposedName(d.Key())
 	targetBranch := string(r.branch)
@@ -1840,13 +1840,13 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 
 		// Finalize the package revision. Commit will be created in pushAndCleanup
 		tag := createFinalTagNameInLocal(d.Key())
-		commitOps.AddPackageApproval(d, tag)
+		commitOps.addPackageApproval(d, tag)
 
 		// Delete base branch (if one exists and should be deleted)
 		switch base := d.base; {
 		case base == nil: // no branch to delete
-		case base.Name() == draftBranch.RefInLocal(), base.Name() == proposedBranch.RefInLocal():
-			refSpecs.AddRefToDelete(base)
+		case base.Name() == draftBranch.refInLocal(), base.Name() == proposedBranch.refInLocal():
+			refSpecs.addRefToDelete(base)
 		}
 
 		// Reference will be created after successful commit in pushAndCleanup
@@ -1854,34 +1854,34 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 
 	case porchapi.PackageRevisionLifecycleProposed:
 		// Push the package revision into a proposed branch.
-		refSpecs.AddRefToPush(d.commit, proposedBranch.RefInLocal())
+		refSpecs.addRefToPush(d.commit, proposedBranch.refInLocal())
 		// Set the target to the proposed branch.
 		targetBranch = string(proposedBranch)
 
 		// Delete base branch (if one exists and should be deleted)
 		switch base := d.base; {
 		case base == nil: // no branch to delete
-		case base.Name() != proposedBranch.RefInLocal():
-			refSpecs.AddRefToDelete(base)
+		case base.Name() != proposedBranch.refInLocal():
+			refSpecs.addRefToDelete(base)
 		}
 
 		// Update package reference (commit and tree hash stay the same)
-		newRef = plumbing.NewHashReference(proposedBranch.RefInLocal(), d.commit)
+		newRef = plumbing.NewHashReference(proposedBranch.refInLocal(), d.commit)
 
 	case porchapi.PackageRevisionLifecycleDraft:
 		// Push the package revision into a draft branch.
-		refSpecs.AddRefToPush(d.commit, draftBranch.RefInLocal())
+		refSpecs.addRefToPush(d.commit, draftBranch.refInLocal())
 		// Set the target to the draft branch.
 		targetBranch = string(draftBranch)
 		// Delete base branch (if one exists and should be deleted)
 		switch base := d.base; {
 		case base == nil: // no branch to delete
-		case base.Name() != draftBranch.RefInLocal():
-			refSpecs.AddRefToDelete(base)
+		case base.Name() != draftBranch.refInLocal():
+			refSpecs.addRefToDelete(base)
 		}
 
 		// Update package reference (commit and tree hash stay the same)
-		newRef = plumbing.NewHashReference(draftBranch.RefInLocal(), d.commit)
+		newRef = plumbing.NewHashReference(draftBranch.refInLocal(), d.commit)
 
 	default:
 		return nil, fmt.Errorf("package has unrecognized lifecycle: %q", d.lifecycle)
@@ -1950,7 +1950,7 @@ func (r *gitRepository) doGitWithAuth(ctx context.Context, op func(transport.Aut
 // findPackage finds the packages in the git repository, under commit, if it is exists at path.
 // If no package is found at that path, returns nil, nil
 func (r *gitRepository) findPackage(commit *object.Commit, packagePath string) (*packageListEntry, error) {
-	t, err := r.discoverPackagesInTree(commit, DiscoverPackagesOptions{FilterPrefix: packagePath, Recurse: false})
+	t, err := r.discoverPackagesInTree(commit, discoverPackagesOptions{filterPrefix: packagePath, recurse: false})
 	if err != nil {
 		return nil, err
 	}
@@ -1961,35 +1961,35 @@ func (r *gitRepository) findPackage(commit *object.Commit, packagePath string) (
 // If filterPrefix is non-empty, only packages with the specified prefix will be returned.
 // It is not an error if filterPrefix matches no packages or even is not a real directory name;
 // we will simply return an empty list of packages.
-func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt DiscoverPackagesOptions) (*packageList, error) {
+func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt discoverPackagesOptions) (*packageList, error) {
 	t := &packageList{
 		parent:   r,
 		commit:   commit,
 		packages: make(map[string]*packageListEntry),
 	}
 
-	err := r.sharedDir.WithLock(func(repo *git.Repository) error {
+	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		rootTree, err := commit.Tree()
 		if err != nil {
 			return pkgerrors.Wrapf(err, "cannot resolve commit %v to tree (corrupted repository?)", commit.Hash)
 		}
 
-		if opt.FilterPrefix != "" {
-			tree, err := rootTree.Tree(opt.FilterPrefix)
+		if opt.filterPrefix != "" {
+			tree, err := rootTree.Tree(opt.filterPrefix)
 			if err != nil {
 				if err == object.ErrDirectoryNotFound {
 					// We treat the filter prefix as a filter, the path doesn't have to exist
-					klog.Warningf("could not find filterPrefix %q in commit %v; returning no packages", opt.FilterPrefix, commit.Hash)
+					klog.Warningf("could not find filterPrefix %q in commit %v; returning no packages", opt.filterPrefix, commit.Hash)
 					return nil
 				} else {
-					return pkgerrors.Wrapf(err, "error getting tree %s", opt.FilterPrefix)
+					return pkgerrors.Wrapf(err, "error getting tree %s", opt.filterPrefix)
 				}
 			}
 			rootTree = tree
 		}
 
 		if rootTree != nil {
-			return t.discoverPackages(r.Key(), rootTree, opt.FilterPrefix, opt.Recurse, repo)
+			return t.discoverPackages(r.Key(), rootTree, opt.filterPrefix, opt.recurse, repo)
 		}
 		return nil
 	})
@@ -1997,7 +1997,7 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 		return nil, err
 	}
 
-	if opt.FilterPrefix == "" {
+	if opt.filterPrefix == "" {
 		klog.Infof("discovered %d packages @%v", len(t.packages), commit.Hash)
 	}
 	return t, nil
@@ -2021,7 +2021,7 @@ func getPkgWorkspace(commit *object.Commit, p *packageListEntry, ref *plumbing.R
 		}
 		commit = c
 	}
-	annotations, err := ExtractGitAnnotations(commit)
+	annotations, err := extractGitAnnotations(commit)
 	if err != nil {
 		klog.Warningf("Error extracting git annotations for package %s: %s", p.pkgKey, err)
 	}

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -123,7 +123,7 @@ func (g GitSuite) TestOpenEmptyRepository(t *testing.T) {
 	if _, err := OpenRepository(ctx, name, namespace, repository, deployment, tempdir, opts); err != nil {
 		t.Errorf("Failed to create new main branch: %v", err)
 	}
-	_, err := repo.Reference(BranchName(g.branch).RefInRemote(), false)
+	_, err := repo.Reference(branchName(g.branch).refInRemote(), false)
 	if err != nil {
 		t.Errorf("Couldn't find branch %q after opening repository with CreateIfMissing strategy: %v", g.branch, err)
 	}
@@ -765,7 +765,7 @@ func (g GitSuite) TestCloseProposedPackage(t *testing.T) {
 	assert.Equal(t, porchapi.PackageRevisionLifecycleProposed, result.Spec.Lifecycle, "Package lifecycle")
 
 	proposedBranch := createProposedName(newRevision.Key())
-	refMustExist(t, repo, proposedBranch.RefInRemote())
+	refMustExist(t, repo, proposedBranch.refInRemote())
 }
 
 func (g GitSuite) TestApproveDraft(t *testing.T) {
@@ -776,7 +776,7 @@ func (g GitSuite) TestApproveDraft(t *testing.T) {
 	const (
 		repositoryName                            = "approve"
 		namespace                                 = "default"
-		draft              BranchName             = "drafts/bucket/v1"
+		draft              branchName             = "drafts/bucket/v1"
 		finalReferenceName plumbing.ReferenceName = "refs/tags/bucket/v1"
 		deployment                                = true
 	)
@@ -805,7 +805,7 @@ func (g GitSuite) TestApproveDraft(t *testing.T) {
 	})
 
 	// Before Update; Check server references. Draft must exist, final not.
-	refMustExist(t, repo, draft.RefInRemote())
+	refMustExist(t, repo, draft.refInRemote())
 	refMustNotExist(t, repo, finalReferenceName)
 
 	update, err := git.UpdatePackageRevision(ctx, bucket)
@@ -831,7 +831,7 @@ func (g GitSuite) TestApproveDraft(t *testing.T) {
 	}
 
 	// After Update: Final must exist, draft must not exist
-	refMustNotExist(t, repo, draft.RefInRemote())
+	refMustNotExist(t, repo, draft.refInRemote())
 	refMustExist(t, repo, finalReferenceName)
 }
 
@@ -843,7 +843,7 @@ func (g GitSuite) TestApproveDraftWithHistory(t *testing.T) {
 	const (
 		repositoryName                            = "approve"
 		namespace                                 = "default"
-		draft              BranchName             = "drafts/pkg-with-history/v1"
+		draft              branchName             = "drafts/pkg-with-history/v1"
 		finalReferenceName plumbing.ReferenceName = "refs/tags/pkg-with-history/v1"
 		deployment                                = true
 	)
@@ -875,7 +875,7 @@ func (g GitSuite) TestApproveDraftWithHistory(t *testing.T) {
 	})
 
 	// Before Update; Check server references. Draft must exist, final not.
-	refMustExist(t, repo, draft.RefInRemote())
+	refMustExist(t, repo, draft.refInRemote())
 	refMustNotExist(t, repo, finalReferenceName)
 
 	update, err := git.UpdatePackageRevision(ctx, bucket)
@@ -904,7 +904,7 @@ func (g GitSuite) TestApproveDraftWithHistory(t *testing.T) {
 	}
 
 	// After Update: Final must exist, draft must not exist
-	refMustNotExist(t, repo, draft.RefInRemote())
+	refMustNotExist(t, repo, draft.refInRemote())
 	refMustExist(t, repo, finalReferenceName)
 }
 
@@ -1005,7 +1005,7 @@ func (g GitSuite) TestDeletePackages(t *testing.T) {
 	branch := plumbing.NewBranchReferenceName(g.branch)
 	want := map[plumbing.ReferenceName]bool{
 		branch:                   true,
-		DefaultMainReferenceName: true,
+		defaultMainReferenceName: true,
 		"HEAD":                   true,
 	}
 	if !cmp.Equal(want, got) {
@@ -1235,7 +1235,7 @@ func (g GitSuite) TestNested(t *testing.T) {
 			want[strings.TrimPrefix(name, proposedPrefixInRemoteRepo)] = porchapi.PackageRevisionLifecycleProposed
 		case name == string(branch):
 			// Skip the registered 'main' branch.
-		case name == string(DefaultMainReferenceName), name == "HEAD":
+		case name == string(defaultMainReferenceName), name == "HEAD":
 			// skip main and HEAD
 		default:
 			// There should be no other refs in the repository.
@@ -1947,7 +1947,7 @@ func TestApproveOnManuallyMovedMain(t *testing.T) {
 	}
 
 	uip := makeUserInfoProvider(repoSpec, &mockK8sUsp{})
-	mainBranchCommitHash := resolveReference(t, gitRepo, DefaultMainReferenceName).Hash()
+	mainBranchCommitHash := resolveReference(t, gitRepo, defaultMainReferenceName).Hash()
 	ch, err := newCommitHelper(gitRepo, uip, mainBranchCommitHash, "", plumbing.ZeroHash)
 	if err != nil {
 		t.Fatalf("Failed to create commit helper: %v", err)
@@ -1964,11 +1964,11 @@ func TestApproveOnManuallyMovedMain(t *testing.T) {
 		t.Fatalf("Failed to create commit: %v", err)
 	}
 
-	err = gitRepo.Storer.SetReference(plumbing.NewHashReference(DefaultMainReferenceName, newHash))
+	err = gitRepo.Storer.SetReference(plumbing.NewHashReference(defaultMainReferenceName, newHash))
 	if err != nil {
 		t.Fatalf("Failed to set reference: %v", err)
 	}
-	t.Logf("Moved %s from %s to %s", DefaultMainReferenceName, mainBranchCommitHash, newHash)
+	t.Logf("Moved %s from %s to %s", defaultMainReferenceName, mainBranchCommitHash, newHash)
 
 	_, err = localRepo.ClosePackageRevisionDraft(ctx, draft1, 1)
 
@@ -2375,8 +2375,8 @@ func TestPushRetryWithTransientError(t *testing.T) {
 
 	// Create a new commit to push
 	var newCommitHash plumbing.Hash
-	err = testrepo.sharedDir.WithLock(func(repo *gogit.Repository) error {
-		mainRef, err := repo.Reference(testrepo.branch.RefInLocal(), true)
+	err = testrepo.sharedDir.withLock(func(repo *gogit.Repository) error {
+		mainRef, err := repo.Reference(testrepo.branch.refInLocal(), true)
 		if err != nil {
 			return err
 		}
@@ -2408,7 +2408,7 @@ func TestPushRetryWithTransientError(t *testing.T) {
 	}()
 
 	refSpecs := newPushRefSpecBuilder()
-	refSpecs.AddRefToPush(newCommitHash, testrepo.branch.RefInLocal())
+	refSpecs.addRefToPush(newCommitHash, testrepo.branch.refInLocal())
 
 	err = testrepo.pushAndCleanup(ctx, refSpecs, nil)
 
@@ -2469,8 +2469,8 @@ func TestPushFailures(t *testing.T) {
 			testrepo := localRepo.(*gitRepository)
 
 			var newCommitHash plumbing.Hash
-			err = testrepo.sharedDir.WithLock(func(repo *gogit.Repository) error {
-				mainRef, err := repo.Reference(testrepo.branch.RefInLocal(), true)
+			err = testrepo.sharedDir.withLock(func(repo *gogit.Repository) error {
+				mainRef, err := repo.Reference(testrepo.branch.refInLocal(), true)
 				if err != nil {
 					return err
 				}
@@ -2499,7 +2499,7 @@ func TestPushFailures(t *testing.T) {
 			})
 
 			refSpecs := newPushRefSpecBuilder()
-			refSpecs.AddRefToPush(newCommitHash, testrepo.branch.RefInLocal())
+			refSpecs.addRefToPush(newCommitHash, testrepo.branch.refInLocal())
 
 			err = testrepo.pushAndCleanup(ctx, refSpecs, nil)
 

--- a/pkg/externalrepo/git/gogit.go
+++ b/pkg/externalrepo/git/gogit.go
@@ -45,7 +45,7 @@ func initializeDefaultBranches(repo *git.Repository) error {
 		return pkgerrors.Wrapf(err, "gogit: failed to remove reference %+v on repo %+v", plumbing.Master, repo)
 	}
 	// gogit points HEAD at a wrong branch; point it at main
-	main := plumbing.NewSymbolicReference(plumbing.HEAD, DefaultMainReferenceName)
+	main := plumbing.NewSymbolicReference(plumbing.HEAD, defaultMainReferenceName)
 	if err := repo.Storer.SetReference(main); err != nil {
 		return pkgerrors.Wrapf(err, "gogit: failed to set reference %+v on repo %+v", main, repo)
 	}
@@ -66,8 +66,8 @@ func initializeOrigin(repo *git.Repository, address string) error {
 		return pkgerrors.Wrapf(err, "gogit: failed to get configuration for repo %+v", repo)
 	}
 
-	cfg.Remotes[OriginName] = &config.RemoteConfig{
-		Name:  OriginName,
+	cfg.Remotes[originName] = &config.RemoteConfig{
+		Name:  originName,
 		URLs:  []string{address},
 		Fetch: defaultFetchSpec,
 	}

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -170,7 +170,7 @@ func (p *gitPackageRevision) ToMainPackageRevision(context.Context) repository.P
 	//Need to compute a separate reference, otherwise the ref will be the same as the versioned package,
 	//while the main gitPackageRevision needs to point at the main branch.
 
-	mainBranchRef := plumbing.NewHashReference(p.repo.branch.RefInLocal(), p.commit)
+	mainBranchRef := plumbing.NewHashReference(p.repo.branch.refInLocal(), p.commit)
 	mainPr := &gitPackageRevision{
 		repo:      p.repo,
 		prKey:     p.prKey,

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -129,7 +129,7 @@ func (p *gitPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 }
 
 func (p *gitPackageRevision) GetResources(context.Context) (*porchapi.PackageRevisionResources, error) {
-	resources, err := p.repo.GetResources(p.tree)
+	resources, err := p.repo.getResources(p.tree)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package resources: %w", err)
 	}
@@ -188,7 +188,7 @@ func (p *gitPackageRevision) ToMainPackageRevision(context.Context) repository.P
 }
 
 func (p *gitPackageRevision) GetKptfile(context.Context) (kptfilev1.KptFile, error) {
-	kfString, err := p.repo.GetResource(p.tree, kptfilev1.KptFileName)
+	kfString, err := p.repo.getResource(p.tree, kptfilev1.KptFileName)
 	if err != nil {
 		return kptfilev1.KptFile{}, pkgerrors.Wrapf(err, "error getting %s resource", kptfilev1.KptFileName)
 	}

--- a/pkg/externalrepo/git/package_tree.go
+++ b/pkg/externalrepo/git/package_tree.go
@@ -133,14 +133,14 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 	}, nil
 }
 
-// DiscoverPackagesOptions holds the configuration for walking a git tree
-type DiscoverPackagesOptions struct {
-	// FilterPrefix restricts package discovery to a particular subdirectory.
+// discoverPackagesOptions holds the configuration for walking a git tree
+type discoverPackagesOptions struct {
+	// filterPrefix restricts package discovery to a particular subdirectory.
 	// The subdirectory is not required to exist (we will return an empty list of packages).
-	FilterPrefix string
+	filterPrefix string
 
-	// Recurse enables recursive traversal of the git tree.
-	Recurse bool
+	// recurse enables recursive traversal of the git tree.
+	recurse bool
 }
 
 // discoverPackages is the recursive function we use to traverse the tree and find packages.

--- a/pkg/externalrepo/git/primitives_test.go
+++ b/pkg/externalrepo/git/primitives_test.go
@@ -120,7 +120,7 @@ func TestSimplePush(t *testing.T) {
 		// Create a first commit in test branch
 		commit = createTestCommit(t, downstream, draftRef.Hash(), "Draft Commit", "readme.txt", "Hello, World!")
 		if err := downstream.Push(&git.PushOptions{
-			RemoteName: OriginName,
+			RemoteName: originName,
 			RefSpecs: []config.RefSpec{
 				config.RefSpec(fmt.Sprintf("%s:%s", commit, draftReferenceName)),
 			},
@@ -140,7 +140,7 @@ func TestSimplePush(t *testing.T) {
 		// Create a competing concurrent in a test branch
 		concurrent := createTestCommit(t, downstream, draftRef.Hash(), "Competing Commit", "test.txt", "competing commit")
 		switch err := downstream.Push(&git.PushOptions{
-			RemoteName: OriginName,
+			RemoteName: originName,
 			RefSpecs: []config.RefSpec{
 				config.RefSpec(fmt.Sprintf("%s:%s", concurrent, draftReferenceName)),
 			},
@@ -192,7 +192,7 @@ func TestFinalPush(t *testing.T) {
 		// Create first commit and tag (finalized package)
 		commit = createTestCommit(t, downstream, main.Hash(), "Package One", "one.txt", "initial")
 		if err := downstream.Push(&git.PushOptions{
-			RemoteName: OriginName,
+			RemoteName: originName,
 			RefSpecs: []config.RefSpec{
 				config.RefSpec(fmt.Sprintf("%s:%s", commit, mainReferenceName)),
 				config.RefSpec(fmt.Sprintf("%s:%s", commit, packageTagReferenceName)),
@@ -217,7 +217,7 @@ func TestFinalPush(t *testing.T) {
 
 		// Simulated concurrent push should fail
 		switch err := downstream.Push(&git.PushOptions{
-			RemoteName: OriginName,
+			RemoteName: originName,
 			RefSpecs: []config.RefSpec{
 				config.RefSpec(fmt.Sprintf("%s:%s", concurrent, mainReferenceName)),
 			},
@@ -235,7 +235,7 @@ func TestFinalPush(t *testing.T) {
 
 		// Liewise, push to the tag should fail
 		switch err := downstream.Push(&git.PushOptions{
-			RemoteName: OriginName,
+			RemoteName: originName,
 			RefSpecs: []config.RefSpec{
 				config.RefSpec(fmt.Sprintf("%s:%s", concurrent, packageTagReferenceName)),
 			},
@@ -353,7 +353,7 @@ func TestProposal(t *testing.T) {
 
 	// Simulate changing package to proposed
 	if err := downstream.Push(&git.PushOptions{
-		RemoteName: OriginName,
+		RemoteName: originName,
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(fmt.Sprintf("%s:%s", bucket.Hash(), upstreamProposedRef)),
 			config.RefSpec(fmt.Sprintf(":%s", upstreamDraftRef)),
@@ -391,7 +391,7 @@ func TestDeleteUpstreamBranches(t *testing.T) {
 
 	// Delete upstream tags and branches
 	forEachRef(t, upstream, func(ref *plumbing.Reference) error {
-		if ref.Name() != DefaultMainReferenceName { // keep main
+		if ref.Name() != defaultMainReferenceName { // keep main
 			return upstream.Storer.RemoveReference(ref.Name())
 		}
 		return nil
@@ -401,7 +401,7 @@ func TestDeleteUpstreamBranches(t *testing.T) {
 
 	// Refetch
 	switch err := downstream.Fetch(&git.FetchOptions{
-		RemoteName: OriginName,
+		RemoteName: originName,
 		Tags:       git.NoTags,
 		Prune:      true,
 	}); err {
@@ -429,7 +429,7 @@ func initRepositoryWithRemote(t *testing.T, dir, address string) *git.Repository
 	repo := InitEmptyRepositoryWithWorktree(t, dir)
 
 	if _, err := repo.CreateRemote(&config.RemoteConfig{
-		Name:  OriginName,
+		Name:  originName,
 		URLs:  []string{address},
 		Fetch: defaultFetchSpec,
 	}); err != nil {

--- a/pkg/externalrepo/git/push.go
+++ b/pkg/externalrepo/git/push.go
@@ -34,16 +34,16 @@ func newPushRefSpecBuilder() *pushRefSpecBuilder {
 	}
 }
 
-func (b *pushRefSpecBuilder) AddRefToPush(hash plumbing.Hash, to plumbing.ReferenceName) {
+func (b *pushRefSpecBuilder) addRefToPush(hash plumbing.Hash, to plumbing.ReferenceName) {
 	b.pushRefs[to] = hash
 }
 
-func (b *pushRefSpecBuilder) AddRefToDelete(ref *plumbing.Reference) {
-	b.AddRefToPush(plumbing.ZeroHash, ref.Name())
-	b.RequireRef(ref)
+func (b *pushRefSpecBuilder) addRefToDelete(ref *plumbing.Reference) {
+	b.addRefToPush(plumbing.ZeroHash, ref.Name())
+	b.requireRef(ref)
 }
 
-func (b *pushRefSpecBuilder) RequireRef(ref *plumbing.Reference) {
+func (b *pushRefSpecBuilder) requireRef(ref *plumbing.Reference) {
 	if ref != nil {
 		b.require[ref.Name()] = ref.Hash()
 	}
@@ -64,7 +64,7 @@ func (b *pushRefSpecBuilder) updateRequiredRefs(repo *git.Repository) {
 	}
 }
 
-func (b *pushRefSpecBuilder) BuildRefSpecs() (push []config.RefSpec, require []config.RefSpec, err error) {
+func (b *pushRefSpecBuilder) buildRefSpecs() (push []config.RefSpec, require []config.RefSpec, err error) {
 	for local, hash := range b.pushRefs {
 		remote, err := refInRemoteFromRefInLocal(local)
 		if err != nil {

--- a/pkg/externalrepo/git/ref.go
+++ b/pkg/externalrepo/git/ref.go
@@ -79,10 +79,6 @@ func (b branchName) refInLocal() plumbing.ReferenceName {
 	return plumbing.ReferenceName(branchPrefixInLocalRepo + string(b))
 }
 
-func (b branchName) forceFetchSpec() config.RefSpec {
-	return config.RefSpec(fmt.Sprintf("+%s:%s", b.refInRemote(), b.refInLocal()))
-}
-
 func isProposedBranchNameInLocal(n plumbing.ReferenceName) bool {
 	return strings.HasPrefix(n.String(), proposedPrefixInLocalRepo)
 }

--- a/pkg/externalrepo/git/ref.go
+++ b/pkg/externalrepo/git/ref.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	MainBranch BranchName = "main"
+	mainBranch branchName = "main"
 
-	branchPrefixInLocalRepo  = "refs/remotes/" + OriginName + "/"
+	branchPrefixInLocalRepo  = "refs/remotes/" + originName + "/"
 	branchPrefixInRemoteRepo = "refs/heads/"
 	tagsPrefixInLocalRepo    = "refs/tags/"
 	tagsPrefixInRemoteRepo   = "refs/tags/"
@@ -65,45 +65,45 @@ var (
 	}
 )
 
-// BranchName represents a relative branch name (i.e. 'main', 'drafts/bucket/v1')
+// branchName represents a relative branch name (i.e. 'main', 'drafts/bucket/v1')
 // and supports transformation to the ReferenceName in local (cached) repository
 // (those references are in the form 'refs/remotes/origin/...') or in the remote
 // repository (those references are in the form 'refs/heads/...').
-type BranchName string
+type branchName string
 
-func (b BranchName) RefInRemote() plumbing.ReferenceName {
+func (b branchName) refInRemote() plumbing.ReferenceName {
 	return plumbing.ReferenceName(branchPrefixInRemoteRepo + string(b))
 }
 
-func (b BranchName) RefInLocal() plumbing.ReferenceName {
+func (b branchName) refInLocal() plumbing.ReferenceName {
 	return plumbing.ReferenceName(branchPrefixInLocalRepo + string(b))
 }
 
-func (b BranchName) ForceFetchSpec() config.RefSpec {
-	return config.RefSpec(fmt.Sprintf("+%s:%s", b.RefInRemote(), b.RefInLocal()))
+func (b branchName) forceFetchSpec() config.RefSpec {
+	return config.RefSpec(fmt.Sprintf("+%s:%s", b.refInRemote(), b.refInLocal()))
 }
 
 func isProposedBranchNameInLocal(n plumbing.ReferenceName) bool {
 	return strings.HasPrefix(n.String(), proposedPrefixInLocalRepo)
 }
 
-func getProposedBranchNameInLocal(n plumbing.ReferenceName) (BranchName, bool) {
+func getProposedBranchNameInLocal(n plumbing.ReferenceName) (branchName, bool) {
 	b, ok := trimOptionalPrefix(n.String(), proposedPrefixInLocalRepo)
-	return BranchName(b), ok
+	return branchName(b), ok
 }
 
 func isDraftBranchNameInLocal(n plumbing.ReferenceName) bool {
 	return strings.HasPrefix(n.String(), draftsPrefixInLocalRepo)
 }
 
-func getDraftBranchNameInLocal(n plumbing.ReferenceName) (BranchName, bool) {
+func getDraftBranchNameInLocal(n plumbing.ReferenceName) (branchName, bool) {
 	b, ok := trimOptionalPrefix(n.String(), draftsPrefixInLocalRepo)
-	return BranchName(b), ok
+	return branchName(b), ok
 }
 
-func getdeletionProposedBranchNameInLocal(n plumbing.ReferenceName) (BranchName, bool) {
+func getdeletionProposedBranchNameInLocal(n plumbing.ReferenceName) (branchName, bool) {
 	b, ok := trimOptionalPrefix(n.String(), deletionProposedPrefixInLocalRepo)
-	return BranchName(b), ok
+	return branchName(b), ok
 }
 
 func isBranchInLocalRepo(n plumbing.ReferenceName) bool {
@@ -122,19 +122,19 @@ func getTagNameInLocalRepo(n plumbing.ReferenceName) (string, bool) {
 	return trimOptionalPrefix(n.String(), tagsPrefixInLocalRepo)
 }
 
-func createDraftName(key repository.PackageRevisionKey) BranchName {
-	return BranchName(draftsPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
+func createDraftName(key repository.PackageRevisionKey) branchName {
+	return branchName(draftsPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
 }
 
-func createProposedName(key repository.PackageRevisionKey) BranchName {
-	return BranchName(proposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
+func createProposedName(key repository.PackageRevisionKey) branchName {
+	return branchName(proposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), string(key.WorkspaceName)))
 }
 
-func createDeletionProposedName(key repository.PackageRevisionKey) BranchName {
+func createDeletionProposedName(key repository.PackageRevisionKey) branchName {
 	if key.Revision > 0 {
-		return BranchName(deletionProposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), "v"+repository.Revision2Str(key.Revision)))
+		return branchName(deletionProposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), "v"+repository.Revision2Str(key.Revision)))
 	} else {
-		return BranchName(deletionProposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), "/"+key.WorkspaceName))
+		return branchName(deletionProposedPrefix + filepath.Join(key.PkgKey.ToFullPathname(), "/"+key.WorkspaceName))
 	}
 }
 

--- a/pkg/externalrepo/git/ref_test.go
+++ b/pkg/externalrepo/git/ref_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 func TestBranchNames(t *testing.T) {
-	const main BranchName = "main"
+	const main branchName = "main"
 
-	if got, want := main.RefInRemote(), "refs/heads/main"; string(got) != want {
+	if got, want := main.refInRemote(), "refs/heads/main"; string(got) != want {
 		t.Errorf("%s in remote repository: got %s, wnat %s", main, got, want)
 	}
-	if got, want := main.RefInLocal(), "refs/remotes/origin/main"; string(got) != want {
+	if got, want := main.refInLocal(), "refs/remotes/origin/main"; string(got) != want {
 		t.Errorf("%s in local repository: got %s, wnat %s", main, got, want)
 	}
 }

--- a/pkg/externalrepo/git/testing_repo.go
+++ b/pkg/externalrepo/git/testing_repo.go
@@ -82,7 +82,7 @@ func InitializeBranch(t *testing.T, git *gogit.Repository, branch string) {
 	t.Helper()
 
 	// If main branch exists, rename it to the specified ref
-	main, err := git.Reference(DefaultMainReferenceName, false)
+	main, err := git.Reference(defaultMainReferenceName, false)
 	switch err {
 	case nil:
 		// found `main branch`
@@ -90,13 +90,13 @@ func InitializeBranch(t *testing.T, git *gogit.Repository, branch string) {
 		// main doesn't exist, we won't create the target branch either.
 		return
 	default:
-		t.Fatalf("Error getting %s branch: %v", DefaultMainReferenceName, err)
+		t.Fatalf("Error getting %s branch: %v", defaultMainReferenceName, err)
 		return
 	}
 
 	// `main` branch was found. Create the target branch off of it if needed.
 	name := plumbing.NewBranchReferenceName(branch)
-	if name != DefaultMainReferenceName {
+	if name != defaultMainReferenceName {
 		ref := plumbing.NewHashReference(name, main.Hash())
 		if err := git.Storer.SetReference(ref); err != nil {
 			t.Fatalf("Error creating target branch %q from %q: %v", ref, main, err)
@@ -104,7 +104,7 @@ func InitializeBranch(t *testing.T, git *gogit.Repository, branch string) {
 
 		t.Cleanup(func() {
 			// Verify that main didn't move during the test
-			new, err := git.Reference(DefaultMainReferenceName, false)
+			new, err := git.Reference(defaultMainReferenceName, false)
 			if err != nil {
 				t.Fatalf("Error getting %s branch after test run: %v", gogit.DefaultRemoteName, err)
 			}
@@ -369,7 +369,7 @@ func fetch(t *testing.T, repo *gogit.Repository) {
 	t.Helper()
 
 	switch err := repo.Fetch(&gogit.FetchOptions{
-		RemoteName: OriginName,
+		RemoteName: originName,
 		Tags:       gogit.NoTags,
 	}); err {
 	case nil, gogit.NoErrAlreadyUpToDate:

--- a/pkg/externalrepo/git/testing_repo.go
+++ b/pkg/externalrepo/git/testing_repo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/nephio-project/porch/pkg/repository"
+	gitserver "github.com/nephio-project/porch/test/git/pkg"
 )
 
 func OpenGitRepositoryFromArchive(t *testing.T, tarfile, tempdir string) *gogit.Repository {
@@ -125,19 +126,19 @@ func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repositor
 func ServeExistingRepository(t *testing.T, git *gogit.Repository) string {
 	t.Helper()
 
-	repo, err := NewRepo(git)
+	repo, err := gitserver.NewRepo(git)
 	if err != nil {
 		t.Fatalf("NewRepo failed: %v", err)
 	}
 
 	key := "default"
 
-	repos := NewStaticRepos()
+	repos := gitserver.NewStaticRepos()
 	if err := repos.Add(key, repo); err != nil {
 		t.Fatalf("repos.Add failed: %v", err)
 	}
 
-	server, err := NewGitServer(repos)
+	server, err := gitserver.NewGitServer(repos)
 	if err != nil {
 		t.Fatalf("NewGitServer() failed: %v", err)
 	}

--- a/pkg/externalrepo/git/testing_repo_test.go
+++ b/pkg/externalrepo/git/testing_repo_test.go
@@ -15,14 +15,8 @@
 package git
 
 import (
-	"archive/tar"
 	"context"
 	"fmt"
-	"io"
-	"net"
-	"os"
-	"path/filepath"
-	"sync"
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -34,27 +28,12 @@ import (
 
 func OpenGitRepositoryFromArchive(t *testing.T, tarfile, tempdir string) *gogit.Repository {
 	t.Helper()
-
-	extractTar(t, tarfile, tempdir)
-
-	git, err := gogit.PlainOpen(filepath.Join(tempdir, ".git"))
-	if err != nil {
-		t.Fatalf("Failed to open Git Repository extracted from %q: %v", tarfile, err)
-	}
-
-	return git
+	return gitserver.OpenGitRepositoryFromArchive(t, tarfile, tempdir)
 }
 
 func OpenGitRepositoryFromArchiveWithWorktree(t *testing.T, tarfile, path string) *gogit.Repository {
 	t.Helper()
-
-	extractTar(t, tarfile, path)
-
-	repo, err := gogit.PlainOpen(path)
-	if err != nil {
-		t.Fatalf("Failed to open Git repository extracted from %q: %v", tarfile, err)
-	}
-	return repo
+	return gitserver.OpenGitRepositoryFromArchiveWithWorktree(t, tarfile, path)
 }
 
 func InitEmptyRepositoryWithWorktree(t *testing.T, path string) *gogit.Repository {
@@ -118,106 +97,12 @@ func InitializeBranch(t *testing.T, git *gogit.Repository, branch string) {
 
 func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repository, string) {
 	t.Helper()
-
-	git := OpenGitRepositoryFromArchive(t, tarfile, tempdir)
-	return git, ServeExistingRepository(t, git)
+	return gitserver.ServeGitRepository(t, tarfile, tempdir)
 }
 
 func ServeExistingRepository(t *testing.T, git *gogit.Repository) string {
 	t.Helper()
-
-	repo, err := gitserver.NewRepo(git)
-	if err != nil {
-		t.Fatalf("NewRepo failed: %v", err)
-	}
-
-	key := "default"
-
-	repos := gitserver.NewStaticRepos()
-	if err := repos.Add(key, repo); err != nil {
-		t.Fatalf("repos.Add failed: %v", err)
-	}
-
-	server, err := gitserver.NewGitServer(repos)
-	if err != nil {
-		t.Fatalf("NewGitServer() failed: %v", err)
-	}
-
-	var wg sync.WaitGroup
-
-	serverAddressChannel := make(chan net.Addr)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() {
-		cancel()
-		wg.Wait()
-	})
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := server.ListenAndServe(ctx, "127.0.0.1:0", serverAddressChannel); err != nil {
-			if ctx.Err() == nil {
-				t.Errorf("Git Server ListenAndServe failed: %v", err)
-			}
-		}
-	}()
-
-	address, ok := <-serverAddressChannel
-	if !ok {
-		t.Fatalf("Git Server failed to start")
-	}
-	return "http://" + address.String() + "/" + key
-}
-
-func extractTar(t *testing.T, tarfile string, dir string) {
-	t.Helper()
-
-	reader, err := os.Open(tarfile) // #nosec G304
-	if err != nil {
-		t.Fatalf("Open(%q) failed: %v", tarfile, err)
-	}
-	defer reader.Close()
-	tr := tar.NewReader(reader)
-
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Reading tar file %q failed: %v", tarfile, err)
-		}
-		if hdr.FileInfo().IsDir() {
-			// #nosec G305
-			path := filepath.Join(dir, hdr.Name)
-			// #nosec G301 G703
-			if err := os.MkdirAll(path, 0755); err != nil {
-				t.Fatalf("MkdirAll(%q) failed: %v", path, err)
-			}
-			continue
-		}
-		path := filepath.Join(dir, filepath.Dir(hdr.Name))
-		// #nosec G301 G703
-		if err := os.MkdirAll(path, 0755); err != nil {
-			t.Fatalf("MkdirAll(%q) failed: %v", path, err)
-		}
-		// #nosec G305
-		path = filepath.Join(dir, hdr.Name)
-		saveToFile(t, path, tr)
-	}
-}
-
-func saveToFile(t *testing.T, path string, src io.Reader) {
-	t.Helper()
-
-	dst, err := os.Create(path) // #nosec G304 G703
-	if err != nil {
-		t.Fatalf("Create(%q) failed; %v", path, err)
-	}
-	defer dst.Close()
-	if _, err := io.Copy(dst, src); err != nil {
-		t.Fatalf("Copy from tar to %q failed: %v", path, err)
-	}
+	return gitserver.ServeExistingRepository(t, git)
 }
 
 func resolveReference(t *testing.T, repo *gogit.Repository, name plumbing.ReferenceName) *plumbing.Reference {

--- a/pkg/task/clone_test.go
+++ b/pkg/task/clone_test.go
@@ -36,8 +36,8 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
-	"github.com/nephio-project/porch/pkg/externalrepo/git"
 	"github.com/nephio-project/porch/pkg/repository"
+	gitserver "github.com/nephio-project/porch/test/git/pkg"
 )
 
 func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
@@ -116,14 +116,14 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 	return repo
 }
 
-func startGitServer(t *testing.T, repo *git.Repo, _ ...git.GitServerOption) string {
+func startGitServer(t *testing.T, repo *gitserver.Repo, _ ...gitserver.GitServerOption) string {
 	key := "default"
-	repos := git.NewStaticRepos()
+	repos := gitserver.NewStaticRepos()
 	if err := repos.Add(key, repo); err != nil {
 		t.Fatalf("repos.Add failed: %v", err)
 	}
 
-	server, err := git.NewGitServer(repos)
+	server, err := gitserver.NewGitServer(repos)
 	if err != nil {
 		t.Fatalf("Failed to create git server: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestCloneGitBasicAuth(t *testing.T) {
 	auth := randomCredentials()
 	gogitRepo := createRepoWithContents(t, testdata)
 
-	repo, err := git.NewRepo(gogitRepo, git.WithBasicAuth(auth.username, auth.password))
+	repo, err := gitserver.NewRepo(gogitRepo, gitserver.WithBasicAuth(auth.username, auth.password))
 	if err != nil {
 		t.Fatalf("NewRepo failed: %+v", err)
 	}

--- a/test/e2e/suiteutils/git_stub_test_utils.go
+++ b/test/e2e/suiteutils/git_stub_test_utils.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/nephio-project/porch/pkg/externalrepo/git"
+	"github.com/nephio-project/porch/test/git/pkg"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -262,10 +262,10 @@ func createLocalGitServer(t *testing.T) GitConfig {
 		}
 	})
 
-	var gitRepoOptions []git.GitRepoOption
-	repos := git.NewDynamicRepos(tmp, gitRepoOptions)
+	var gitRepoOptions []gitserver.GitRepoOption
+	repos := gitserver.NewDynamicRepos(tmp, gitRepoOptions)
 
-	server, err := git.NewGitServer(repos)
+	server, err := gitserver.NewGitServer(repos)
 	if err != nil {
 		t.Fatalf("Failed to start git server: %v", err)
 		return GitConfig{}

--- a/test/git/main.go
+++ b/test/git/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/nephio-project/porch/pkg/externalrepo/git"
+	"github.com/nephio-project/porch/test/git/pkg"
 	"k8s.io/klog/v2"
 )
 
@@ -59,10 +59,10 @@ func run(dirs []string) error {
 		return fmt.Errorf("can serve only one git repository, not %d", len(dirs))
 	}
 
-	var gitRepoOptions []git.GitRepoOption
-	repos := git.NewDynamicRepos(baseDir, gitRepoOptions)
+	var gitRepoOptions []gitserver.GitRepoOption
+	repos := gitserver.NewDynamicRepos(baseDir, gitRepoOptions)
 
-	server, err := git.NewGitServer(repos)
+	server, err := gitserver.NewGitServer(repos)
 	if err != nil {
 		return fmt.Errorf("filed to initialize git server: %w", err)
 	}

--- a/test/git/pkg/repo.go
+++ b/test/git/pkg/repo.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package git
+package gitserver
 
 import gogit "github.com/go-git/go-git/v5"
 

--- a/test/git/pkg/repos.go
+++ b/test/git/pkg/repos.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package git
+package gitserver
 
 import (
 	"context"
@@ -36,7 +36,7 @@ type StaticRepos struct {
 	repos map[string]*Repo
 }
 
-// NewRepos constructs an instance of Repos
+// NewStaticRepos constructs an instance of StaticRepos
 func NewStaticRepos() *StaticRepos {
 	return &StaticRepos{
 		repos: make(map[string]*Repo),

--- a/test/git/pkg/server.go
+++ b/test/git/pkg/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package git
+package gitserver
 
 import (
 	"bufio"
@@ -588,7 +588,7 @@ func parseHash(s string) (GitHash, error) {
 	return h, nil
 }
 
-// NewPackageLineWriter constructs a PacketLineWriter
+// NewPacketLineWriter constructs a PacketLineWriter
 func NewPacketLineWriter(w io.Writer) *PacketLineWriter {
 	bw := bufio.NewWriter(w)
 	return &PacketLineWriter{

--- a/test/git/pkg/testing_helpers.go
+++ b/test/git/pkg/testing_helpers.go
@@ -1,0 +1,157 @@
+// Copyright 2022-2026 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitserver
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+)
+
+func OpenGitRepositoryFromArchive(t *testing.T, tarfile, tempdir string) *gogit.Repository {
+	t.Helper()
+
+	ExtractTar(t, tarfile, tempdir)
+
+	git, err := gogit.PlainOpen(filepath.Join(tempdir, ".git"))
+	if err != nil {
+		t.Fatalf("Failed to open Git Repository extracted from %q: %v", tarfile, err)
+	}
+
+	return git
+}
+
+func OpenGitRepositoryFromArchiveWithWorktree(t *testing.T, tarfile, path string) *gogit.Repository {
+	t.Helper()
+
+	ExtractTar(t, tarfile, path)
+
+	repo, err := gogit.PlainOpen(path)
+	if err != nil {
+		t.Fatalf("Failed to open Git repository extracted from %q: %v", tarfile, err)
+	}
+	return repo
+}
+
+func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repository, string) {
+	t.Helper()
+
+	git := OpenGitRepositoryFromArchive(t, tarfile, tempdir)
+	return git, ServeExistingRepository(t, git)
+}
+
+func ServeExistingRepository(t *testing.T, repo *gogit.Repository) string {
+	t.Helper()
+
+	r, err := NewRepo(repo)
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	key := "default"
+
+	repos := NewStaticRepos()
+	if err := repos.Add(key, r); err != nil {
+		t.Fatalf("repos.Add failed: %v", err)
+	}
+
+	server, err := NewGitServer(repos)
+	if err != nil {
+		t.Fatalf("NewGitServer() failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	serverAddressChannel := make(chan net.Addr)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := server.ListenAndServe(ctx, "127.0.0.1:0", serverAddressChannel); err != nil {
+			if ctx.Err() == nil {
+				t.Errorf("Git Server ListenAndServe failed: %v", err)
+			}
+		}
+	}()
+
+	address, ok := <-serverAddressChannel
+	if !ok {
+		t.Fatalf("Git Server failed to start")
+	}
+	return "http://" + address.String() + "/" + key
+}
+
+func ExtractTar(t *testing.T, tarfile string, dir string) {
+	t.Helper()
+
+	reader, err := os.Open(tarfile) // #nosec G304
+	if err != nil {
+		t.Fatalf("Open(%q) failed: %v", tarfile, err)
+	}
+	defer reader.Close()
+	tr := tar.NewReader(reader)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Reading tar file %q failed: %v", tarfile, err)
+		}
+		if hdr.FileInfo().IsDir() {
+			// #nosec G305
+			path := filepath.Join(dir, hdr.Name)
+			// #nosec G301 G703
+			if err := os.MkdirAll(path, 0755); err != nil {
+				t.Fatalf("MkdirAll(%q) failed: %v", path, err)
+			}
+			continue
+		}
+		path := filepath.Join(dir, filepath.Dir(hdr.Name))
+		// #nosec G301 G703
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("MkdirAll(%q) failed: %v", path, err)
+		}
+		// #nosec G305
+		path = filepath.Join(dir, hdr.Name)
+		saveToFile(t, path, tr)
+	}
+}
+
+func saveToFile(t *testing.T, path string, src io.Reader) {
+	t.Helper()
+
+	dst, err := os.Create(path) // #nosec G304 G703
+	if err != nil {
+		t.Fatalf("Create(%q) failed; %v", path, err)
+	}
+	defer dst.Close()
+	if _, err := io.Copy(dst, src); err != nil {
+		t.Fatalf("Copy from tar to %q failed: %v", path, err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Backport of nephio-project/nephio#503 
---

## Description
<!-- Describe what this PR does and why -->
- What changed: The git test server is moved out to test. All the types and functions that are unused outside the git package are made protected. Some of the git repository test tooling is moved out to the common test package so crcache test cases can use then as well.
- Why it’s needed: Allows for better analysis of what actually needs to be refactored, and what are it's external constraints.
- How it works:  

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  
https://github.com/nephio-project/porch/pull/503
https://github.com/nephio-project/porch/issues/881
---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[x] I have used AI in the creation of this PR.

Examples:
- Grepping and renaming of things done by kiro.