### PR TITLE
Scalability Improvements 9: During porch-server startup, background.go based repository sync should allow for synchronising multiple repositories at once.

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -96,6 +96,7 @@ type PorchServer struct {
 	cache                      cachetypes.Cache
 	periodicRepoSyncFrequency  time.Duration
 	listTimeoutPerRepository   time.Duration
+	maxConcurrentLists         int
 	repoOperationRetryAttempts int
 }
 
@@ -326,6 +327,7 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 		// Set background job periodic frequency the same as repo sync frequency.
 		periodicRepoSyncFrequency:  c.ExtraConfig.CacheOptions.RepoSyncFrequency,
 		listTimeoutPerRepository:   c.ExtraConfig.CacheOptions.CRCacheOptions.ListTimeoutPerRepository,
+		maxConcurrentLists:         c.ExtraConfig.CacheOptions.CRCacheOptions.MaxConcurrentLists,
 		repoOperationRetryAttempts: c.ExtraConfig.CacheOptions.RepoOperationRetryAttempts,
 	}
 
@@ -341,6 +343,7 @@ func (s *PorchServer) Run(ctx context.Context) error {
 	porch.RunBackground(ctx, s.coreClient, s.cache,
 		porch.WithPeriodicRepoSyncFrequency(s.periodicRepoSyncFrequency),
 		porch.WithListTimeoutPerRepo(s.listTimeoutPerRepository),
+		porch.WithMaxConcurrentLists(s.maxConcurrentLists),
 		porch.WithRepoOperationRetryAttempts(s.repoOperationRetryAttempts),
 	)
 

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -109,6 +109,13 @@ func (r *dbRepository) Close(ctx context.Context) error {
 	r.repositorySync.Stop()
 
 	defer func() {
+		// repoDeleteFromDB is a CASCADE delete - automatically deletes all packages, revisions and resources
+		if err := repoDeleteFromDB(ctx, r.Key()); err != nil {
+			klog.Warningf("dbRepository:close: delete of repository %+v from DB failed: %q", r.Key(), err)
+		}
+	}()
+
+	defer func() {
 		if err := r.externalRepo.Close(ctx); err != nil {
 			klog.Warningf("dbRepository:close: close of external repository %+v failed: %q", r.Key(), err)
 		} else {
@@ -128,7 +135,7 @@ func (r *dbRepository) Close(ctx context.Context) error {
 		}
 	}
 
-	return repoDeleteFromDB(ctx, r.Key())
+	return nil
 }
 
 func (r *dbRepository) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -85,11 +85,13 @@ func (r *dbRepository) OpenRepository(ctx context.Context, externalRepoOptions e
 		return nil
 	} else if err != sql.ErrNoRows {
 		klog.Warningf("dbRepository:OpenRepository: %+v DB read failed with error %q", r.Key(), err)
+		externalRepo.Close(ctx)
 		return err
 	}
 
 	if err = repoWriteToDB(ctx, r); err != nil {
 		klog.Warningf("dbRepository:OpenRepository: %+v DB write failed with error %q", r.Key(), err)
+		externalRepo.Close(ctx)
 		return err
 	}
 
@@ -106,6 +108,14 @@ func (r *dbRepository) Close(ctx context.Context) error {
 
 	r.repositorySync.Stop()
 
+	defer func() {
+		if err := r.externalRepo.Close(ctx); err != nil {
+			klog.Warningf("dbRepository:close: close of external repository %+v failed: %q", r.Key(), err)
+		} else {
+			klog.V(5).Infof("dbRepository:close: closed repository %+v", r.Key())
+		}
+	}()
+
 	dbPkgs, err := pkgReadPkgsFromDB(ctx, r.Key())
 	if err != nil {
 		return err
@@ -118,20 +128,7 @@ func (r *dbRepository) Close(ctx context.Context) error {
 		}
 	}
 
-	err = repoDeleteFromDB(ctx, r.Key())
-	if err != nil {
-		return err
-	}
-
-	err = r.externalRepo.Close(ctx)
-
-	if err == nil {
-		klog.V(5).Infof("dbRepository:close: closed repository %+v", r.Key())
-	} else {
-		klog.Warningf("dbRepository:close: close of repository %+v failed: %q", r.Key(), err)
-	}
-
-	return err
+	return repoDeleteFromDB(ctx, r.Key())
 }
 
 func (r *dbRepository) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {

--- a/pkg/cache/repomap/saferepomap.go
+++ b/pkg/cache/repomap/saferepomap.go
@@ -16,6 +16,7 @@
 package repomap
 
 import (
+	"context"
 	"sync"
 
 	"github.com/nephio-project/porch/pkg/repository"
@@ -68,6 +69,10 @@ func (s *SafeRepoMap) LoadOrCreate(key repository.RepositoryKey, create func() (
 		if l.err != nil && !loaded {
 			// Remove failed entry only if this thread created it, so subsequent calls can retry
 			s.syncMap.Delete(key)
+			// Close any partially created repo to release resources (e.g. git cache dir)
+			if l.repo != nil {
+				l.repo.Close(context.Background())
+			}
 		}
 	})
 

--- a/pkg/cache/sync/condition.go
+++ b/pkg/cache/sync/condition.go
@@ -22,6 +22,7 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/cache/util"
 	"github.com/nephio-project/porch/pkg/repository"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,6 +40,9 @@ func SetRepositoryCondition(ctx context.Context, coreClient client.WithWatch, re
 	}
 
 	if err := coreClient.Get(ctx, key, repo); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ErrRepositoryNotFound
+		}
 		return fmt.Errorf("failed to get repository: %w", err)
 	}
 

--- a/pkg/cache/sync/sync.go
+++ b/pkg/cache/sync/sync.go
@@ -16,6 +16,8 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -32,6 +34,9 @@ const (
 	timeFormat        = "2006-01-02 15:04:05"
 	nextSyncLogFormat = "repositorySync %+v: next scheduled time: %v"
 )
+
+// ErrRepositoryNotFound is returned when the repository CRD no longer exists
+var ErrRepositoryNotFound = fmt.Errorf("repository not found")
 
 // SyncHandler defines the interface for repository sync operations
 type SyncHandler interface {
@@ -217,6 +222,11 @@ func (m *SyncManager) updateRepositoryCondition(ctx context.Context) {
 		status = util.RepositoryStatusError
 	}
 	if err := m.SetRepositoryCondition(ctx, status); err != nil {
+		if errors.Is(err, ErrRepositoryNotFound) {
+			klog.Infof("repositorySync %+v: repository no longer exists, stopping sync", m.handler.Key())
+			m.Stop()
+			return
+		}
 		klog.Warningf("repositorySync %+v: failed to set repository condition: %v", m.handler.Key(), err)
 	}
 }

--- a/pkg/externalrepo/git/gitrepofactory.go
+++ b/pkg/externalrepo/git/gitrepofactory.go
@@ -103,6 +103,9 @@ func (f *GitRepoFactory) CheckRepositoryConnection(ctx context.Context, reposito
 		Timeout: 20,
 	})
 	if err != nil {
+		if errors.Is(err, transport.ErrEmptyRemoteRepository) {
+			return nil
+		}
 		return fmt.Errorf("failed to list remote refs: %w", err)
 	}
 

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -94,7 +94,7 @@ type background struct {
 	MaxConcurrentLists         int
 	repoMutexes                map[string]*sync.Mutex // Per-repository mutexes for event ordering
 	repoMutexesLock            sync.RWMutex           // Protects repoMutexes map
-	workerSemaphore            *semaphore.Weighted // Rate limit Git server operations
+	workerSemaphore            *semaphore.Weighted    // Rate limit Git server operations
 }
 
 const (
@@ -239,18 +239,12 @@ func (b *background) updateCache(ctx context.Context, event watch.EventType, rep
 }
 
 func (b *background) getRepositoryMutex(repoKey string) *sync.Mutex {
-	b.repoMutexesLock.RLock()
+	b.repoMutexesLock.Lock()
+	defer b.repoMutexesLock.Unlock()
 	mutex, exists := b.repoMutexes[repoKey]
-	b.repoMutexesLock.RUnlock()
-	
 	if !exists {
-		b.repoMutexesLock.Lock()
-		// Double-check after acquiring write lock
-		if mutex, exists = b.repoMutexes[repoKey]; !exists {
-			mutex = &sync.Mutex{}
-			b.repoMutexes[repoKey] = mutex
-		}
-		b.repoMutexesLock.Unlock()
+		mutex = &sync.Mutex{}
+		b.repoMutexes[repoKey] = mutex
 	}
 	return mutex
 }
@@ -258,25 +252,14 @@ func (b *background) getRepositoryMutex(repoKey string) *sync.Mutex {
 func (b *background) processRepositoryEvent(ctx context.Context, event watch.EventType, repository *configapi.Repository) {
 	// Create unique key for the repository
 	repoKey := fmt.Sprintf("%s/%s", repository.Namespace, repository.Name)
-
 	go func() {
-		// Get per-repository mutex to ensure event ordering
 		mutex := b.getRepositoryMutex(repoKey)
 		mutex.Lock()
-		defer func() {
-			mutex.Unlock()
-			// Clean up mutex for deleted repositories
-			if event == watch.Deleted {
-				b.repoMutexesLock.Lock()
-				delete(b.repoMutexes, repoKey)
-				b.repoMutexesLock.Unlock()
-			}
-		}()
+		defer mutex.Unlock()
 		if err := b.handleRepositoryEvent(ctx, repository, event); err != nil {
 			klog.Warningf("Processing error for %s:%s: %v", repository.Namespace, repository.Name, err)
 		}
 	}()
-
 }
 
 func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.Repository, eventType watch.EventType) error {
@@ -342,27 +325,32 @@ func (b *background) runOnce(ctx context.Context) error {
 
 	for i := range repositories.Items {
 		repo := &repositories.Items[i]
+		func() {
+			repoKey := fmt.Sprintf("%s/%s", repo.Namespace, repo.Name)
+			mutex := b.getRepositoryMutex(repoKey)
+			mutex.Lock()
+			defer mutex.Unlock()
 
-		// Check repository connectivity
-		if err := b.checkRepositoryConnectivity(ctx, repo); err != nil {
-			klog.Warningf("Repository connectivity check failed for %s: %v", repo.Name, err)
-			condition := v1.Condition{
-				Type:               configapi.RepositoryReady,
-				Status:             v1.ConditionFalse,
-				ObservedGeneration: repo.Generation,
-				LastTransitionTime: v1.Now(),
-				Reason:             configapi.ReasonError,
-				Message:            fmt.Sprintf("Repository connectivity check failed: %v", err),
+			if err := b.checkRepositoryConnectivity(ctx, repo); err != nil {
+				klog.Warningf("Repository connectivity check failed for %s: %v", repo.Name, err)
+				condition := v1.Condition{
+					Type:               configapi.RepositoryReady,
+					Status:             v1.ConditionFalse,
+					ObservedGeneration: repo.Generation,
+					LastTransitionTime: v1.Now(),
+					Reason:             configapi.ReasonError,
+					Message:            fmt.Sprintf("Repository connectivity check failed: %v", err),
+				}
+				if err := b.updateRepositoryStatusCondition(ctx, repo, condition); err != nil {
+					klog.Errorf("Failed to update repository status for %s: %v", repo.Name, err)
+				}
+				return
 			}
-			if err := b.updateRepositoryStatusCondition(ctx, repo, condition); err != nil {
-				klog.Errorf("Failed to update repository status for %s: %v", repo.Name, err)
-			}
-			continue // Skip cacheRepository if connectivity fails
-		}
 
-		if err := b.cacheRepository(ctx, repo); err != nil {
-			klog.Errorf("Failed to cache repository: %v", err)
-		}
+			if err := b.cacheRepository(ctx, repo); err != nil {
+				klog.Errorf("Failed to cache repository: %v", err)
+			}
+		}()
 	}
 
 	return nil

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -78,9 +78,6 @@ func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache
 	}
 
 	// Initialize Git server semaphore with configured MaxConcurrentLists
-	if b.MaxConcurrentLists == 0 {
-		b.MaxConcurrentLists = 20 // Default value
-	}
 	b.workerSemaphore = semaphore.NewWeighted(int64(b.MaxConcurrentLists))
 
 	go b.run(ctx)
@@ -248,29 +245,16 @@ func (b *background) processRepositoryEvent(ctx context.Context, event watch.Eve
 	// Create unique key for the repository
 	repoKey := fmt.Sprintf("%s/%s", repository.Namespace, repository.Name)
 
-	errCh := make(chan error, 1)
 	go func() {
-		defer close(errCh)
 		// Get per-repository mutex to ensure event ordering
 		mutex := b.getRepositoryMutex(repoKey)
 		mutex.Lock()
 		defer mutex.Unlock()
 		if err := b.handleRepositoryEvent(ctx, repository, event); err != nil {
-			errCh <- err
+			klog.Warningf("Processing error for %s:%s: %v", repository.Namespace, repository.Name, err)
 		}
 	}()
 
-	// Handle errors from goroutine asynchronously
-	go func() {
-		select {
-		case err := <-errCh:
-			if err != nil && ctx.Err() == nil {
-				klog.Warningf("Processing error for %s:%s: %v", repository.Namespace, repository.Name, err)
-			}
-		case <-ctx.Done():
-			return
-		}
-	}()
 }
 
 func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.Repository, eventType watch.EventType) error {
@@ -302,10 +286,10 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 	var err error
 	switch eventType {
 	case watch.Deleted:
-		err = b.cache.CloseRepository(ctx, repo, repoList.Items)
+		err = b.cache.CloseRepository(listCtx, repo, repoList.Items)
 	default:
 		// Check connectivity before caching
-		if err = b.checkRepositoryConnectivity(ctx, repo); err != nil {
+		if err = b.checkRepositoryConnectivity(listCtx, repo); err != nil {
 			klog.Warningf("Repository connectivity check failed for %s: %v", repo.Name, err)
 			condition := v1.Condition{
 				Type:               configapi.RepositoryReady,
@@ -315,9 +299,9 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 				Reason:             configapi.ReasonError,
 				Message:            fmt.Sprintf("Repository connectivity check failed: %v", err),
 			}
-			return b.updateRepositoryStatusCondition(ctx, repo, condition)
+			return b.updateRepositoryStatusCondition(listCtx, repo, condition)
 		}
-		err = b.cacheRepository(ctx, repo)
+		err = b.cacheRepository(listCtx, repo)
 	}
 	if err == nil {
 		klog.Infof("%s, handling completed in %s", msgPreamble, time.Since(start))

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -17,11 +17,13 @@ package porch
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/util"
+	"golang.org/x/sync/semaphore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +55,12 @@ func WithListTimeoutPerRepo(timeout time.Duration) BackgroundOption {
 	})
 }
 
+func WithMaxConcurrentLists(maxList int) BackgroundOption {
+	return backgroundOptionFunc(func(b *background) {
+		b.MaxConcurrentLists = maxList
+	})
+}
+
 func WithRepoOperationRetryAttempts(count int) BackgroundOption {
 	return backgroundOptionFunc(func(b *background) {
 		b.repoOperationRetryAttempts = count
@@ -69,6 +77,12 @@ func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cache
 		o.apply(b)
 	}
 
+	// Initialize Git server semaphore with configured MaxConcurrentLists
+	if b.MaxConcurrentLists == 0 {
+		b.MaxConcurrentLists = 20 // Default value
+	}
+	b.workerSemaphore = semaphore.NewWeighted(int64(b.MaxConcurrentLists))
+
 	go b.run(ctx)
 }
 
@@ -79,6 +93,9 @@ type background struct {
 	periodicRepoSyncFrequency  time.Duration
 	listTimeoutPerRepo         time.Duration
 	repoOperationRetryAttempts int
+	MaxConcurrentLists         int
+	repoMutexes                sync.Map            // Per-repository mutexes for event ordering
+	workerSemaphore            *semaphore.Weighted // Rate limit Git server operations
 }
 
 const (
@@ -213,17 +230,59 @@ func (b *background) handleWatchEvent(ctx context.Context, event watch.Event, bo
 func (b *background) updateCache(ctx context.Context, event watch.EventType, repository *configapi.Repository) error {
 	switch event {
 	case watch.Added, watch.Modified, watch.Deleted:
-		return b.handleRepositoryEvent(ctx, repository, event)
+		// Process directly without channel bottleneck
+		b.processRepositoryEvent(ctx, event, repository)
+		return nil // Return immediately since processing is async
 	default:
 		klog.Warningf("Unhandled watch event type: %s", event)
 	}
 	return nil
 }
 
+func (b *background) getRepositoryMutex(repoKey string) *sync.Mutex {
+	mutex, _ := b.repoMutexes.LoadOrStore(repoKey, &sync.Mutex{})
+	return mutex.(*sync.Mutex)
+}
+
+func (b *background) processRepositoryEvent(ctx context.Context, event watch.EventType, repository *configapi.Repository) {
+	// Create unique key for the repository
+	repoKey := fmt.Sprintf("%s/%s", repository.Namespace, repository.Name)
+
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		// Get per-repository mutex to ensure event ordering
+		mutex := b.getRepositoryMutex(repoKey)
+		mutex.Lock()
+		defer mutex.Unlock()
+		if err := b.handleRepositoryEvent(ctx, repository, event); err != nil {
+			errCh <- err
+		}
+	}()
+
+	// Handle errors from goroutine asynchronously
+	go func() {
+		select {
+		case err := <-errCh:
+			if err != nil && ctx.Err() == nil {
+				klog.Warningf("Processing error for %s:%s: %v", repository.Namespace, repository.Name, err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}()
+}
+
 func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.Repository, eventType watch.EventType) error {
 	msgPreamble := fmt.Sprintf("repository %s event handling: repo %s:%s", eventType, repo.Namespace, repo.Name)
 	start := time.Now()
 	klog.Infof("%s, handling starting", msgPreamble)
+
+	// Rate limit the goroutine processing
+	if err := b.workerSemaphore.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("failed to acquire Git server semaphore: %w", err)
+	}
+	defer b.workerSemaphore.Release(1)
 
 	if err := util.ValidateRepository(repo.Name, repo.Spec.Git.Directory); err != nil {
 		return fmt.Errorf("%s, handling failed, repo specification invalid :%q", msgPreamble, err)
@@ -240,14 +299,13 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 	if err := b.coreClient.List(listCtx, &repoList); err != nil {
 		return fmt.Errorf("%s, handling failed, could not list repos using core client :%q", msgPreamble, err)
 	}
-
 	var err error
 	switch eventType {
 	case watch.Deleted:
-		err = b.cache.CloseRepository(listCtx, repo, repoList.Items)
+		err = b.cache.CloseRepository(ctx, repo, repoList.Items)
 	default:
 		// Check connectivity before caching
-		if err = b.checkRepositoryConnectivity(listCtx, repo); err != nil {
+		if err = b.checkRepositoryConnectivity(ctx, repo); err != nil {
 			klog.Warningf("Repository connectivity check failed for %s: %v", repo.Name, err)
 			condition := v1.Condition{
 				Type:               configapi.RepositoryReady,
@@ -257,9 +315,9 @@ func (b *background) handleRepositoryEvent(ctx context.Context, repo *configapi.
 				Reason:             configapi.ReasonError,
 				Message:            fmt.Sprintf("Repository connectivity check failed: %v", err),
 			}
-			return b.updateRepositoryStatusCondition(listCtx, repo, condition)
+			return b.updateRepositoryStatusCondition(ctx, repo, condition)
 		}
-		err = b.cacheRepository(listCtx, repo)
+		err = b.cacheRepository(ctx, repo)
 	}
 	if err == nil {
 		klog.Infof("%s, handling completed in %s", msgPreamble, time.Since(start))

--- a/pkg/registry/porch/background.go
+++ b/pkg/registry/porch/background.go
@@ -69,8 +69,9 @@ func WithRepoOperationRetryAttempts(count int) BackgroundOption {
 
 func RunBackground(ctx context.Context, coreClient client.WithWatch, cache cachetypes.Cache, options ...BackgroundOption) {
 	b := &background{
-		coreClient: coreClient,
-		cache:      cache,
+		coreClient:  coreClient,
+		cache:       cache,
+		repoMutexes: make(map[string]*sync.Mutex),
 	}
 
 	for _, o := range options {
@@ -91,7 +92,8 @@ type background struct {
 	listTimeoutPerRepo         time.Duration
 	repoOperationRetryAttempts int
 	MaxConcurrentLists         int
-	repoMutexes                sync.Map            // Per-repository mutexes for event ordering
+	repoMutexes                map[string]*sync.Mutex // Per-repository mutexes for event ordering
+	repoMutexesLock            sync.RWMutex           // Protects repoMutexes map
 	workerSemaphore            *semaphore.Weighted // Rate limit Git server operations
 }
 
@@ -237,8 +239,20 @@ func (b *background) updateCache(ctx context.Context, event watch.EventType, rep
 }
 
 func (b *background) getRepositoryMutex(repoKey string) *sync.Mutex {
-	mutex, _ := b.repoMutexes.LoadOrStore(repoKey, &sync.Mutex{})
-	return mutex.(*sync.Mutex)
+	b.repoMutexesLock.RLock()
+	mutex, exists := b.repoMutexes[repoKey]
+	b.repoMutexesLock.RUnlock()
+	
+	if !exists {
+		b.repoMutexesLock.Lock()
+		// Double-check after acquiring write lock
+		if mutex, exists = b.repoMutexes[repoKey]; !exists {
+			mutex = &sync.Mutex{}
+			b.repoMutexes[repoKey] = mutex
+		}
+		b.repoMutexesLock.Unlock()
+	}
+	return mutex
 }
 
 func (b *background) processRepositoryEvent(ctx context.Context, event watch.EventType, repository *configapi.Repository) {
@@ -249,7 +263,15 @@ func (b *background) processRepositoryEvent(ctx context.Context, event watch.Eve
 		// Get per-repository mutex to ensure event ordering
 		mutex := b.getRepositoryMutex(repoKey)
 		mutex.Lock()
-		defer mutex.Unlock()
+		defer func() {
+			mutex.Unlock()
+			// Clean up mutex for deleted repositories
+			if event == watch.Deleted {
+				b.repoMutexesLock.Lock()
+				delete(b.repoMutexes, repoKey)
+				b.repoMutexesLock.Unlock()
+			}
+		}()
 		if err := b.handleRepositoryEvent(ctx, repository, event); err != nil {
 			klog.Warningf("Processing error for %s:%s: %v", repository.Namespace, repository.Name, err)
 		}

--- a/pkg/registry/porch/background_test.go
+++ b/pkg/registry/porch/background_test.go
@@ -49,16 +49,23 @@ func TestBackgroundOptions(t *testing.T) {
 			expected: &background{repoOperationRetryAttempts: 5},
 		},
 		{
+			name:     "With max concurrent lists",
+			options:  []BackgroundOption{WithMaxConcurrentLists(5)},
+			expected: &background{MaxConcurrentLists: 5},
+		},
+		{
 			name: "With multiple options",
 			options: []BackgroundOption{
 				WithPeriodicRepoSyncFrequency(5 * time.Second),
 				WithListTimeoutPerRepo(10 * time.Second),
 				WithRepoOperationRetryAttempts(3),
+				WithMaxConcurrentLists(20),
 			},
 			expected: &background{
 				periodicRepoSyncFrequency:  5 * time.Second,
 				listTimeoutPerRepo:         10 * time.Second,
 				repoOperationRetryAttempts: 3,
+				MaxConcurrentLists:         20,
 			},
 		},
 	}
@@ -295,7 +302,9 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			mockCache := &mockcache.MockCache{}
 
 			// Add mocks for repository events to verify they get processed
-			if tt.name == "Repository ADDED event" || tt.name == "Repository MODIFIED event" {
+			// Add mocks for repository events to verify they get processed
+			switch tt.name {
+			case "Repository ADDED event", "Repository MODIFIED event":
 				// ADDED and MODIFIED events go through the same path (connectivity check + cache)
 				mockClient.On("List", mock.Anything, mock.Anything).Return(nil)
 				mockCache.On("CheckRepositoryConnectivity", mock.Anything, mock.Anything).Return(nil)
@@ -304,7 +313,7 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 				mockResourceWriter := &mockclient.MockSubResourceWriter{}
 				mockResourceWriter.On("Update", mock.Anything, mock.Anything).Return(nil)
 				mockClient.On("Status").Return(mockResourceWriter)
-			} else if tt.name == "Repository DELETED event" {
+			case "Repository DELETED event":
 				// DELETED events go through a different path (close repository)
 				mockClient.On("List", mock.Anything, mock.Anything).Return(nil)
 				mockCache.On("CloseRepository", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -331,11 +340,12 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			b.handleWatchEvent(context.Background(), tt.event, &bookmark, &consecutiveFailures, reconnect)
 
 			// For repository events, wait for goroutine to complete and verify cache was called
-			if tt.name == "Repository ADDED event" || tt.name == "Repository MODIFIED event" {
+			switch tt.name {
+			case "Repository ADDED event", "Repository MODIFIED event":
 				time.Sleep(200 * time.Millisecond) // Give goroutines time to complete
 				mockCache.AssertCalled(t, "CheckRepositoryConnectivity", mock.Anything, mock.Anything)
 				mockCache.AssertCalled(t, "OpenRepository", mock.Anything, mock.Anything)
-			} else if tt.name == "Repository DELETED event" {
+			case "Repository DELETED event":
 				time.Sleep(200 * time.Millisecond) // Give goroutines time to complete
 				mockCache.AssertCalled(t, "CloseRepository", mock.Anything, mock.Anything, mock.Anything)
 			}

--- a/pkg/registry/porch/background_test.go
+++ b/pkg/registry/porch/background_test.go
@@ -13,6 +13,7 @@ import (
 	mockrepo "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/sync/semaphore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,22 +31,22 @@ func TestBackgroundOptions(t *testing.T) {
 	tests := []struct {
 		name     string
 		options  []BackgroundOption
-		expected background
+		expected *background
 	}{
 		{
 			name:     "With periodic repo sync frequency",
 			options:  []BackgroundOption{WithPeriodicRepoSyncFrequency(5 * time.Second)},
-			expected: background{periodicRepoSyncFrequency: 5 * time.Second},
+			expected: &background{periodicRepoSyncFrequency: 5 * time.Second},
 		},
 		{
 			name:     "With list timeout per repo",
 			options:  []BackgroundOption{WithListTimeoutPerRepo(10 * time.Second)},
-			expected: background{listTimeoutPerRepo: 10 * time.Second},
+			expected: &background{listTimeoutPerRepo: 10 * time.Second},
 		},
 		{
 			name:     "With repo operation retry attempts",
 			options:  []BackgroundOption{WithRepoOperationRetryAttempts(5)},
-			expected: background{repoOperationRetryAttempts: 5},
+			expected: &background{repoOperationRetryAttempts: 5},
 		},
 		{
 			name: "With multiple options",
@@ -54,7 +55,7 @@ func TestBackgroundOptions(t *testing.T) {
 				WithListTimeoutPerRepo(10 * time.Second),
 				WithRepoOperationRetryAttempts(3),
 			},
-			expected: background{
+			expected: &background{
 				periodicRepoSyncFrequency:  5 * time.Second,
 				listTimeoutPerRepo:         10 * time.Second,
 				repoOperationRetryAttempts: 3,
@@ -64,7 +65,9 @@ func TestBackgroundOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &background{}
+			b := &background{
+				workerSemaphore: semaphore.NewWeighted(20),
+			}
 			for _, o := range tt.options {
 				o.apply(b)
 			}
@@ -80,24 +83,38 @@ func TestBackgroundUpdateCache(t *testing.T) {
 	mockCache := &mockcache.MockCache{}
 
 	b := &background{
-		coreClient: mockClient,
-		cache:      mockCache,
+		coreClient:      mockClient,
+		workerSemaphore: semaphore.NewWeighted(20),
+		cache:           mockCache,
 	}
 
+	// Test invalid repository - should not call OpenRepository
 	event := watch.Added
 	repository := createRepo(1, 1, false)
 	repository.Spec.Git.Directory = "invalid//directory"
 
+	// Expect no calls to cache methods since validation should fail
+	mockCache.AssertNotCalled(t, "OpenRepository")
+	mockCache.AssertNotCalled(t, "CheckRepositoryConnectivity")
+
 	err := b.updateCache(context.Background(), event, repository)
+	assert.Nil(t, err) // updateCache returns nil immediately since processing is async
 
-	if err != nil {
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), fmt.Errorf("handling failed, repo specification invalid").Error())
-	}
+	// Give goroutine time to complete and fail validation
+	time.Sleep(100 * time.Millisecond)
 
+	// Verify cache methods were never called
+	mockCache.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
+
+	// Test bookmark event
 	event = watch.Bookmark
 	err = b.updateCache(context.Background(), event, repository)
 	assert.Nil(t, err)
+
+	// Verify cache methods expectations for bookmark event
+	mockCache.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
 }
 
 func TestBackgroundHandleWatchEvent(t *testing.T) {
@@ -187,6 +204,78 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			expectedReconnectReset:      true, // reconnect.reset() called because it's an error event
 		},
 		{
+			name: "Repository ADDED event",
+			event: watch.Event{
+				Type: watch.Added,
+				Object: &configapi.Repository{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: configapi.RepositorySpec{
+						Git: &configapi.GitRepository{
+							Repo:      "https://example.com/repo.git",
+							Branch:    "main",
+							Directory: "/valid/path",
+						},
+					},
+				},
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  2,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 0, // Reset to 0 for repository events
+			expectedReconnectReset:      false,
+		},
+		{
+			name: "Repository MODIFIED event",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: &configapi.Repository{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: configapi.RepositorySpec{
+						Git: &configapi.GitRepository{
+							Repo:      "https://example.com/repo.git",
+							Branch:    "main",
+							Directory: "/valid/path",
+						},
+					},
+				},
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  1,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 0, // Reset to 0 for repository events
+			expectedReconnectReset:      false,
+		},
+		{
+			name: "Repository DELETED event",
+			event: watch.Event{
+				Type: watch.Deleted,
+				Object: &configapi.Repository{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: configapi.RepositorySpec{
+						Git: &configapi.GitRepository{
+							Repo:      "https://example.com/repo.git",
+							Branch:    "main",
+							Directory: "/valid/path",
+						},
+					},
+				},
+			},
+			initialBookmark:             "bookmark",
+			initialConsecutiveFailures:  3,
+			expectedBookmark:            "bookmark",
+			expectedConsecutiveFailures: 0, // Reset to 0 for repository events
+			expectedReconnectReset:      false,
+		},
+		{
 			name: "Unexpected event object type",
 			event: watch.Event{
 				Type:   watch.Added,
@@ -205,8 +294,25 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			mockClient := &mockclient.MockWithWatch{}
 			mockCache := &mockcache.MockCache{}
 
+			// Add mocks for repository events to verify they get processed
+			if tt.name == "Repository ADDED event" || tt.name == "Repository MODIFIED event" {
+				// ADDED and MODIFIED events go through the same path (connectivity check + cache)
+				mockClient.On("List", mock.Anything, mock.Anything).Return(nil)
+				mockCache.On("CheckRepositoryConnectivity", mock.Anything, mock.Anything).Return(nil)
+				mockCache.On("OpenRepository", mock.Anything, mock.Anything).Return(nil, nil)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockResourceWriter := &mockclient.MockSubResourceWriter{}
+				mockResourceWriter.On("Update", mock.Anything, mock.Anything).Return(nil)
+				mockClient.On("Status").Return(mockResourceWriter)
+			} else if tt.name == "Repository DELETED event" {
+				// DELETED events go through a different path (close repository)
+				mockClient.On("List", mock.Anything, mock.Anything).Return(nil)
+				mockCache.On("CloseRepository", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			}
+
 			b := &background{
 				coreClient:                 mockClient,
+				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
 			}
@@ -224,6 +330,16 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			// Call the function under test
 			b.handleWatchEvent(context.Background(), tt.event, &bookmark, &consecutiveFailures, reconnect)
 
+			// For repository events, wait for goroutine to complete and verify cache was called
+			if tt.name == "Repository ADDED event" || tt.name == "Repository MODIFIED event" {
+				time.Sleep(200 * time.Millisecond) // Give goroutines time to complete
+				mockCache.AssertCalled(t, "CheckRepositoryConnectivity", mock.Anything, mock.Anything)
+				mockCache.AssertCalled(t, "OpenRepository", mock.Anything, mock.Anything)
+			} else if tt.name == "Repository DELETED event" {
+				time.Sleep(200 * time.Millisecond) // Give goroutines time to complete
+				mockCache.AssertCalled(t, "CloseRepository", mock.Anything, mock.Anything, mock.Anything)
+			}
+
 			// Verify results
 			assert.Equal(t, tt.expectedBookmark, bookmark)
 			assert.Equal(t, tt.expectedConsecutiveFailures, consecutiveFailures)
@@ -231,6 +347,10 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 			if tt.expectedReconnectReset {
 				assert.Equal(t, initialCurr, reconnect.curr, "Expected reconnect timer to be reset")
 			}
+
+			// Verify cache methods expectations
+			mockCache.AssertExpectations(t)
+			mockClient.AssertExpectations(t)
 		})
 	}
 }
@@ -359,6 +479,7 @@ func TestBackgroundHandleRepositoryEvent(t *testing.T) {
 
 			b := &background{
 				coreClient:                 mockClient,
+				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				listTimeoutPerRepo:         1 * time.Second,
 				repoOperationRetryAttempts: 3,
@@ -500,6 +621,7 @@ func TestBackgroundRunOnce(t *testing.T) {
 
 			b := &background{
 				coreClient:                 mockClient,
+				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
 			}
@@ -712,6 +834,7 @@ func TestBackgroundCacheRepository(t *testing.T) {
 
 			b := &background{
 				coreClient:                 mockClient,
+				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
 			}

--- a/pkg/registry/porch/background_test.go
+++ b/pkg/registry/porch/background_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -74,6 +75,7 @@ func TestBackgroundOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &background{
 				workerSemaphore: semaphore.NewWeighted(20),
+				repoMutexes:     make(map[string]*sync.Mutex),
 			}
 			for _, o := range tt.options {
 				o.apply(b)
@@ -93,6 +95,7 @@ func TestBackgroundUpdateCache(t *testing.T) {
 		coreClient:      mockClient,
 		workerSemaphore: semaphore.NewWeighted(20),
 		cache:           mockCache,
+		repoMutexes:     make(map[string]*sync.Mutex),
 	}
 
 	// Test invalid repository - should not call OpenRepository
@@ -324,6 +327,7 @@ func TestBackgroundHandleWatchEvent(t *testing.T) {
 				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
+				repoMutexes:                make(map[string]*sync.Mutex),
 			}
 
 			// Initialize test variables
@@ -493,6 +497,7 @@ func TestBackgroundHandleRepositoryEvent(t *testing.T) {
 				cache:                      mockCache,
 				listTimeoutPerRepo:         1 * time.Second,
 				repoOperationRetryAttempts: 3,
+				repoMutexes:                make(map[string]*sync.Mutex),
 			}
 
 			var repository *configapi.Repository
@@ -634,6 +639,7 @@ func TestBackgroundRunOnce(t *testing.T) {
 				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
+				repoMutexes:                make(map[string]*sync.Mutex),
 			}
 
 			tt.setupMocks(mockClient, mockResourceWriter, mockCache, mockRepo)
@@ -847,6 +853,7 @@ func TestBackgroundCacheRepository(t *testing.T) {
 				workerSemaphore:            semaphore.NewWeighted(20),
 				cache:                      mockCache,
 				repoOperationRetryAttempts: 3,
+				repoMutexes:                make(map[string]*sync.Mutex),
 			}
 
 			repository := tt.setupRepo()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
 background.go based repository sync should allow for synchronising multiple repositories at once.

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  
Stop sync go routines when the repo doesn't exist
Repository events now spawn individual goroutines with per-repository mutexes for ordering, allowing multiple repositories to be processed simultaneously
Added workerSemaphore with configurable MaxConcurrentLists (default 20) to control parallel repository processing

- Why it’s needed:  
Performance: Sequential processing of 1000+ repositories creates significant bottlenecks during startup and periodic syncs
Scalability: Large deployments with many repositories need concurrent processing to maintain reasonable sync times

- How it works:  
processRepositoryEvent() spawns goroutines for each repository event, using repoMutexes.LoadOrStore() to ensure per-repository event ordering
workerSemaphore.Acquire() in handleRepositoryEvent() limits concurrent repository operations to prevent resource exhaustion

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  https://github.com/nephio-project/porch/issues/799

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
- Amazon Q was used
