### PR TITLE
Backport 500

### DIFF
--- a/deployments/porch/2-function-runner.yaml
+++ b/deployments/porch/2-function-runner.yaml
@@ -24,7 +24,7 @@ metadata:
   name: function-runner
   namespace: porch-system
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: function-runner

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/design.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/design.md
@@ -244,6 +244,57 @@ For detailed explanations of how these differences affect operations, see the in
 - May recreate pods for functions with irregular usage patterns
 - Configurable TTL allows tuning for specific workloads
 
+### Pod Selection Strategy
+
+**Decision**: Use round-robin distribution among pods with equal minimum load.
+
+**Rationale:**
+- Ensures even distribution of requests across equally-loaded pods
+- Prevents all requests from going to the same pod when multiple pods have equal capacity
+- Simple and predictable load balancing behavior
+- Works well with parallel execution within pods
+
+**Implementation:**
+- Find the minimum waitlist length across all pods for a function
+- Use round-robin to select among pods that have the minimum waitlist
+- Maintains round-robin index per function to track position
+
+**Alternatives considered:**
+- **Pure least-loaded**: Can cause all requests to go to same pod when loads are equal
+- **Random selection**: Less predictable distribution patterns
+- **Weighted round-robin**: Unnecessary complexity for uniform pod capacities
+
+**Trade-offs:**
+- Slightly more complex than pure least-loaded selection
+- Requires maintaining round-robin index per function
+- Better load distribution justifies the minimal added complexity
+
+### Parallel Execution Model
+
+**Decision**: Allow parallel function evaluations within the same pod.
+
+**Rationale:**
+- Improves throughput by utilizing pod capacity fully
+- Reduces wait times when multiple requests target the same function
+- Simplifies code by removing serialization mutex
+- Works well with round-robin pod selection for even load distribution
+
+**Implementation:**
+- Removed per-pod mutex that was serializing executions
+- Concurrent executions tracked via atomic counter
+- gRPC connection shared across parallel calls to same pod
+- Context timeout prevents goroutine leaks
+
+**Alternatives considered:**
+- **Serial execution per pod**: Simpler but underutilizes pod capacity
+- **Connection pooling**: More complex, unnecessary with gRPC multiplexing
+- **Per-function concurrency limits**: Added complexity without clear benefit
+
+**Trade-offs:**
+- Functions must be safe for concurrent execution (standard KRM function requirement)
+- Multiple evaluations share pod resources (CPU, memory)
+- Better resource utilization justifies the concurrency model
+
 ### Service Mesh Compatibility
 
 **Decision**: Use ClusterIP services as frontends for function pods.

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/function-evaluation.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/function-evaluation.md
@@ -437,13 +437,19 @@ The evaluation system employs several performance strategies.
 - Multiple requests can execute concurrently
 - Each request gets own gRPC connection
 - Pod cache manager coordinates access
-- Waitlist prevents duplicate pod creation
+- Round-robin load balancing across equal-load pods
 
 **Concurrency characteristics:**
-- Same function, same pod: Sequential (one at a time)
+- Same function, same pod: Parallel execution supported
 - Same function, different pods: Concurrent
 - Different functions: Fully concurrent
 - No artificial concurrency limits
+
+**Load balancing:**
+- Requests distributed to least-loaded pods
+- Round-robin among pods with equal load
+- Ensures even work distribution
+- Prevents hotspotting on single pod
 
 ### Resource Limits
 

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/pod-lifecycle-management.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/pod-lifecycle-management.md
@@ -34,7 +34,7 @@ The Pod Cache Manager runs as a single goroutine managing all pod caching operat
 
 The manager maintains two data structures:
 
-**Cache Map** - Maps function image names to pod information and gRPC client connections. Each entry contains the pod namespace/name and an active gRPC client connection to the pod's wrapper server.
+**Cache Map** - Maps function image names to pod information and gRPC client connections. Each entry contains the pod namespace/name and an active gRPC client connection to the pod's wrapper server. When multiple pods serve the same function, the cache uses a round-robin index to distribute requests evenly across pods with equal load.
 
 **Waitlist Map** - Maps function image names to lists of channels waiting for pod readiness. When multiple evaluation requests arrive for the same function before a pod is ready, they queue in the waitlist to prevent duplicate pod creation.
 
@@ -346,9 +346,14 @@ The system supports concurrent operations efficiently:
 - Each request gets own gRPC connection
 - Pod cache manager coordinates access via channels
 - Waitlist prevents duplicate pod creation
+- Function evaluations can execute in parallel within the same pod
+
+**Pod Selection Strategy:**
+
+When multiple pods serve the same function, the cache manager selects the pod with the least load (smallest waitlist length). When multiple pods have equal load, the system uses round-robin distribution to ensure even load balancing across pods rather than always selecting the first available pod.
 
 **Concurrency benefits:**
-- Same function, same pod: Sequential (one at a time)
+- Same function, same pod: Parallel (multiple evaluations execute concurrently)
 - Same function, different pods: Concurrent
 - Different functions: Fully concurrent
 - No artificial concurrency limits

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/interactions.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/interactions.md
@@ -141,10 +141,12 @@ Pod      Pod       Pod
 
 **Execution pattern:**
 - Pod cache checked for existing pod (reuse if available)
+- Pod selection uses round-robin among pods with minimum waitlist length
 - Cache miss triggers pod creation with wrapper server
 - ClusterIP service provides stable DNS-based access
 - gRPC connection to wrapper server in pod
 - Wrapper server executes function binary and returns results
+- Multiple evaluations can execute in parallel on the same pod
 
 **For detailed pod lifecycle, see [Pod Lifecycle Management]({{% relref "/docs/5_architecture_and_components/function-runner/functionality/pod-lifecycle-management.md" %}}).**
 
@@ -430,7 +432,8 @@ The Function Runner handles concurrent operations safely:
 
 **Concurrency characteristics:**
 - Multiple function executions can run concurrently
-- Each request gets own gRPC connection
+- Multiple evaluations can run in parallel on the same pod
+- Each request gets own gRPC connection to pod
 - Pod cache manager coordinates access via channels
 - Waitlist prevents duplicate pod creation
 

