### PR TITLE
Bugfix: Prune empty git subtrees after package deletion in subdirectory repos

### DIFF
--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -36,6 +36,9 @@ const (
 	porchSignatureEmail = "porch@kpt.dev"
 )
 
+// emptyGitTreeHash is the well-known git hash for an empty tree object.
+var emptyGitTreeHash = plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+
 type commitHelper struct {
 	repository *git.Repository
 
@@ -337,33 +340,34 @@ func (h *commitHelper) storeBlobHashInTrees(fullPath string, hash plumbing.Hash)
 }
 
 // storeTrees writes the tree at treePath to git, first writing all child trees.
+// Empty subtrees are pruned so that deleting a package does not leave behind empty ancestor directories
 func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 	tree, ok := h.trees[treePath]
 	if !ok {
 		return plumbing.Hash{}, fmt.Errorf("failed to find a tree %q", treePath)
 	}
-
 	entries := tree.Entries
 	sort.Slice(entries, func(i, j int) bool {
 		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
 	})
 
-	// Store all child trees and get their hashes
+	// Store all child trees, pruning any that resolve to empty
+	pruned := entries[:0]
 	for i := range entries {
 		e := &entries[i]
-		if e.Mode != filemode.Dir {
-			continue
+		if e.Mode == filemode.Dir && e.Hash.IsZero() {
+			hash, err := h.storeTrees(path.Join(treePath, e.Name))
+			if err != nil {
+				return plumbing.Hash{}, err
+			}
+			if hash == emptyGitTreeHash {
+				continue
+			}
+			e.Hash = hash
 		}
-		if !e.Hash.IsZero() {
-			continue
-		}
-
-		hash, err := h.storeTrees(path.Join(treePath, e.Name))
-		if err != nil {
-			return plumbing.Hash{}, err
-		}
-		e.Hash = hash
+		pruned = append(pruned, *e)
 	}
+	tree.Entries = pruned
 
 	treeHash, err := storeTree(h.repository, tree)
 	if err != nil {

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -36,9 +36,6 @@ const (
 	porchSignatureEmail = "porch@kpt.dev"
 )
 
-// emptyGitTreeHash is the well-known git hash for an empty tree object.
-var emptyGitTreeHash = plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
-
 type commitHelper struct {
 	repository *git.Repository
 

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -382,7 +382,6 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 
 		e.Hash = hash
 	}
-	tree.Entries = pruned
 
 	treeHash, err := storeTree(h.repository, tree)
 	if err != nil {

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -36,6 +36,9 @@ const (
 	porchSignatureEmail = "porch@kpt.dev"
 )
 
+// emptyGitTreeHash is the well-known git hash for an empty tree object.
+var emptyGitTreeHash = plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+
 type commitHelper struct {
 	repository *git.Repository
 
@@ -349,33 +352,23 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
 	})
 
-	// Store all child trees and get their hashes.
-	// Remove empty child directories to avoid leaving behind empty subdirectories
-	for i := 0; i < len(entries); i++ {
+	// Store all child trees, pruning any that resolve to empty
+	remaining := entries[:0]
+	for i := range entries {
 		e := &entries[i]
-		if e.Mode != filemode.Dir {
-			continue
+		if e.Mode == filemode.Dir && e.Hash.IsZero() {
+			hash, err := h.storeTrees(path.Join(treePath, e.Name))
+			if err != nil {
+				return plumbing.Hash{}, err
+			}
+			if hash == emptyGitTreeHash {
+				continue
+			}
+			e.Hash = hash
 		}
-		if !e.Hash.IsZero() {
-			continue
-		}
-
-		childPath := path.Join(treePath, e.Name)
-		childTree := h.trees[childPath]
-		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
-			continue
-		}
-		hash, err := h.storeTrees(childPath)
-		if err != nil {
-			return plumbing.Hash{}, err
-		}
-		// After recursion, the child may have become empty if all its
-		// children were pruned. Check again and remove if so.
-		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
-			continue
-		}
-		e.Hash = hash
+		remaining = append(remaining, *e)
 	}
+	tree.Entries = remaining
 
 	treeHash, err := storeTree(h.repository, tree)
 	if err != nil {
@@ -392,19 +385,6 @@ func entrySortKey(e *object.TreeEntry) string {
 		return e.Name + "/"
 	}
 	return e.Name
-}
-
-// pruneEmptyChild removes a child directory from the parent tree if it has no entries.
-// Returns true if the child was pruned.
-func (h *commitHelper) pruneEmptyChild(parent *object.Tree, child *object.Tree, childPath string, entries *[]object.TreeEntry, i *int) bool {
-	if child == nil || len(child.Entries) != 0 {
-		return false
-	}
-	*entries = append((*entries)[:*i], (*entries)[*i+1:]...)
-	parent.Entries = *entries
-	delete(h.trees, childPath)
-	*i--
-	return true
 }
 
 // storeCommit creates and writes a commit object to git.

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -350,8 +350,7 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 	})
 
 	// Store all child trees and get their hashes.
