### PR TITLE
Bugfix: Multiple field selectors

### DIFF
--- a/pkg/registry/porch/fieldselector.go
+++ b/pkg/registry/porch/fieldselector.go
@@ -194,7 +194,7 @@ func parsePackageRevisionFieldSelector(options *metainternalversion.ListOptions)
 			filter.KptfileLabels[labelKey] = requirement.Value
 
 			// skip the upcoming requirement.Field check
-			return filter, nil
+			continue
 		}
 
 		filteredField := porchapi.PkgRevFieldSelector(requirement.Field)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
Fix multiple label field selectors returning incorrect results in PackageRevision queries

---

## Description
- What changed: Replaced `return filter, nil` with `continue` in `parsePackageRevisionFieldSelector` in `pkg/registry/porch/fieldselector.go`
- Why it's needed: When using multiple `spec.packageMetadata.labels` field selectors, only the first was evaluated and the function returned early after processing it, silently ignoring all future selectors
- How it works: Using `continue` instead of `return` allows the loop to process all items before returning the fully populated filter

---

## Related Issue(s)
- Fixes https://github.com/nephio-project/porch/issues/804

---

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. Follow reproduction instructions in the issue.

---

## Additional Notes (Optional)

---

## AI Disclosure
- [x] I have used AI in the creation of this PR.
- Amazon Q to assist with root cause analysis, and populating issue/PR templates