--- a/docs/content/en/docs/6_configuration_and_deployments/configurations/components/function-runner-config/_index.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/configurations/components/function-runner-config/_index.md
@@ -149,7 +149,7 @@ metadata:
   name: function-runner
   namespace: porch-system
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: function-runner

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -71,6 +71,8 @@ type podCacheConfigEntry struct {
 type functionInfo struct {
 	// status of all pods belonging to the same KRM function image
 	pods []functionPodInfo
+	// roundRobinIdx is used to distribute requests across pods when all have equal load
+	roundRobinIdx int
 }
 
 // functionPodInfo represents the state of a single pod instance.
@@ -82,8 +84,6 @@ type functionPodInfo struct {
 	waitlist []chan<- *connectionResponse
 	// time of last function evaluation, used by the garbage collector to identify idle pods
 	lastActivity time.Time
-	// mutex used to prevent concurrent fn evaluations in the same pod
-	fnEvaluationMutex *sync.Mutex
 	// the number of currently ongoing and waiting fn evaluations in the pod
 	concurrentEvaluations *atomic.Int32
 }
@@ -369,25 +369,39 @@ func forEachConcurrently(m []podCacheConfigEntry, fn func(k podCacheConfigEntry)
 	wg.Wait()
 }
 
-// findBestPod returns with the index of the least loaded healthy pod for the given function.
+// findBestPod returns with the index of the best pod for the given function.
+// It uses round-robin among pods with equal load to ensure even distribution.
 // If there are no suitable pods, it returns with -1.
 func (pcm *podCacheManager) findBestPod(fn *functionInfo) (int, int) {
 	if fn == nil {
 		return -1, 0
 	}
-	if len(fn.pods) == 0 {
+	n := len(fn.pods)
+	if n == 0 {
 		return -1, 0
 	}
-	bestPodIdx := 0
-	bestWaitlistLen := fn.pods[0].WaitlistLen()
-	for i := 1; i < len(fn.pods); i++ {
-		waitlistLen := fn.pods[i].WaitlistLen()
-		if waitlistLen < bestWaitlistLen {
-			bestPodIdx = i
-			bestWaitlistLen = waitlistLen
+
+	minWaitlist := 0
+	// Find the minimum waitlist length across all pods
+	minWaitlist = fn.pods[0].WaitlistLen()
+	for i := 1; i < n; i++ {
+		wl := fn.pods[i].WaitlistLen()
+		if wl < minWaitlist {
+			minWaitlist = wl
 		}
 	}
-	return bestPodIdx, bestWaitlistLen
+
+	// Round-robin among pods that have the minimum waitlist length
+	for i := 0; i < n; i++ {
+		idx := (fn.roundRobinIdx + i) % n
+		if fn.pods[idx].WaitlistLen() == minWaitlist {
+			fn.roundRobinIdx = (idx + 1) % n
+			return idx, minWaitlist
+		}
+	}
+
+	// This should never happen since minWaitlist was calculated from these same pods
+	return -1, 0
 }
 
 // removeUnhealthyPods removes unhealthy pods from the function's pod list.
@@ -539,7 +553,6 @@ func NewPodInfo(firstResponseCh chan<- *connectionResponse) functionPodInfo {
 		podData:               nil, // This will be filled in when the pod is ready.
 		lastActivity:          time.Now(),
 		concurrentEvaluations: &atomic.Int32{},
-		fnEvaluationMutex:     &sync.Mutex{},
 	}
 	if firstResponseCh != nil {
 		pod.waitlist = append(pod.waitlist, firstResponseCh)
@@ -564,7 +577,6 @@ func (pod *functionPodInfo) SendResponse(responseCh chan<- *connectionResponse, 
 	default:
 		responseCh <- &connectionResponse{
 			podData:               *pod.podData,
-			fnEvaluationMutex:     pod.fnEvaluationMutex,
 			concurrentEvaluations: pod.concurrentEvaluations,
 			err:                   nil,
 		}

--- a/func/internal/podcachemanager_unit_test.go
+++ b/func/internal/podcachemanager_unit_test.go
@@ -39,7 +39,6 @@ func makePodInfoWithLoad(load int32) functionPodInfo {
 	counter.Store(load)
 	return functionPodInfo{
 		concurrentEvaluations: counter,
-		fnEvaluationMutex:     &sync.Mutex{},
 		lastActivity:          time.Now(),
 		waitlist:              []chan<- *connectionResponse{},
 	}
@@ -57,7 +56,6 @@ func makeReadyPodInfo(image string, podKey, serviceKey client.ObjectKey, grpcCon
 			grpcConnection: grpcConn,
 		},
 		concurrentEvaluations: counter,
-		fnEvaluationMutex:     &sync.Mutex{},
 		lastActivity:          time.Now(),
 		waitlist:              []chan<- *connectionResponse{},
 	}
@@ -301,7 +299,6 @@ func TestNewPodInfo(t *testing.T) {
 		assert.Nil(t, pod.podData)
 		assert.Empty(t, pod.waitlist)
 		assert.Equal(t, int32(0), pod.concurrentEvaluations.Load())
-		assert.NotNil(t, pod.fnEvaluationMutex)
 	})
 
 	t.Run("non-nil channel adds to waitlist and increments counter", func(t *testing.T) {
@@ -318,7 +315,6 @@ func TestSendResponse(t *testing.T) {
 		pod := &functionPodInfo{
 			podData:               &podData{image: "test"},
 			concurrentEvaluations: &atomic.Int32{},
-			fnEvaluationMutex:     &sync.Mutex{},
 		}
 		ch := make(chan *connectionResponse, 1)
 		testErr := fmt.Errorf("test error")
@@ -334,7 +330,6 @@ func TestSendResponse(t *testing.T) {
 		pod := &functionPodInfo{
 			podData:               nil,
 			concurrentEvaluations: &atomic.Int32{},
-			fnEvaluationMutex:     &sync.Mutex{},
 		}
 		ch := make(chan *connectionResponse, 1)
 
@@ -359,7 +354,6 @@ func TestSendResponse(t *testing.T) {
 				serviceKey:     &serviceKey,
 			},
 			concurrentEvaluations: &atomic.Int32{},
-			fnEvaluationMutex:     &sync.Mutex{},
 		}
 		ch := make(chan *connectionResponse, 1)
 
@@ -369,7 +363,6 @@ func TestSendResponse(t *testing.T) {
 		assert.NoError(t, resp.err)
 		assert.Equal(t, "test-image", resp.podData.image)
 		assert.NotNil(t, resp.grpcConnection)
-		assert.NotNil(t, resp.fnEvaluationMutex)
 		assert.NotNil(t, resp.concurrentEvaluations)
 	})
 }
@@ -461,7 +454,6 @@ func TestRemoveUnhealthyPods(t *testing.T) {
 				{
 					podData:               nil, // under creation
 					concurrentEvaluations: &atomic.Int32{},
-					fnEvaluationMutex:     &sync.Mutex{},
 				},
 			},
 		}

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -17,7 +17,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -93,8 +92,6 @@ type connectionRequest struct {
 
 type connectionResponse struct {
 	podData
-	// mutex used to prevent concurrent fn evaluations in the same pod
-	fnEvaluationMutex *sync.Mutex
 	// the number of currently ongoing and waiting fn evaluations in the pod
 	concurrentEvaluations *atomic.Int32
 	// err indicates the error that prevents us to allocate a pod for the fn evaluator
@@ -215,23 +212,25 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 	}
 
 	// Waiting for the client from the channel. This step is blocking.
-	pod := <-responseChannel
-	if pod == nil || pod.grpcConnection == nil || pod.err != nil {
-		return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
-	}
+	select {
+	case pod := <-responseChannel:
+		if pod == nil || pod.grpcConnection == nil || pod.err != nil {
+			return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
+		}
 
-	defer pod.concurrentEvaluations.Add(-1)
-	pod.fnEvaluationMutex.Lock()
-	defer pod.fnEvaluationMutex.Unlock()
+		defer pod.concurrentEvaluations.Add(-1)
 
-	resp, err := evaluator.NewFunctionEvaluatorClient(pod.grpcConnection).EvaluateFunction(ctx, req)
-	if err != nil {
-		klog.V(4).Infof("Resource List: %s", req.ResourceList)
-		return nil, fmt.Errorf("unable to evaluate %v with pod evaluator: %w", req.Image, err)
+		resp, err := evaluator.NewFunctionEvaluatorClient(pod.grpcConnection).EvaluateFunction(ctx, req)
+		if err != nil {
+			klog.V(4).Infof("Resource List: %s", req.ResourceList)
+			return nil, fmt.Errorf("unable to evaluate %v with pod evaluator: %w", req.Image, err)
+		}
+		// Log stderr when the function succeeded. If the function fails, stderr will be surfaced to the users.
+		if len(resp.Log) > 0 {
+			klog.Warningf("evaluating %v succeeded, but stderr is: %v", req.Image, string(resp.Log))
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
 	}
-	// Log stderr when the function succeeded. If the function fails, stderr will be surfaced to the users.
-	if len(resp.Log) > 0 {
-		klog.Warningf("evaluating %v succeeded, but stderr is: %v", req.Image, string(resp.Log))
-	}
-	return resp, nil
 }

--- a/func/internal/podevaluator_porch_parallel_execution_test.go
+++ b/func/internal/podevaluator_porch_parallel_execution_test.go
@@ -53,7 +53,7 @@ func startFakeServer(ctx context.Context, t *testing.T, delay time.Duration) (st
 	return addr, nil
 }
 
-func TestPodEvaluatorExecutionSerial(t *testing.T) {
+func TestPodEvaluatorExecutionParallel(t *testing.T) {
 	const sleep = 2 * time.Second
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -75,16 +75,16 @@ func TestPodEvaluatorExecutionSerial(t *testing.T) {
 
 	reqCh := make(chan *connectionRequest, 2)
 	go func() {
-		lock := &sync.Mutex{}
 		counter := &atomic.Int32{}
 		for req := range reqCh {
+			// Increment counter to simulate single pod with limited concurrency
+			counter.Add(1)
 			req.responseCh <- &connectionResponse{
 				podData: podData{
 					image:          req.image,
 					grpcConnection: conn,
 					podKey:         ptr.To(client.ObjectKey{}),
 				},
-				fnEvaluationMutex:     lock,
 				concurrentEvaluations: counter,
 				err:                   nil,
 			}
@@ -116,7 +116,13 @@ func TestPodEvaluatorExecutionSerial(t *testing.T) {
 	t.Logf("durations: %v", durations)
 
 	slices.Sort(durations)
-	if durations[funcCallCount-1] < time.Duration(funcCallCount)*sleep {
-		t.Errorf("expected serial but slowest took only %v", durations[funcCallCount-1])
+	// Since the current implementation allows parallel execution on the same connection,
+	// we should expect parallel behavior, not serial. Update the test expectation.
+	if durations[funcCallCount-1] > time.Duration(funcCallCount)*sleep {
+		t.Errorf("expected parallel but execution took too long: %v", durations[funcCallCount-1])
+	}
+	// Verify that all calls completed in roughly the same time (parallel execution)
+	if durations[funcCallCount-1]-durations[0] > sleep/2 {
+		t.Errorf("expected parallel execution but calls had significant time difference: %v", durations[funcCallCount-1]-durations[0])
 	}
 }

--- a/func/internal/podevaluator_unit_test.go
+++ b/func/internal/podevaluator_unit_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -103,7 +102,6 @@ func TestEvaluateFunction_GrpcCallFails(t *testing.T) {
 		req := <-reqCh
 		req.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: conn},
-			fnEvaluationMutex:     &sync.Mutex{},
 			concurrentEvaluations: counter,
 		}
 	}()
@@ -138,7 +136,6 @@ func TestEvaluateFunction_SuccessWithStderr(t *testing.T) {
 		req := <-reqCh
 		req.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: conn},
-			fnEvaluationMutex:     &sync.Mutex{},
 			concurrentEvaluations: counter,
 		}
 	}()
@@ -173,7 +170,6 @@ func TestEvaluateFunction_SuccessClean(t *testing.T) {
 		req := <-reqCh
 		req.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: conn},
-			fnEvaluationMutex:     &sync.Mutex{},
 			concurrentEvaluations: counter,
 		}
 	}()
@@ -206,7 +202,6 @@ func TestEvaluateFunction_CounterDecrement(t *testing.T) {
 		req := <-reqCh
 		req.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: conn},
-			fnEvaluationMutex:     &sync.Mutex{},
 			concurrentEvaluations: counter,
 		}
 	}()

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/component-base/compatibility"
 	"k8s.io/klog/v2"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -142,7 +143,7 @@ func (c completedConfig) getRestConfig() (*rest.Config, error) {
 	}
 }
 
-func (c completedConfig) buildClient() (client.WithWatch, error) {
+func (c completedConfig) buildClient(ctx context.Context) (client.WithWatch, error) {
 	restConfig, err := c.getRestConfig()
 	if err != nil {
 		return nil, err
@@ -166,7 +167,48 @@ func (c completedConfig) buildClient() (client.WithWatch, error) {
 		return nil, fmt.Errorf("error building scheme: %w", err)
 	}
 
-	return client.NewWithWatch(restConfig, client.Options{Scheme: scheme})
+	informerCache, err := ctrlcache.New(restConfig, ctrlcache.Options{
+		Scheme: scheme,
+		ByObject: map[client.Object]ctrlcache.ByObject{
+			//The informer should pre-cache all the repositories at startup
+			&configapi.Repository{}: {},
+		},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache: %w", err)
+	}
+
+	go func() {
+		if err := informerCache.Start(ctx); err != nil {
+			klog.Errorf("informer cache stopped with error: %v", err)
+		}
+	}()
+
+	if !informerCache.WaitForCacheSync(ctx) {
+		return nil, fmt.Errorf("informer cache failed to sync")
+	}
+
+	// Register field index for metadata.name so that field selector queries on Repository work through the cache
+	if err := informerCache.IndexField(ctx, &configapi.Repository{}, "metadata.name", func(obj client.Object) []string {
+		return []string{obj.GetName()}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create index for metadata.name: %w", err)
+	}
+
+	return client.NewWithWatch(restConfig, client.Options{Scheme: scheme, Cache: &client.CacheOptions{
+		Reader: informerCache,
+		DisableFor: []client.Object{
+			//The caching client should not cache resources served by porch-server
+			&porchapi.PackageRevision{},
+			&porchapi.PackageRevisionResources{},
+			// PackageRev uses write-then-read patterns (Create then Get in
+			// ClosePackageRevisionDraft/SetMeta). Since writes bypass the
+			// informer cache, a subsequent Get can miss the just-created object.
+			// This is not ideal, but crcache doesn't support a level of resources where caching makes a difference
+			&internalapi.PackageRev{},
+		},
+	}})
 }
 
 func (c completedConfig) getCoreV1Client() (*corev1client.CoreV1Client, error) {
@@ -192,7 +234,7 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 		return nil, err
 	}
 
-	coreClient, err := c.buildClient()
+	coreClient, err := c.buildClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build client for core apiserver: %w", err)
 	}

--- a/pkg/cache/dbcache/dbhandler.go
+++ b/pkg/cache/dbcache/dbhandler.go
@@ -49,6 +49,12 @@ func OpenDB(ctx context.Context, opts cachetypes.CacheOptions) error {
 		return err
 	}
 
+	// Configure connection pool limits
+	db.SetMaxOpenConns(opts.DBCacheOptions.MaxConnections)
+	db.SetMaxIdleConns(opts.DBCacheOptions.MaxIdleConnections)
+	db.SetConnMaxLifetime(opts.DBCacheOptions.MaxConnLifetime)
+	klog.Infof("OpenDB: configured connection pool - MaxOpenConns=%d, MaxIdleConns=%d, MaxConnLifetime=%v",
+		opts.DBCacheOptions.MaxConnections, opts.DBCacheOptions.MaxIdleConnections, opts.DBCacheOptions.MaxConnLifetime)
 	if err := db.Ping(); err != nil {
 		db.Close()
 		klog.V(4).Infof("OpenDB: database open failed")

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -419,6 +419,18 @@ func (pr *dbPackageRevision) UpdateResources(ctx context.Context, new *porchapi.
 
 	pr.resources = new.Spec.Resources
 
+	if kfString, ok := new.Spec.Resources[kptfile.KptFileName]; ok {
+		if kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfString)); err == nil {
+			if pr.spec == nil {
+				pr.spec = &porchapi.PackageRevisionSpec{}
+			}
+			pr.spec.PackageMetadata = &porchapi.PackageMetadata{
+				Labels:      kf.Labels,
+				Annotations: kf.Annotations,
+			}
+		}
+	}
+
 	if change != nil && porchapi.IsValidFirstTaskType(change.Type) {
 		if len(pr.tasks) > 0 {
 			klog.Warningf("Replacing first task of %q", pr.Key())

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -25,6 +25,8 @@ import (
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func (t *DbTestSuite) TestPackageRevisionDBWriteRead() {
@@ -753,4 +755,227 @@ func (t *DbTestSuite) TestFindUpstreamReference() {
 	t.NoError(err)
 	err = repoDeleteFromDB(t.Context(), downstreamRepo.Key())
 	t.NoError(err)
+}
+
+func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func()) {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo("label-ns", "label-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "label-pkg")
+
+	// PR with labels app=web, env=prod
+	pr1 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-1",
+			Revision:      1,
+		},
+		meta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": "web", "env": "prod"},
+		},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr1))
+
+	// PR with labels app=api, env=staging
+	pr2 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-2",
+			Revision:      2,
+		},
+		meta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": "api", "env": "staging"},
+		},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr2))
+
+	// PR with no labels
+	pr3 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-3",
+			Revision:      3,
+		},
+		meta:      metav1.ObjectMeta{},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr3))
+
+	return dbRepo.Key(), func() {
+		t.deleteTestRepo(dbRepo.Key())
+	}
+}
+
+func (t *DbTestSuite) TestPrLabelFilterEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-1", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterDoubleEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-2", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNotEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterIn() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNotIn() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// pr2 (app=api) and pr3 (no app label, IS NULL matches)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterExists() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Exists, []string{})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// pr1 and pr2 have the "app" label
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterDoesNotExist() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
+	t.Require().NoError(err)
+
+	reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req, *reqExists),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
+	t.Empty(results)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterMultipleRequirements() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+	t.Require().NoError(err)
+	reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*reqApp, *reqEnv),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-1", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNilSelector() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	filter := repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 3)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNoMatch() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Empty(results)
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -1030,4 +1030,122 @@ func (t *DbTestSuite) TestPrLabelFilter() {
 		t.Len(results, 1)
 		t.Equal("ws-1", results[0].Key().WorkspaceName)
 	})
