### PR TITLE
Backport #500

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -419,6 +419,18 @@ func (pr *dbPackageRevision) UpdateResources(ctx context.Context, new *porchapi.
 
 	pr.resources = new.Spec.Resources
 
+	if kfString, ok := new.Spec.Resources[kptfile.KptFileName]; ok {
+		if kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfString)); err == nil {
+			if pr.spec == nil {
+				pr.spec = &porchapi.PackageRevisionSpec{}
+			}
+			pr.spec.PackageMetadata = &porchapi.PackageMetadata{
+				Labels:      kf.Labels,
+				Annotations: kf.Annotations,
+			}
+		}
+	}
+
 	if change != nil && porchapi.IsValidFirstTaskType(change.Type) {
 		if len(pr.tasks) > 0 {
 			klog.Warningf("Replacing first task of %q", pr.Key())

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -25,6 +25,8 @@ import (
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func (t *DbTestSuite) TestPackageRevisionDBWriteRead() {
@@ -753,4 +755,227 @@ func (t *DbTestSuite) TestFindUpstreamReference() {
 	t.NoError(err)
 	err = repoDeleteFromDB(t.Context(), downstreamRepo.Key())
 	t.NoError(err)
+}
+
+func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func()) {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo("label-ns", "label-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "label-pkg")
+
+	// PR with labels app=web, env=prod
+	pr1 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-1",
+			Revision:      1,
+		},
+		meta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": "web", "env": "prod"},
+		},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr1))
+
+	// PR with labels app=api, env=staging
+	pr2 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-2",
+			Revision:      2,
+		},
+		meta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": "api", "env": "staging"},
+		},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr2))
+
+	// PR with no labels
+	pr3 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-3",
+			Revision:      3,
+		},
+		meta:      metav1.ObjectMeta{},
+		lifecycle: "Published",
+		resources: map[string]string{},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr3))
+
+	return dbRepo.Key(), func() {
+		t.deleteTestRepo(dbRepo.Key())
+	}
+}
+
+func (t *DbTestSuite) TestPrLabelFilterEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-1", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterDoubleEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-2", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNotEquals() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterIn() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNotIn() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// pr2 (app=api) and pr3 (no app label, IS NULL matches)
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterExists() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Exists, []string{})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// pr1 and pr2 have the "app" label
+	t.Len(results, 2)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterDoesNotExist() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
+	t.Require().NoError(err)
+
+	reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req, *reqExists),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
+	t.Empty(results)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterMultipleRequirements() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+	t.Require().NoError(err)
+	reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*reqApp, *reqEnv),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-1", results[0].Key().WorkspaceName)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNilSelector() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	filter := repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 3)
+}
+
+func (t *DbTestSuite) TestPrLabelFilterNoMatch() {
+	repoKey, cleanup := t.setupLabelFilterTestData()
+	defer cleanup()
+
+	req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
+	t.Require().NoError(err)
+
+	filter := repository.ListPackageRevisionFilter{
+		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		Label: labels.NewSelector().Add(*req),
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Empty(results)
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -1030,4 +1030,122 @@ func (t *DbTestSuite) TestPrLabelFilter() {
 		t.Len(results, 1)
 		t.Equal("ws-1", results[0].Key().WorkspaceName)
 	})
+
+	t.Run("LatestRevisionDoubleEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.DoubleEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionIn", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.In, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionNotIn", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotIn, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionExists", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Exists, []string{})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionEqualsFalse", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionNotEqualsFalse", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
+
+	t.Run("LatestRevisionInWithoutTrue", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.In, []string{"false", "other"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
+
+	t.Run("LatestRevisionNotInWithoutTrue", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotIn, []string{"false"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -795,7 +795,6 @@ func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func
 	}
 	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr2))
 
-	// PR with no labels
 	pr3 := dbPackageRevision{
 		pkgRevKey: repository.PackageRevisionKey{
 			PkgKey:        dbPkg.Key(),
@@ -813,169 +812,222 @@ func (t *DbTestSuite) setupLabelFilterTestData() (repository.RepositoryKey, func
 	}
 }
 
-func (t *DbTestSuite) TestPrLabelFilterEquals() {
+func (t *DbTestSuite) TestPrLabelFilter() {
 	repoKey, cleanup := t.setupLabelFilterTestData()
 	defer cleanup()
 
-	req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("Equals", func() {
+		req, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-1", results[0].Key().WorkspaceName)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterDoubleEquals() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("DoubleEquals", func() {
+		req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("env", selection.DoubleEquals, []string{"staging"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-2", results[0].Key().WorkspaceName)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-2", results[0].Key().WorkspaceName)
-}
+	t.Run("NotEquals", func() {
+		req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterNotEquals() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+	})
 
-	req, err := labels.NewRequirement("app", selection.NotEquals, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("In", func() {
+		req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 2)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterIn() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("NotIn", func() {
+		req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("app", selection.In, []string{"web", "api"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// pr2 (app=api) and pr3 (no app label, IS NULL matches)
+		t.Len(results, 2)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 2)
-}
+	t.Run("Exists", func() {
+		req, err := labels.NewRequirement("app", selection.Exists, []string{})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterNotIn() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// pr1 and pr2 have the "app" label
+		t.Len(results, 2)
+	})
 
-	req, err := labels.NewRequirement("app", selection.NotIn, []string{"web"})
-	t.Require().NoError(err)
+	t.Run("DoesNotExist", func() {
+		req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// pr2 (app=api) and pr3 (no app label, IS NULL matches)
-	t.Len(results, 2)
-}
+		reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterExists() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req, *reqExists),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
+		t.Empty(results)
+	})
 
-	req, err := labels.NewRequirement("app", selection.Exists, []string{})
-	t.Require().NoError(err)
+	t.Run("MultipleRequirements", func() {
+		reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
+		reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// pr1 and pr2 have the "app" label
-	t.Len(results, 2)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*reqApp, *reqEnv),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterDoesNotExist() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("NilSelector", func() {
+		filter := repository.ListPackageRevisionFilter{
+			Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 3)
+	})
 
-	req, err := labels.NewRequirement("env", selection.DoesNotExist, []string{})
-	t.Require().NoError(err)
+	t.Run("NoMatch", func() {
+		req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
+		t.Require().NoError(err)
 
-	reqExists, err := labels.NewRequirement("app", selection.Exists, []string{})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Empty(results)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req, *reqExists),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	// No PRs have "app" label but lack "env" label — both pr1 and pr2 have both
-	t.Empty(results)
-}
+	t.Run("LatestRevisionEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
 
-func (t *DbTestSuite) TestPrLabelFilterMultipleRequirements() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-3", results[0].Key().WorkspaceName)
+	})
 
-	reqApp, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
-	t.Require().NoError(err)
-	reqEnv, err := labels.NewRequirement("env", selection.Equals, []string{"prod"})
-	t.Require().NoError(err)
+	t.Run("LatestRevisionNotEquals", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*reqApp, *reqEnv),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 1)
-	t.Equal("ws-1", results[0].Key().WorkspaceName)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterNilSelector() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("LatestRevisionDoesNotExist", func() {
+		req, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.DoesNotExist, []string{})
+		t.Require().NoError(err)
 
-	filter := repository.ListPackageRevisionFilter{
-		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Len(results, 3)
-}
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*req),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 2)
+		for _, r := range results {
+			t.NotEqual("ws-3", r.Key().WorkspaceName)
+		}
+	})
 
-func (t *DbTestSuite) TestPrLabelFilterNoMatch() {
-	repoKey, cleanup := t.setupLabelFilterTestData()
-	defer cleanup()
+	t.Run("LatestRevisionCombinedWithRegularLabel", func() {
+		latestReq, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.Equals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+		// ws-3 has no labels, so combining latest=true with any app label should return nothing
+		appReq, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
 
-	req, err := labels.NewRequirement("app", selection.Equals, []string{"nonexistent"})
-	t.Require().NoError(err)
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*latestReq, *appReq),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Empty(results)
+	})
 
-	filter := repository.ListPackageRevisionFilter{
-		Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
-		Label: labels.NewSelector().Add(*req),
-	}
-	results, err := pkgRevListPRsFromDB(t.Context(), filter)
-	t.Require().NoError(err)
-	t.Empty(results)
+	t.Run("NotLatestWithRegularLabel", func() {
+		notLatestReq, err := labels.NewRequirement(porchapi.LatestPackageRevisionKey, selection.NotEquals, []string{porchapi.LatestPackageRevisionValue})
+		t.Require().NoError(err)
+		appReq, err := labels.NewRequirement("app", selection.Equals, []string{"web"})
+		t.Require().NoError(err)
+
+		filter := repository.ListPackageRevisionFilter{
+			Key:   repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: repoKey}},
+			Label: labels.NewSelector().Add(*notLatestReq, *appReq),
+		}
+		results, err := pkgRevListPRsFromDB(t.Context(), filter)
+		t.Require().NoError(err)
+		t.Len(results, 1)
+		t.Equal("ws-1", results[0].Key().WorkspaceName)
+	})
 }

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -160,10 +160,7 @@ func (r *dbRepository) ListPackageRevisions(ctx context.Context, filter reposito
 			klog.V(4).Infof("ListPackageRevisions: skipping package revision %+v with nil repository", pkgRev.Key())
 			continue
 		}
-		genericPkgRev := repository.PackageRevision(pkgRev)
-		if filter.MatchesLabels(ctx, genericPkgRev) {
-			genericPkgRevs[i] = genericPkgRev
-		}
+		genericPkgRevs[i] = pkgRev
 	}
 	genericPkgRevs = slices.DeleteFunc(genericPkgRevs, func(rev repository.PackageRevision) bool {
 		return rev == nil

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -20,6 +20,8 @@ import (
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/repository"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func pkgListFilter2WhereClause(filter repository.ListPackageFilter) string {
@@ -61,6 +63,7 @@ func prListFilter2WhereClause(filter repository.ListPackageRevisionFilter) strin
 	whereStatement, first = filter2SubClauseWorkspace(whereStatement, prKey.WorkspaceName, "package_revisions.k8s_name", first)
 
 	whereStatement, first = filter2SubClauseLifecycle(whereStatement, filter.Lifecycles, "package_revisions.lifecycle", first)
+	whereStatement, first = filter2SubClausePrLabels(whereStatement, filter.Label, first)
 	whereStatement, _ = filter2SubClauseKptfileLabels(whereStatement, filter.KptfileLabels, first)
 
 	if whereStatement == "" {
@@ -153,4 +156,62 @@ func filter2SubClauseKptfileLabels(whereStatement string, filterLabels map[strin
 	} else {
 		return whereStatement + "AND " + combinedClause, false
 	}
+}
+
+func filter2SubClausePrLabels(whereStatement string, labelSelector labels.Selector, first bool) (string, bool) {
+
+	if labelSelector == nil {
+		return whereStatement, first
+	}
+
+	subClauses := labelSelectorToJSONBClauses(labelSelector)
+	if len(subClauses) == 0 {
+		return whereStatement, first
+	}
+
+	combinedClause := "(" + strings.Join(subClauses, " AND ") + ")"
+
+	if first {
+		return whereStatement + combinedClause, false
+	} else {
+		return whereStatement + "AND " + combinedClause, false
+	}
+}
+
+func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
+	jsonbPath := "package_revisions.meta::jsonb->'labels'"
+	reqs, hasSelector := labelSelector.Requirements()
+	if !hasSelector {
+		return nil
+	}
+
+	var clauses []string
+	for _, req := range reqs {
+		key := req.Key()
+		values := req.Values().List()
+
+		switch req.Operator() {
+		case selection.Equals, selection.DoubleEquals:
+			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' = '%s')", jsonbPath, key, values[0]))
+		case selection.NotEquals:
+			clauses = append(clauses, fmt.Sprintf("((%s->>'%s') IS NULL OR %s->>'%s' != '%s')", jsonbPath, key, jsonbPath, key, values[0]))
+		case selection.In:
+			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' IN (%s))", jsonbPath, key, quotedStringListForJsonB(values)))
+		case selection.NotIn:
+			clauses = append(clauses, fmt.Sprintf("((%s->>'%s') IS NULL OR %s->>'%s' NOT IN (%s))", jsonbPath, key, jsonbPath, key, quotedStringListForJsonB(values)))
+		case selection.Exists:
+			clauses = append(clauses, fmt.Sprintf("(%s ? '%s')", jsonbPath, key))
+		case selection.DoesNotExist:
+			clauses = append(clauses, fmt.Sprintf("(NOT (%s ? '%s'))", jsonbPath, key))
+		}
+	}
+	return clauses
+}
+
+func quotedStringListForJsonB(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("'%s'", v)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -16,6 +16,7 @@ package dbcache
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
@@ -190,6 +191,11 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 		key := req.Key()
 		values := req.Values().List()
 
+		if key == porchapi.LatestPackageRevisionKey {
+			clauses = append(clauses, latestRevisionClause(req.Operator(), values))
+			continue
+		}
+
 		switch req.Operator() {
 		case selection.Equals, selection.DoubleEquals:
 			clauses = append(clauses, fmt.Sprintf("(%s->>'%s' = '%s')", jsonbPath, key, values[0]))
@@ -206,6 +212,40 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 		}
 	}
 	return clauses
+}
+
+// latestRevisionClause generates a SQL clause for the latest-revision label.
+// This label is not stored in the meta JSON but as a separate boolean column.
+func latestRevisionClause(op selection.Operator, values []string) string {
+	col := "package_revisions.latest"
+	switch op {
+	case selection.Equals, selection.DoubleEquals:
+		if values[0] == porchapi.LatestPackageRevisionValue {
+			return fmt.Sprintf("(%s = TRUE)", col)
+		}
+		return fmt.Sprintf("(%s = FALSE)", col)
+	case selection.NotEquals:
+		if values[0] == porchapi.LatestPackageRevisionValue {
+			return fmt.Sprintf("(%s = FALSE)", col)
+		}
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.In:
+		if slices.Contains(values, porchapi.LatestPackageRevisionValue) {
+			return fmt.Sprintf("(%s = TRUE)", col)
+		}
+		return fmt.Sprintf("(%s = FALSE)", col)
+	case selection.NotIn:
+		if slices.Contains(values, porchapi.LatestPackageRevisionValue) {
+			return fmt.Sprintf("(%s = FALSE)", col)
+		}
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.Exists:
+		return fmt.Sprintf("(%s = TRUE)", col)
+	case selection.DoesNotExist:
+		return fmt.Sprintf("(%s = FALSE)", col)
+	default:
+		return "TRUE"
+	}
 }
 
 func quotedStringListForJsonB(values []string) string {

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -214,8 +214,6 @@ func labelSelectorToJSONBClauses(labelSelector labels.Selector) []string {
 	return clauses
 }
 
-// latestRevisionClause generates a SQL clause for the latest-revision label.
-// This label is not stored in the meta JSON but as a separate boolean column.
 func latestRevisionClause(op selection.Operator, values []string) string {
 	col := "package_revisions.latest"
 	switch op {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Backport of nephio-project/nephio#500: Move label filtering to sql queries

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  As part of listing PackageRevisions, instead of loading the full list of packagerevisions into memory, label filtering is done with adding `WHERE` clauses to the DB query.
- Why it’s needed:  Reduces the memory footprint of porch in case there are high numbers of packagerevisions
- How it works:  Parses the label selectors, and generates WEHRE clauses from them

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes # Fixes https://github.com/nephio-project/porch/issues/797
- Backport of https://github.com/nephio-project/porch/pull/500

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated - N/A  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  


## AI Disclosure
[x] I have used AI in the creation of this PR.

Examples:

- Kiro generated the unit test cases