-	// Remove empty child directories to avoid leaving behind empty
-	// subdirectories when a package is deleted from a repo subdirectory.
+	// Remove empty child directories to avoid leaving behind empty subdirectories
 	for i := 0; i < len(entries); i++ {
 		e := &entries[i]
 		if e.Mode != filemode.Dir {

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -351,21 +351,36 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
 	})
 
-	// Store all child trees, pruning any that resolve to empty
-	pruned := entries[:0]
-	for i := range entries {
+	// Store all child trees and get their hashes.
+	// Remove empty child directories to avoid leaving behind empty
+	// subdirectories when a package is deleted from a repo subdirectory.
+	for i := 0; i < len(entries); i++ {
 		e := &entries[i]
-		if e.Mode == filemode.Dir && e.Hash.IsZero() {
-			hash, err := h.storeTrees(path.Join(treePath, e.Name))
-			if err != nil {
-				return plumbing.Hash{}, err
-			}
-			if hash == emptyGitTreeHash {
-				continue
-			}
-			e.Hash = hash
+		if e.Mode != filemode.Dir {
+			continue
 		}
-		pruned = append(pruned, *e)
+		if !e.Hash.IsZero() {
+			continue
+		}
+
+		childPath := path.Join(treePath, e.Name)
+		childTree := h.trees[childPath]
+		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
+			continue
+		}
+
+		hash, err := h.storeTrees(childPath)
+		if err != nil {
+			return plumbing.Hash{}, err
+		}
+
+		// After recursion, the child may have become empty if all its
+		// children were pruned. Check again and remove if so.
+		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
+			continue
+		}
+
+		e.Hash = hash
 	}
 	tree.Entries = pruned
 
@@ -384,6 +399,19 @@ func entrySortKey(e *object.TreeEntry) string {
 		return e.Name + "/"
 	}
 	return e.Name
+}
+
+// pruneEmptyChild removes a child directory from the parent tree if it has no entries.
+// Returns true if the child was pruned.
+func (h *commitHelper) pruneEmptyChild(parent *object.Tree, child *object.Tree, childPath string, entries *[]object.TreeEntry, i *int) bool {
+	if child == nil || len(child.Entries) != 0 {
+		return false
+	}
+	*entries = append((*entries)[:*i], (*entries)[*i+1:]...)
+	parent.Entries = *entries
+	delete(h.trees, childPath)
+	*i--
+	return true
 }
 
 // storeCommit creates and writes a commit object to git.

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -343,6 +343,7 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 	if !ok {
 		return plumbing.Hash{}, fmt.Errorf("failed to find a tree %q", treePath)
 	}
+
 	entries := tree.Entries
 	sort.Slice(entries, func(i, j int) bool {
 		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
@@ -365,18 +366,15 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
 			continue
 		}
-
 		hash, err := h.storeTrees(childPath)
 		if err != nil {
 			return plumbing.Hash{}, err
 		}
-
 		// After recursion, the child may have become empty if all its
 		// children were pruned. Check again and remove if so.
 		if h.pruneEmptyChild(tree, childTree, childPath, &entries, &i) {
 			continue
 		}
-
 		e.Hash = hash
 	}
 