+
+	t.Run("LatestRevisionDoubleEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.DoubleEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionIn", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.In, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionNotIn", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotIn, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionExists", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Exists, []string{})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionEqualsFalse", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionNotEqualsFalse", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionInWithoutTrue", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.In, []string{"false", "other"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionNotInWithoutTrue", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotIn, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -795,7 +795,6 @@ func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func
 	}
 	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr2))
 
-	// PR with no labels
 	pr3 := dbPackageRevision{
 		pkgRevKey: repository.PackageRevisionKey{
 			PkgKey:        dbPkg.Key(),
@@ -813,169 +812,222 @@ func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func
 	}
 }
 
-func (t *DbTestSuite) TestPrLabelFilterEquals() {
+func (t *DbTestSuite) TestPrLabelFilter() {
 	repoKey, cleanup := t.setupLabelFilterTestData()
 	defer cleanup()
 
-	req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("Equals", func() {
+		req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-1", results[0].Key().WorkspaceName)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterDoubleEquals() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("DoubleEquals", func() {
+		req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-2", results[0].Key().WorkspaceName)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-2", results[0].Key().WorkspaceName)
-}
+	t.Run("NotEquals", func() {
+		req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterNotEquals() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+	})
 
-	req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("In", func() {
+		req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 2)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterIn() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("NotIn", func() {
+		req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// pr2 (app=api) and pr3 (no app label, IS NULL matches)
+		t.Len(results, 2)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 2)
-}
+	t.Run("Exists", func() {
+		req, err := labels.NewRequirement("app", selection.Exists, []string{})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterNotIn() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// pr1 and pr2 have the "app" label
+		t.Len(results, 2)
+	})
 
-	req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("DoesNotExist", func() {
+		req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// pr2 (app=api) and pr3 (no app label, IS NULL matches)
-	t.Len(results, 2)
-}
+		reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterExists() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req, *reqExists),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
+		t.Empty(results)
+	})
 
-	req, err := labels.NewRequirement("app", selection.Exists, []string{})
-	t.Require().NoError(err)
+	t.Run("MultipleRequirements", func() {
+		reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
+		reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// pr1 and pr2 have the "app" label
-	t.Len(results, 2)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*reqApp, *reqEnv),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterDoesNotExist() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("NilSelector", func() {
+		filter := repository.ListPackageRevisionFilter{
+			Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 3)
+	})
 
-	req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
-	t.Require().NoError(err)
+	t.Run("NoMatch", func() {
+		req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
+		t.Require().NoError(err)
 
-	reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Empty(results)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req, *reqExists),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
-	t.Empty(results)
-}
+	t.Run("LatestRevisionEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterMultipleRequirements() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
 
-	reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
-	t.Require().NoError(err)
-	reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
-	t.Require().NoError(err)
+	t.Run("LatestRevisionNotEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*reqApp, *reqEnv),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-1", results[0].Key().WorkspaceName)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterNilSelector() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("LatestRevisionDoesNotExist", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.DoesNotExist, []string{})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 3)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterNoMatch() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("LatestRevisionCombinedWithRegularLabel", func() {
+		latestReq, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+		// ws-3 has no labels, so combining latest=true with any app label should return nothing
+		appReq, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*latestReq, *appReq),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Empty(results)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Empty(results)
+	t.Run("NotLatestWithRegularLabel", func() {
+		notLatestReq, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+		appReq, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*notLatestReq, *appReq),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 }

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -160,10 +160,7 @@ func (r *dbRepository) ListPackageRevisions(ctx context.Context, filter reposito
 			klog.V(4).Infof("ListPackageRevisions: skipping package revision %+v with nil repository", pkgRev.Key())
 			continue
 		}
-		genericPkgRev := repository.PackageRevision(pkgRev)
-		if filter.MatchesLabels(ctx, genericPkgRev) {
-			genericPkgRevs[i] = genericPkgRev
-		}
+		genericPkgRevs[i] = pkgRev
 	}
 	genericPkgRevs = slices.DeleteFunc(genericPkgRevs, func(rev repository.PackageRevision) bool {
 		return rev == nil

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -20,6 +20,8 @@ import (
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func pkgListFilter2WhereClause(filter repository.ListPackageFilter) string {
@@ -61,6 +63,7 @@ func prListFilter2WhereClause(filter repository.ListPackageRevisionFilter) strin
 	whereStatement, first = filter2SubClauseWorkspace(whereStatement, prKey.WorkspaceName, "package_revisions.k8s_name", first)
 
 	whereStatement, first = filter2SubClauseLifecycle(whereStatement, filter.Lifecycles, "package_revisions.lifecycle", first)
+	whereStatement, first = filter2SubClausePrLabels(whereStatement, filter.Label, first)
 	whereStatement, _ = filter2SubClauseKptfileLabels(whereStatement, filter.KptfileLabels, first)
 
 	if whereStatement == "" {
@@ -153,4 +156,62 @@ func filter2SubClauseKptfileLabels(whereStatement string, filterLabels map[strin
 	} else {
 		return whereStatement + "AND " + combinedClause, false
 	}
+}
+
+func filter2SubClausePrLabels(whereStatement string, labelSelector labels.Selector, first bool) (string, bool) {
+
+	if labelSelector == nil {
+		return whereStatement, first
+	}
+
+	subClauses := labelSelectorToJSONBClauses(labelSelector)
+	if len(subClauses) == 0 {
+		return whereStatement, first
+	}
+
+	combinedClause := "(" + strings.Join(subClauses, " AND ") + ")"
+
+	if first {
+		return whereStatement + combinedClause, false
+	} else {
+		return whereStatement + "AND " + combinedClause, false
+	}
+}
+
+func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
+	jsonbPath := "package_revisions.meta::jsonb->'labels'"
+	reqs, hasSelector := labelSelector.Requirements()
+	if !hasSelector {
+		return nil
+	}
+
+	var clauses []string
+	for _, req := range reqs {
+		key := req.Key()
+		values := req.Values().List()
+
+		switch req.Operator() {
+		case selection.Equals, selection.DoubleEquals:
+			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' = '%s')", jsonbPath, key, values[0]))
+		case selection.NotEquals:
+			clauses = append(clauses, fmt.Sprintf("((%s->>'%s') IS NULL OR %s->>'%s' != '%s')", jsonbPath, key, jsonbPath, key, values[0]))
+		case selection.In:
+			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' IN (%s))", jsonbPath, key, quotedStringListForJsonB(values)))
+		case selection.NotIn:
+			clauses = append(clauses, fmt.Sprintf("((%s->>'%s') IS NULL OR %s->>'%s' NOT IN (%s))", jsonbPath, key, jsonbPath, key, quotedStringListForJsonB(values)))
+		case selection.Exists:
+			clauses = append(clauses, fmt.Sprintf("(%s ? '%s')", jsonbPath, key))
+		case selection.DoesNotExist:
+			clauses = append(clauses, fmt.Sprintf("(NOT (%s ? '%s'))", jsonbPath, key))
+		}
+	}
+	return clauses
+}
+
+func quotedStringListForJsonB(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("'%s'", v)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -16,6 +16,7 @@ package dbcache
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
@@ -190,6 +191,11 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 		key := req.Key()
 		values := req.Values().List()
 
+		if key == porchapi.LatestPackageRevisionKey {
+			clauses = append(clauses, latestRevisionClause(req.Operator(), values))
+			continue
+		}
+
 		switch req.Operator() {
 		case selection.Equals, selection.DoubleEquals:
 			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' = '%s')", jsonbPath, key, values[0]))
@@ -206,6 +212,40 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 		}
 	}
 	return clauses
+}
+
+// latestRevisionClause generates a SQL clause for the latest-revision label.
+// This label is not stored in the meta JSON but as a separate boolean column.
+func latestRevisionClause(op selection.Operator, values []string) string {
+	col := "package_revisions.latest"
+	switch op {
+	case selection.Equals, selection.DoubleEquals:
+		if values[0] == porchapi.LatestPackageRevisionValue {
+			return fmt.Sprintf("(%s = TRUE)", col)
+		}
+		return fmt.Sprintf("(%s = FALSE)", col)
+	case selection.NotEquals:
+		if values[0] == porchapi.LatestPackageRevisionValue {
+			return fmt.Sprintf("(%s = FALSE)", col)
+		}
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.In:
+		if slices.Contains(values, porchapi.LatestPackageRevisionValue) {
+			return fmt.Sprintf("(%s = TRUE)", col)
+		}
+		return fmt.Sprintf("(%s = FALSE)", col)
+	case selection.NotIn:
+		if slices.Contains(values, porchapi.LatestPackageRevisionValue) {
+			return fmt.Sprintf("(%s = FALSE)", col)
+		}
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.Exists:
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.DoesNotExist:
+		return fmt.Sprintf("(%s = FALSE)", col)
+	default:
+		return "TRUE"
+	}
 }
 
 func quotedStringListForJsonB(values []string) string {

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -214,8 +214,6 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 	return clauses
 }
 
-// latestRevisionClause generates a SQL clause for the latest-revision label.
-// This label is not stored in the meta JSON but as a separate boolean column.
 func latestRevisionClause(op selection.Operator, values []string) string {
 	col := "package_revisions.latest"
 	switch op {

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -48,8 +48,11 @@ type CacheOptions struct {
 const DefaultDBCacheDriver string = "pgx"
 
 type DBCacheOptions struct {
-	Driver     string
-	DataSource string
+	Driver             string
+	DataSource         string
+	MaxConnections     int
+	MaxIdleConnections int
+	MaxConnLifetime    time.Duration
 }
 
 type Cache interface {

--- a/pkg/cli/commands/rpkg/clone/command.go
+++ b/pkg/cli/commands/rpkg/clone/command.go
@@ -24,7 +24,6 @@ import (
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	cliutils "github.com/nephio-project/porch/internal/cliutils"
 	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/docs"
-	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/util"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -103,15 +102,6 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 
 	source := args[0]
 	target := args[1]
-
-	pkgExists, err := util.PackageAlreadyExists(r.ctx, r.client, r.repository, target, *r.cfg.Namespace)
-	if err != nil {
-		return err
-	}
-	if pkgExists {
-		return fmt.Errorf("`clone` cannot create a new revision for package %q that already exists in repo %q; make subsequent revisions using `copy`",
-			target, r.repository)
-	}
 
 	switch {
 	case strings.HasPrefix(source, "oci://"):

--- a/pkg/cli/commands/rpkg/init/command.go
+++ b/pkg/cli/commands/rpkg/init/command.go
@@ -22,7 +22,6 @@ import (
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	cliutils "github.com/nephio-project/porch/internal/cliutils"
 	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/docs"
-	"github.com/nephio-project/porch/pkg/cli/commands/rpkg/util"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -99,14 +98,6 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 	}
 
 	r.name = args[0]
-	pkgExists, err := util.PackageAlreadyExists(r.ctx, r.client, r.repository, r.name, *r.cfg.Namespace)
-	if err != nil {
-		return err
-	}
-	if pkgExists {
-		return fmt.Errorf("`init` cannot create a new revision for package %q that already exists in repo %q; make subsequent revisions using `copy`",
-			r.name, r.repository)
-	}
 	return nil
 }
 

--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -114,20 +114,18 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 			}
 		}
 	case upstream, downstream:
-		// do nothing
+		packageRevisionList := porchapi.PackageRevisionList{}
+		listOpts := []client.ListOption{}
+		if r.cfg.Namespace != nil && *r.cfg.Namespace != "" {
+			listOpts = append(listOpts, client.InNamespace(*r.cfg.Namespace))
+		}
+		if err := r.client.List(r.ctx, &packageRevisionList, listOpts...); err != nil {
+			return errors.E(op, err)
+		}
+		r.prs = packageRevisionList.Items
 	default:
 		return errors.E(op, fmt.Errorf("argument for 'discover' must be one of 'upstream' or 'downstream'"))
 	}
-
-	packageRevisionList := porchapi.PackageRevisionList{}
-	listOpts := []client.ListOption{}
-	if r.cfg.Namespace != nil && *r.cfg.Namespace != "" {
-		listOpts = append(listOpts, client.InNamespace(*r.cfg.Namespace))
-	}
-	if err := r.client.List(r.ctx, &packageRevisionList, listOpts...); err != nil {
-		return errors.E(op, err)
-	}
-	r.prs = packageRevisionList.Items
 
 	return nil
 }
@@ -253,6 +251,19 @@ func makePackageRevision(oldLocal *porchapi.PackageRevision, workspace string, t
 }
 
 func (r *runner) findPackageRevision(prName string) *porchapi.PackageRevision {
+	// Use GET instead of searching through cached list
+	if r.discover == "" {
+		pr := &porchapi.PackageRevision{}
+		ns := ""
+		if r.cfg.Namespace != nil {
+			ns = *r.cfg.Namespace
+		}
+		if err := r.client.Get(r.ctx, client.ObjectKey{Namespace: ns, Name: prName}, pr); err != nil {
+			return nil
+		}
+		return pr
+	}
+	// Discover mode uses cached list
 	for i := range r.prs {
 		pr := r.prs[i]
 		if pr.Name == prName {
@@ -263,6 +274,47 @@ func (r *runner) findPackageRevision(prName string) *porchapi.PackageRevision {
 }
 
 func (r *runner) findPackageRevisionForRef(name, repo string, revision int) *porchapi.PackageRevision {
+	// Use List with server-side filtering by package name, repo, and revision
+	if r.discover == "" {
+		list := &porchapi.PackageRevisionList{}
+		ns := ""
+		if r.cfg.Namespace != nil {
+			ns = *r.cfg.Namespace
+		}
+
+		// Build list options with server-side filtering
+		listOpts := []client.ListOption{
+			client.InNamespace(ns),
+		}
+
+		// Add field selectors for package name, repo, and revision
+		fields := make(map[string]string)
+		if name != "" {
+			fields["spec.packageName"] = name
+		}
+		if repo != "" {
+			fields["spec.repository"] = repo
+		}
+		if revision > 0 {
+			fields["spec.revision"] = fmt.Sprintf("%d", revision)
+		}
+		if len(fields) > 0 {
+			listOpts = append(listOpts, client.MatchingFields(fields))
+		}
+
+		if err := r.client.List(r.ctx, list, listOpts...); err != nil {
+			return nil
+		}
+
+		for i := range list.Items {
+			pr := &list.Items[i]
+			if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision == revision {
+				return pr
+			}
+		}
+		return nil
+	}
+	// Discover mode uses cached list
 	for i := range r.prs {
 		pr := r.prs[i]
 		if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision == revision {
@@ -273,12 +325,53 @@ func (r *runner) findPackageRevisionForRef(name, repo string, revision int) *por
 }
 
 func (r *runner) findLatestPackageRevisionForRef(name, repo string) *porchapi.PackageRevision {
+	// Discovery mode always uses cached list
+	if r.discover != "" {
+		latest := 0
+		var output *porchapi.PackageRevision
+		for _, pr := range r.prs {
+			if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision > latest {
+				latest = pr.Spec.Revision
+				output = &pr
+			}
+		}
+		return output
+	}
+
+	// Non-discovery mode: list with server-side filtering
+	list := &porchapi.PackageRevisionList{}
+	ns := ""
+	if r.cfg.Namespace != nil {
+		ns = *r.cfg.Namespace
+	}
+
+	// Build list options with server-side filtering
+	listOpts := []client.ListOption{
+		client.InNamespace(ns),
+	}
+
+	// Add field selectors for package name and repo
+	fields := make(map[string]string)
+	if name != "" {
+		fields["spec.packageName"] = name
+	}
+	if repo != "" {
+		fields["spec.repository"] = repo
+	}
+	if len(fields) > 0 {
+		listOpts = append(listOpts, client.MatchingFields(fields))
+	}
+
+	if err := r.client.List(r.ctx, list, listOpts...); err != nil {
+		return nil
+	}
 	latest := 0
 	var output *porchapi.PackageRevision
-	for _, pr := range r.prs {
+	for i := range list.Items {
+		pr := &list.Items[i]
 		if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision > latest {
 			latest = pr.Spec.Revision
-			output = &pr
+			output = pr
 		}
 	}
 	return output

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -215,6 +215,14 @@ func TestUpgradeCommand(t *testing.T) {
 			}
 			return nil
 		},
+		List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if prList, ok := list.(*porchapi.PackageRevisionList); ok {
+				// Return all package revisions and let client-side filtering handle it
+				prList.Items = prs
+				return nil
+			}
+			return nil
+		},
 	}
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -295,7 +303,28 @@ func TestFindLatestPR(t *testing.T) {
 		*localRevision,
 	}
 
-	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, "ns", 0)
+	// Create fake client with custom List interceptor
+	scheme := runtime.NewScheme()
+	if err := porchapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add porch API to scheme: %v", err)
+	}
+	interceptorFuncs := interceptor.Funcs{
+		List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if prList, ok := list.(*porchapi.PackageRevisionList); ok {
+				// Return all package revisions and let client-side filtering handle it
+				prList.Items = prs
+				return nil
+			}
+			return nil
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(origRevision, newUpstreamRevision, localRevision).
+		WithInterceptorFuncs(interceptorFuncs).
+		Build()
+
+	r := createRunner(context.Background(), client, prs, "ns", 0)
 
 	found := r.findLatestPackageRevisionForRef("orig", "repo")
 	assert.Equal(t, "repo.orig.v2", found.Name)
@@ -450,7 +479,6 @@ func TestDiscoverUpdates(t *testing.T) {
 func TestPreRunStrategyValidation(t *testing.T) {
 	ns := "ns"
 	dummyApiServer := "http://localhost:9999"
-	fakeClient := fake.NewClientBuilder().Build()
 	cfg := &genericclioptions.ConfigFlags{
 		APIServer: &dummyApiServer,
 		Namespace: &ns,
@@ -460,6 +488,7 @@ func TestPreRunStrategyValidation(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		strategy             string
+		discover             string
 		validationShouldPass bool
 		expectedErrorMsg     string
 	}{
@@ -467,19 +496,24 @@ func TestPreRunStrategyValidation(t *testing.T) {
 			name:                 "Valid strategy: copy-merge",
 			strategy:             string(porchapi.CopyMerge),
 			validationShouldPass: true,
-			// Will fail with connection error later, after validation passes
 		},
 		{
 			name:                 "Empty strategy is valid (uses default resource-merge)",
 			strategy:             "",
 			validationShouldPass: true,
-			// Will fail with connection error later, after validation passes
 		},
 		{
 			name:                 "Invalid strategy",
 			strategy:             "non-existent-strategy",
 			validationShouldPass: false,
 			expectedErrorMsg:     "invalid strategy \"non-existent-strategy\"; must be one of:",
+		},
+		{
+			name:                 "Valid strategy with discover mode fails connection",
+			strategy:             string(porchapi.ResourceMerge),
+			discover:             "upstream",
+			validationShouldPass: true,
+			expectedErrorMsg:     "connection refused",
 		},
 	}
 
@@ -488,24 +522,25 @@ func TestPreRunStrategyValidation(t *testing.T) {
 			r := &runner{
 				ctx:       ctx,
 				cfg:       cfg,
-				client:    fakeClient,
 				revision:  2,
 				workspace: "v2",
 				strategy:  tc.strategy,
+				discover:  tc.discover,
 			}
 			r.Command = NewCommand(r.ctx, r.cfg)
 
 			err := r.preRunE(r.Command, []string{"some-package-revision"})
 
 			if !tc.validationShouldPass {
-				// For invalid strategies, check specific validation error
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrorMsg)
+			} else if tc.discover != "" {
+				// For valid strategies in discover mode, validation passes but connection fails
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectedErrorMsg)
 			} else {
-				// For valid strategies, we expect a different error (connection error)
-				// since we provided an invalid API server
-				assert.Error(t, err)
-				assert.NotContains(t, err.Error(), "invalid strategy")
+				// For valid strategies in non-discover mode, preRunE should succeed
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/cli/commands/rpkg/util/common.go
+++ b/pkg/cli/commands/rpkg/util/common.go
@@ -15,35 +15,16 @@
 package util
 
 import (
-	"context"
 	"fmt"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	fnsdk "github.com/kptdev/krm-functions-sdk/go/fn"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	ResourceVersionAnnotation = "internal.kpt.dev/resource-version"
 )
-
-func PackageAlreadyExists(ctx context.Context, c client.Client, repository, packageName, namespace string) (bool, error) {
-	// only the first package revision can be created from init or clone, so
-	// we need to check that the package doesn't already exist.
-	packageRevisionList := porchapi.PackageRevisionList{}
-	if err := c.List(ctx, &packageRevisionList, &client.ListOptions{
-		Namespace: namespace,
-	}); err != nil {
-		return false, err
-	}
-	for _, pr := range packageRevisionList.Items {
-		if pr.Spec.RepositoryName == repository && pr.Spec.PackageName == packageName {
-			return true, nil
-		}
-	}
-	return false, nil
-}
 
 func GetResourceFileKubeObject(prr *porchapi.PackageRevisionResources, file, kind, name string) (*fnsdk.KubeObject, error) {
 	if prr.Spec.Resources == nil {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -59,10 +59,14 @@ type PorchServerOptions struct {
 
 	CoreAPIKubeconfigPath string
 
-	CacheDirectory    string
-	CacheType         string
-	DbCacheDriver     string
-	DbCacheDataSource string
+	CacheDirectory       string
+	CacheType            string
+	DbCacheDriver        string
+	DbCacheDataSource    string
+	DbMaxConnections     int
+	DbMaxIdleConnections int
+	DbMaxConnLifetime    time.Duration
+	DbPushDrafsToGit     bool
 
 	DefaultImagePrefix       string
 	FunctionRunnerAddress    string
@@ -181,6 +185,33 @@ func (o *PorchServerOptions) Complete() error {
 	if o.CacheType == string(cachetypes.DBCacheType) {
 		if err := o.setupDBCacheConn(); err != nil {
 			return err
+		}
+		// Set connection pool defaults from environment variables
+		if maxConns := os.Getenv("DB_MAX_CONNECTIONS"); maxConns != "" {
+			if n, err := fmt.Sscanf(maxConns, "%d", &o.DbMaxConnections); err != nil || n != 1 {
+				klog.Warningf("Invalid DB_MAX_CONNECTIONS value %q, using default 300", maxConns)
+				o.DbMaxConnections = 300
+			}
+		} else {
+			o.DbMaxConnections = 300
+		}
+		if maxIdle := os.Getenv("DB_MAX_IDLE_CONNECTIONS"); maxIdle != "" {
+			if n, err := fmt.Sscanf(maxIdle, "%d", &o.DbMaxIdleConnections); err != nil || n != 1 {
+				klog.Warningf("Invalid DB_MAX_IDLE_CONNECTIONS value %q, using default 100", maxIdle)
+				o.DbMaxIdleConnections = 100
+			}
+		} else {
+			o.DbMaxIdleConnections = 100
+		}
+		if maxLifetime := os.Getenv("DB_MAX_CONN_LIFETIME"); maxLifetime != "" {
+			if d, err := time.ParseDuration(maxLifetime); err != nil {
+				klog.Warningf("Invalid DB_MAX_CONN_LIFETIME value %q, using default 3m", maxLifetime)
+				o.DbMaxConnLifetime = 3 * time.Minute
+			} else {
+				o.DbMaxConnLifetime = d
+			}
+		} else {
+			o.DbMaxConnLifetime = 3 * time.Minute
 		}
 	}
 
@@ -304,8 +335,11 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 				RepoOperationRetryAttempts: o.RepoOperationRetryAttempts,
 				CacheType:                  cachetypes.CacheType(o.CacheType),
 				DBCacheOptions: cachetypes.DBCacheOptions{
-					Driver:     o.DbCacheDriver,
-					DataSource: o.DbCacheDataSource,
+					Driver:             o.DbCacheDriver,
+					DataSource:         o.DbCacheDataSource,
+					MaxConnections:     o.DbMaxConnections,
+					MaxIdleConnections: o.DbMaxIdleConnections,
+					MaxConnLifetime:    o.DbMaxConnLifetime,
 				},
 			},
 			ListTimeoutPerRepository: o.ListTimeoutPerRepository,

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -79,39 +78,150 @@ func TestComplete(t *testing.T) {
 }
 
 func TestSetupDBCacheConn(t *testing.T) {
-	opts := NewPorchServerOptions(os.Stdout, os.Stderr)
+	// Default expected connection pooling values
+	defaultMaxConns := 300
+	defaultMaxIdleConns := 100
+	defaultMaxConnLifetime := 3 * time.Minute
 
-	err := opts.setupDBCacheConn()
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "missing required environment variables"))
+	tests := []struct {
+		name                    string
+		envVars                 map[string]string
+		expectError             bool
+		errorContains           string
+		expectedDriver          string
+		expectedDataSource      string
+		expectedMaxConns        int
+		expectedMaxIdleConns    int
+		expectedMaxConnLifetime time.Duration
+	}{
+		{
+			name: "missing required environment variables",
+			envVars: map[string]string{
+				"DB_HOST": "", // Empty value should trigger missing var error
+				"DB_PORT": "",
+				"DB_NAME": "",
+			},
+			expectError:   true,
+			errorContains: "missing required environment variables",
+		},
+		{
+			name: "unsupported DB driver",
+			envVars: map[string]string{
+				"DB_DRIVER": "db-driver",
+			},
+			expectError:   true,
+			errorContains: "unsupported DB driver: db-driver",
+		},
+		{
+			name:                    "pgx driver with defaults",
+			envVars:                 map[string]string{},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "mysql driver",
+			envVars: map[string]string{
+				"DB_DRIVER": "mysql",
+			},
+			expectError:             false,
+			expectedDriver:          "mysql",
+			expectedDataSource:      "db-user:db-password@tcp(db-host:db-port)/db-name",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "pgx with SSL mode",
+			envVars: map[string]string{
+				"DB_SSL_MODE": "verify-full",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user@db-host:db-port/db-name?sslmode=verify-full",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+		{
+			name: "custom connection pooling values",
+			envVars: map[string]string{
+				"DB_MAX_CONNECTIONS":      "50",
+				"DB_MAX_IDLE_CONNECTIONS": "25",
+				"DB_MAX_CONN_LIFETIME":    "5m",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        50,
+			expectedMaxIdleConns:    25,
+			expectedMaxConnLifetime: 5 * time.Minute,
+		},
+		{
+			name: "invalid connection pooling values use defaults",
+			envVars: map[string]string{
+				"DB_MAX_CONNECTIONS":      "invalid",
+				"DB_MAX_IDLE_CONNECTIONS": "not-a-number",
+				"DB_MAX_CONN_LIFETIME":    "bad-duration",
+			},
+			expectError:             false,
+			expectedDriver:          "pgx",
+			expectedDataSource:      "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable",
+			expectedMaxConns:        defaultMaxConns,
+			expectedMaxIdleConns:    defaultMaxIdleConns,
+			expectedMaxConnLifetime: defaultMaxConnLifetime,
+		},
+	}
 
-	os.Setenv("DB_DRIVER", "db-driver")
-	os.Setenv("DB_HOST", "db-host")
-	os.Setenv("DB_PORT", "db-port")
-	os.Setenv("DB_NAME", "db-name")
-	os.Setenv("DB_USER", "db-user")
-	os.Setenv("DB_PASSWORD", "db-password")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all DB-related environment variables
+			dbEnvVars := []string{
+				"DB_DRIVER", "DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_SSL_MODE",
+				"DB_MAX_CONNECTIONS", "DB_MAX_IDLE_CONNECTIONS", "DB_MAX_CONN_LIFETIME",
+			}
+			for _, envVar := range dbEnvVars {
+				os.Unsetenv(envVar)
+			}
 
-	err = opts.setupDBCacheConn()
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "unsupported DB driver: db-driver"))
+			// Set default required environment variables
+			os.Setenv("DB_HOST", "db-host")
+			os.Setenv("DB_PORT", "db-port")
+			os.Setenv("DB_NAME", "db-name")
+			os.Setenv("DB_USER", "db-user")
+			os.Setenv("DB_PASSWORD", "db-password")
 
-	os.Setenv("DB_DRIVER", "pgx")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "pgx", opts.DbCacheDriver)
-	assert.Equal(t, "postgres://db-user:db-password@db-host:db-port/db-name?sslmode=disable", opts.DbCacheDataSource)
+			// Set test-specific environment variables (can override defaults)
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
 
-	os.Setenv("DB_DRIVER", "mysql")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "mysql", opts.DbCacheDriver)
-	assert.Equal(t, "db-user:db-password@tcp(db-host:db-port)/db-name", opts.DbCacheDataSource)
+			opts := NewPorchServerOptions(os.Stdout, os.Stderr)
+			opts.CacheType = "DB"
 
-	os.Setenv("DB_SSL_MODE", "verify-full")
-	os.Setenv("DB_DRIVER", "pgx")
-	err = opts.setupDBCacheConn()
-	assert.Nil(t, err)
-	assert.Equal(t, "pgx", opts.DbCacheDriver)
-	assert.Equal(t, "postgres://db-user@db-host:db-port/db-name?sslmode=verify-full", opts.DbCacheDataSource)
+			err := opts.Complete()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedDriver, opts.DbCacheDriver)
+				assert.Equal(t, tt.expectedDataSource, opts.DbCacheDataSource)
+				assert.Equal(t, tt.expectedMaxConns, opts.DbMaxConnections)
+				assert.Equal(t, tt.expectedMaxIdleConns, opts.DbMaxIdleConnections)
+				assert.Equal(t, tt.expectedMaxConnLifetime, opts.DbMaxConnLifetime)
+			}
+
+			// Clean up
+			for _, envVar := range dbEnvVars {
+				os.Unsetenv(envVar)
+			}
+		})
+	}
 }

--- a/test/e2e/cli/testdata/rpkg-clone/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-clone/config.yaml
@@ -29,7 +29,7 @@ commands:
       - --workspace=clone-3
       - basens-clone
     stderr: |
-      error: `clone` cannot create a new revision for package "basens-clone" that already exists in repo "git"; make subsequent revisions using `copy`
+      Error: Internal error occurred: `clone` cannot create a new revision for package "basens-clone" that already exists in repo "git"; make subsequent revisions using `copy` 
     exitCode: 1
   - args:
       - porchctl

--- a/test/e2e/cli/testdata/rpkg-init/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-init/config.yaml
@@ -92,5 +92,5 @@ commands:
       - --workspace=init-2
       - init-package
     stderr: |
-      error: `init` cannot create a new revision for package "init-package" that already exists in repo "git"; make subsequent revisions using `copy`
+      Error: Internal error occurred: package "init-package" already exists in repository "git" 
     exitCode: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Backport of nephio-project/nephio#500: Move label filtering to sql queries

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  As part of listing PackageRevisions, instead of loading the full list of packagerevisions into memory, label filtering is done with adding `WHERE` clauses to the DB query.
- Why it’s needed:  Reduces the memory footprint of porch in case there are high numbers of packagerevisions
- How it works:  Parses the label selectors, and generates WEHRE clauses from them

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes # Fixes https://github.com/nephio-project/porch/issues/797
- Backport of https://github.com/nephio-project/porch/pull/500

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated - N/A  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  


## AI Disclosure
[x] I have used AI in the creation of this PR.

Examples:

- Kiro generated the unit test cases
