### PR TITLE
chore: Pin image versions and permissions in Github Actions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Nephio Authors
+# Copyright 2024-2026 The Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -43,7 +43,7 @@ jobs:
     if: needs.check-changes.outputs.code == 'true'
     steps:
       - name: Checkout Porch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go
         uses: ./.github/actions/setup-go-kpt
         with:

--- a/.github/workflows/gosec-scan.yaml
+++ b/.github/workflows/gosec-scan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Nephio Authors
+# Copyright 2024-2026 The Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@ name: Gosec security scan
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   check-changes:
@@ -24,8 +29,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -45,7 +50,7 @@ jobs:
       GOTOOLCHAIN: auto
     steps:
       - name: Checkout Porch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go
         uses: ./.github/actions/setup-go-kpt
         with:
@@ -57,7 +62,7 @@ jobs:
           GOTOOLCHAIN: auto
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: gosec-results.sarif
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/openssf_scorecard.yaml
+++ b/.github/workflows/openssf_scorecard.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: OpenSSF Scorecard
 
 # Declare default permissions as read only.
@@ -23,23 +37,23 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3.28.9
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           sarif_file: results.sarif
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -26,6 +26,9 @@ concurrency:
 env:
   KIND_CONTEXT_NAME: porch-test
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   # 1. Resolve the last 4 published releases and build the server matrix
@@ -78,14 +81,14 @@ jobs:
 
       - name: Checkout upstream latest (1.5 branch)
         if: matrix.server_version == 'latest'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: nephio-project/porch
           ref: '1.5' # NOTE this should revert back to main when we merge back
 
       - name: Checkout upstream tag ${{ matrix.server_version }}
         if: matrix.server_version != 'latest'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: nephio-project/porch
           ref: ${{ matrix.server_version }}
@@ -93,7 +96,7 @@ jobs:
       # --- Step 2: Setup tooling ---
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -116,7 +119,7 @@ jobs:
       # --- Install's Kind without deploying a cluster ---
 
       - name: Install Kind
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           version: v0.30.0
           install_only: true
@@ -221,7 +224,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "compat-results-${{ matrix.server_version }}"
           path: .build/compat-results/
@@ -236,7 +239,7 @@ jobs:
           fi
       - name: Archive server logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "server-log-${{ matrix.server_version }}"
           path: server.log
@@ -254,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: compat-results-*
           path: results/

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -29,14 +29,17 @@ env:
   PORCH_SERVER_IMAGE: porch-server
   PORCH_CONTROLLERS_IMAGE: porch-controllers
 
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -56,7 +59,7 @@ jobs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     steps:
       - name: Checkout Porch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go
         uses: ./.github/actions/setup-go-kpt
         with:
@@ -101,7 +104,7 @@ jobs:
             ${IMAGE_REPO}/${PORCH_WRAPPER_SERVER_IMAGE}:${IMAGE_TAG} \
             | gzip > porch-images.tar.gz
       - name: Upload images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: porch-images
           path: porch-images.tar.gz
@@ -143,13 +146,13 @@ jobs:
 
     steps:
       - name: Checkout Porch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go and kpt
         uses: ./.github/actions/setup-go-kpt
         with:
           go-cache: "true"
       - name: Install Kind
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           version: v0.30.0
           install_only: true
@@ -160,7 +163,7 @@ jobs:
       - name: Setup dev env
         run: ${GITHUB_WORKSPACE}/scripts/setup-dev-env.sh
       - name: Download image artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: porch-images
       - name: Load images to kind
@@ -188,7 +191,7 @@ jobs:
           fi
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4  
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.log_prefix }}-logs
           path: "*.log"

--- a/.github/workflows/porchctl-dev-release.yaml
+++ b/.github/workflows/porchctl-dev-release.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Nephio Authors
+# Copyright 2024-2026 The Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -31,7 +34,7 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Set up Go
@@ -43,7 +46,7 @@ jobs:
       - name: Pack binary
         run: tar cvzf porchctl.tgz -C .build/ porchctl
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: porchctl.tgz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           
@@ -43,7 +46,7 @@ jobs:
 
       - name: Run GoReleaser
         id: run-goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/sonar-ci-artifacts.yaml
+++ b/.github/workflows/sonar-ci-artifacts.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI test report
 on:
   push:
@@ -6,14 +20,17 @@ on:
   pull_request:
       types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -27,7 +44,7 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         # Disabling shallow clones is recommended for improving the relevancy of reporting
         fetch-depth: 0
@@ -43,7 +60,7 @@ jobs:
 
     - name: Archive test results
       if: steps.test.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: coverage-report
         path: ./coverage.out
@@ -54,7 +71,7 @@ jobs:
       
     - name: Archive PR number
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: PR_NUMBER
         path: PR_NUMBER.txt

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,9 +1,28 @@
+# Copyright 2026 The Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: SonarCloud analysis
 
 on: 
   workflow_run:
     workflows: [CI test report]
     types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
 
 jobs:
   check-artifacts:
@@ -14,7 +33,7 @@ jobs:
     steps:
       - name: Check for coverage artifact
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -37,7 +56,7 @@ jobs:
 
     - name: Download PR number artifact
       if: github.event.workflow_run.event == 'pull_request'
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
       with:
         workflow: CI test report
         run_id: ${{ github.event.workflow_run.id }}
@@ -46,13 +65,13 @@ jobs:
     - name: Read PR_NUMBER.txt
       if: github.event.workflow_run.event == 'pull_request'
       id: pr_number
-      uses: juliangruber/read-file-action@v1.1.7
+      uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1.1.7
       with:
         path: ./PR_NUMBER.txt
 
     - name: Request GitHub API for PR data
       if: github.event.workflow_run.event == 'pull_request'
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@02f5e7c637a73a3b12ed81015fa7fb5f11cc5d7d # v2.x
       id: get_pr_data
       with:
         route: GET /repos/{full_name}/pulls/{number}
@@ -62,10 +81,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
     - name: Checkout base branch
@@ -74,11 +93,11 @@ jobs:
         git remote add upstream ${{ github.event.repository.clone_url }}
         git fetch upstream
         git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-        git checkout ${{ github.event.workflow_run.head_branch }}
+        git checkout ${{ github.event.workflow_run.head_sha }}
         git clean -ffdx && git reset --hard HEAD
 
     - name: Download coverage artifact
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
       with:
         workflow: CI test report
         run_id: ${{ github.event.workflow_run.id }}
@@ -91,7 +110,7 @@ jobs:
         
     - name: SonarQube Scan on PR
       if: github.event.workflow_run.event == 'pull_request'
-      uses: SonarSource/sonarqube-scan-action@v7.0.0
+      uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
@@ -105,7 +124,7 @@ jobs:
 
     - name: SonarCloud Scan on push
       if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.event.repository.full_name
-      uses: SonarSource/sonarqube-scan-action@v7.0.0
+      uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:


### PR DESCRIPTION
 ## Description
  - What changed:
    - Pin every third-party action referenced in `.github/workflows/*` to a full 40-char commit SHA with a `# vX.Y.Z` comment.
    - Add top-level `permissions: contents: read` to the 7 workflows that lacked a default.
    - In `sonarcloud.yml`, replace `github.event.workflow_run.head_branch` with `head_sha`.
    - Go security scan enabled for the pushes to `main` branch.

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [x] Other: CI / security hardening

 ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated

## AI Disclosure
  - [x] I have used Kiro CLI to audit workflows, resolve action commit SHAs.