--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/nephio-project/porch/pkg/repository"
@@ -239,5 +240,97 @@ func TestCommitWithUser(t *testing.T) {
 		if got, want := commit.Message, message; got != want {
 			t.Errorf("Commit.Message: got %q, want %q", got, want)
 		}
+	}
+}
+
+func createPackageCommit(t *testing.T, repo *gogit.Repository, parentHash plumbing.Hash, packagePath string) plumbing.Hash {
+	t.Helper()
+	ch, err := newCommitHelper(repo, nil, parentHash, packagePath, plumbing.ZeroHash)
+	if err != nil {
+		t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
+	}
+	if err := ch.storeFile(path.Join(packagePath, "Kptfile"), "apiVersion: kpt.dev/v1"); err != nil {
+		t.Fatalf("storeFile failed: %v", err)
+	}
+	hash, _, err := ch.commit(context.Background(), fmt.Sprintf("Create %s", packagePath), packagePath)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+	return hash
+}
+
+func deletePackageCommit(t *testing.T, repo *gogit.Repository, parentHash plumbing.Hash, packagePath string) plumbing.Hash {
+	t.Helper()
+	ch, err := newCommitHelper(repo, nil, parentHash, packagePath, plumbing.ZeroHash)
+	if err != nil {
+		t.Fatalf("newCommitHelper(%q) for deletion failed: %v", packagePath, err)
+	}
+	hash, _, err := ch.commit(context.Background(), fmt.Sprintf("Delete %s", packagePath), packagePath)
+	if err != nil {
+		t.Fatalf("delete commit failed: %v", err)
+	}
+	return hash
+}
+
+func TestStoreTreesPrunesEmptySubdirectory(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	createHash := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "subdir/testpkg")
+	deleteHash := deletePackageCommit(t, gitRepo, createHash, "subdir/testpkg")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	for _, entry := range root.Entries {
+		if entry.Name == "subdir" {
+			t.Errorf("expected 'subdir' to be pruned from root tree, but it still exists")
+		}
+	}
+}
+
+func TestStoreTreesPrunesNestedEmptySubdirectories(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	createHash := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "level1/level2/testpkg")
+	deleteHash := deletePackageCommit(t, gitRepo, createHash, "level1/level2/testpkg")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	for _, entry := range root.Entries {
+		if entry.Name == "level1" {
+			t.Errorf("expected 'level1' to be pruned from root tree, but it still exists")
+		}
+	}
+}
+
+func TestStoreTreesRetainsNonEmptySubdirectory(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	commitA := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "subdir/pkg-a")
+	commitB := createPackageCommit(t, gitRepo, commitA, "subdir/pkg-b")
+	deleteHash := deletePackageCommit(t, gitRepo, commitB, "subdir/pkg-a")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	subdirEntry := findTreeEntry(t, root, "subdir")
+	if subdirEntry == nil {
+		t.Fatalf("expected 'subdir' to still exist since pkg-b is still there")
+	}
+
+	subdirTree, err := object.GetTree(gitRepo.Storer, subdirEntry.Hash)
+	if err != nil {
+		t.Fatalf("failed to get subdir tree: %v", err)
+	}
+
+	foundPkgB := false
+	for _, entry := range subdirTree.Entries {
+		if entry.Name == "pkg-a" {
+			t.Errorf("expected 'pkg-a' to be deleted but it still exists")
+		}
+		if entry.Name == "pkg-b" {
+			foundPkgB = true
+		}
+	}
+	if !foundPkgB {
+		t.Errorf("expected 'pkg-b' to still exist in subdir")
 	}
 }

--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
-	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/nephio-project/porch/pkg/repository"

--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/nephio-project/porch/pkg/repository"


### PR DESCRIPTION
## Title
Fix: Prune empty git subtrees after package deletion in subdirectory repos

---

## Description
- What changed: Modified `storeTrees` in `pkg/externalrepo/git/commit.go` to skip directory entries that resolve to the empty git tree hash. Added `emptyGitTreeHash` variable. Added 3 unit tests and 2 test helpers in `commit_test.go`.
- Why it's needed: Repos configured with a git subdirectory (e.g. `directory: /test2`) leave behind empty tree objects after all packages are deleted. This produces invalid git state that git itself would never create.
- How it works: During the existing recursive `storeTrees` pass, after storing a child tree, we check if its hash matches the well-known empty tree hash (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`). If so, the entry is skipped (from being added to the pruned slice). at the end of propagation asserting the pruned list as the entires effectively doing a deletion of the empty items from the slice.

### Root Cause
`initializeTrees` correctly removes the package entry from its parent tree on deletion, but `storeTrees` never checked if ancestor directories became empty as a result. The empty directory entry was stored and committed.

---

## Related Issue(s)
- Fixes https://github.com/nephio-project/porch/issues/910

---

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions
Follow testing reproduction instructions in the [issue](https://github.com/nephio-project/porch/issues/910)

As for the unit tests they check the following,
The `TestStoreTreesPrunesEmptySubdirectory` = Single package in subdirectory, delete it -> subdir is pruned
The `TestStoreTreesPrunesNestedEmptySubdirectories` = Package in nested subdirectory, delete it -> entire chain is pruned
The `TestStoreTreesRetainsNonEmptySubdirectory` = Two packages in subdirectory, delete one -> subdir retained with remaining package

---

## Additional Notes
- Only affects repos with a non-root subdirectory. Root directory repos were never affected.
- Existing unit tests all pass unchanged.

---

## AI Disclosure
- [x] I have used AI in the creation of this PR.
1. Amazon Q to help identify root cause found in `storeTrees`
2. Amazon Q to generate unit tests in `commit_test.go` based on likely scenarios
3. Amazon Q to assist with populating the template of the issue + PR
