### PR TITLE
cherrypick #509 - the DB cache should handle it as a single database query

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -81,8 +81,6 @@ type ExtraConfig struct {
 	CoreAPIKubeconfigPath    string
 	GRPCRuntimeOptions       engine.GRPCRuntimeOptions
 	CacheOptions             cachetypes.CacheOptions
-	ListTimeoutPerRepository time.Duration
-	MaxConcurrentLists       int
 }
 
 // Config defines the config for the apiserver
@@ -97,7 +95,7 @@ type PorchServer struct {
 	coreClient                 client.WithWatch
 	cache                      cachetypes.Cache
 	periodicRepoSyncFrequency  time.Duration
-	ListTimeoutPerRepository   time.Duration
+	listTimeoutPerRepository   time.Duration
 	repoOperationRetryAttempts int
 }
 
@@ -311,12 +309,10 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 	}
 
 	restStorageOptions := porch.RESTStorageOptions{
-		Scheme:               Scheme,
-		Codecs:               Codecs,
-		CaD:                  cad,
-		CoreClient:           coreClient,
-		TimeoutPerRepository: c.ExtraConfig.ListTimeoutPerRepository,
-		MaxConcurrentLists:   c.ExtraConfig.MaxConcurrentLists,
+		Scheme:     Scheme,
+		Codecs:     Codecs,
+		CaD:        cad,
+		CoreClient: coreClient,
 	}
 	porchGroup, err := restStorageOptions.NewRESTStorage()
 	if err != nil {
@@ -329,7 +325,7 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 		cache:            cacheImpl,
 		// Set background job periodic frequency the same as repo sync frequency.
 		periodicRepoSyncFrequency:  c.ExtraConfig.CacheOptions.RepoSyncFrequency,
-		ListTimeoutPerRepository:   c.ExtraConfig.ListTimeoutPerRepository,
+		listTimeoutPerRepository:   c.ExtraConfig.CacheOptions.CRCacheOptions.ListTimeoutPerRepository,
 		repoOperationRetryAttempts: c.ExtraConfig.CacheOptions.RepoOperationRetryAttempts,
 	}
 
@@ -344,7 +340,7 @@ func (c completedConfig) New(ctx context.Context) (*PorchServer, error) {
 func (s *PorchServer) Run(ctx context.Context) error {
 	porch.RunBackground(ctx, s.coreClient, s.cache,
 		porch.WithPeriodicRepoSyncFrequency(s.periodicRepoSyncFrequency),
-		porch.WithListTimeoutPerRepo(s.ListTimeoutPerRepository),
+		porch.WithListTimeoutPerRepo(s.listTimeoutPerRepository),
 		porch.WithRepoOperationRetryAttempts(s.repoOperationRetryAttempts),
 	)
 

--- a/pkg/cache/crcache/cache.go
+++ b/pkg/cache/crcache/cache.go
@@ -16,6 +16,7 @@ package crcache
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
@@ -26,7 +27,10 @@ import (
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/fields"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var tracer = otel.Tracer("crcache")
@@ -156,4 +160,113 @@ func (c *Cache) FindAllUpstreamReferencesInRepositories(ctx context.Context, nam
 		return true
 	})
 	return downstreamName, nil
+}
+
+func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+
+	var opts []client.ListOption
+
+	namespace, namespaced := genericapirequest.NamespaceFrom(ctx)
+	if namespaced && namespace != "" {
+		if namespaceMatches, filteredNamespace := filter.MatchesNamespace(namespace); !namespaceMatches {
+			return nil, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filteredNamespace)
+		}
+
+		opts = append(opts, client.InNamespace(namespace))
+	}
+
+	if filterRepo := filter.FilteredRepository(); filterRepo != "" {
+		opts = append(opts, client.MatchingFields(fields.Set{"metadata.name": filterRepo}))
+	}
+
+	var repoList configapi.RepositoryList
+	if err := c.options.CoreClient.List(ctx, &repoList, opts...); err != nil {
+		return nil, fmt.Errorf("error listing repository objects: %w", err)
+	}
+	repos := repoList.Items
+
+	type pkgRevResult struct {
+		Revisions []repository.PackageRevision
+		Err       error
+	}
+
+	repoCount := len(repos)
+	if repoCount == 0 {
+		return []repository.PackageRevision{}, nil
+	}
+
+	workerCount := repoCount
+	if c.options.CRCacheOptions.MaxConcurrentLists > 0 {
+		workerCount = min(c.options.CRCacheOptions.MaxConcurrentLists, repoCount)
+	}
+
+	klog.V(3).Infof("Listing %d repositories with %d workers", repoCount, workerCount)
+
+	resultsCh := make(chan pkgRevResult, workerCount)
+	repoQueue := make(chan *configapi.Repository, repoCount)
+
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			for repo := range repoQueue {
+				klog.V(3).Infof("[WORKER %d] Processing repository %s", i, repo.Name)
+				listCtx := ctx
+				var cancel context.CancelFunc
+				if c.options.CRCacheOptions.ListTimeoutPerRepository != 0 {
+					listCtx, cancel = context.WithTimeout(ctx, c.options.CRCacheOptions.ListTimeoutPerRepository)
+				}
+				cachedRepo, err := c.OpenRepository(ctx, repo)
+				if err != nil {
+					resultsCh <- pkgRevResult{Err: err}
+					continue
+				}
+				revisions, err := cachedRepo.ListPackageRevisions(listCtx, filter)
+				klog.V(3).Infof("[WORKER %d] ListPackageRevisions for %s done, len: %d, err: %v", i, repo.Name, len(revisions), err)
+				resultsCh <- pkgRevResult{Revisions: revisions, Err: err}
+				if cancel != nil {
+					cancel()
+				}
+			}
+		}()
+	}
+
+	for _, repo := range repos {
+		repoQueue <- &repo
+	}
+
+	innerCtx := ctx
+	if deadline, ok := ctx.Deadline(); ok {
+		const buffer = 5 * time.Second
+		if timeout := time.Until(deadline.Add(-buffer)); timeout > 0 {
+			var cancel context.CancelFunc
+			innerCtx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+	}
+
+	received := 0
+	resultPRs := []repository.PackageRevision{}
+
+	for {
+		select {
+		case <-innerCtx.Done():
+			klog.Warningf("Timeout reached — returning partial results")
+			close(repoQueue)
+			return resultPRs, nil
+
+		case res := <-resultsCh:
+			received++
+			klog.V(4).Infof("listPackageRevisions received %d repo", received)
+			if res.Err != nil {
+				klog.Warningf("error listing package revisions: %+v", res.Err)
+			}
+			for _, rev := range res.Revisions {
+				resultPRs = append(resultPRs, rev)
+			}
+
+		}
+		if received == repoCount {
+			close(repoQueue)
+			return resultPRs, nil
+		}
+	}
 }

--- a/pkg/cache/crcache/cache.go
+++ b/pkg/cache/crcache/cache.go
@@ -216,6 +216,9 @@ func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.List
 				}
 				cachedRepo, err := c.OpenRepository(ctx, repo)
 				if err != nil {
+					if cancel != nil {
+						cancel()
+					}
 					resultsCh <- pkgRevResult{Err: err}
 					continue
 				}

--- a/pkg/cache/dbcache/dbcache.go
+++ b/pkg/cache/dbcache/dbcache.go
@@ -155,3 +155,16 @@ func (c *dbCache) CheckRepositoryConnectivity(ctx context.Context, repositorySpe
 func (c *dbCache) FindAllUpstreamReferencesInRepositories(ctx context.Context, namespace, prName string) (string, error) {
 	return findUpstreamRefsFromDB(ctx, namespace, prName)
 }
+
+func (c *dbCache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	dbprs, err := pkgRevListPRsFromDB(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	var prs []repository.PackageRevision
+	prs = make([]repository.PackageRevision, len(dbprs))
+	for i, dbpr := range dbprs {
+		prs[i] = dbpr
+	}
+	return prs, nil
+}

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -43,18 +43,51 @@ var (
 	_ repository.PackageRevisionDraft = &dbPackageRevision{}
 )
 
+type kptfileStatus struct {
+	Conditions   []porchapi.Condition `json:"conditions,omitempty"`
+	UpstreamLock *kptfile.Locator     `json:"upstreamLock,omitempty"`
+}
+
+func extractKptfileStatus(resources map[string]string) kptfileStatus {
+	s, _, _ := extractFromKptfile(resources)
+	return s
+}
+
+func extractFromKptfile(resources map[string]string) (kptfileStatus, []porchapi.ReadinessGate, *porchapi.PackageMetadata) {
+	kfString, ok := resources[kptfile.KptFileName]
+	if !ok {
+		return kptfileStatus{}, nil, nil
+	}
+	kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfString))
+	if err != nil {
+		klog.Warningf("extractFromKptfile: failed to decode Kptfile: %v", err)
+		return kptfileStatus{}, nil, nil
+	}
+	var s kptfileStatus
+	if kf.Status != nil {
+		s.Conditions = repository.ToAPIConditions(*kf)
+	}
+	s.UpstreamLock = kf.UpstreamLock
+	return s, repository.ToAPIReadinessGates(*kf), &porchapi.PackageMetadata{
+		Labels:      kf.Labels,
+		Annotations: kf.Annotations,
+	}
+}
+
 type dbPackageRevision struct {
-	repo      *dbRepository
-	pkgRevKey repository.PackageRevisionKey
-	meta      metav1.ObjectMeta
-	spec      *porchapi.PackageRevisionSpec
-	updated   time.Time
-	updatedBy string
-	lifecycle porchapi.PackageRevisionLifecycle
-	extPRID   kptfile.Locator
-	latest    bool
-	tasks     []porchapi.Task
-	resources map[string]string
+	repo          *dbRepository
+	pkgRevKey     repository.PackageRevisionKey
+	meta          metav1.ObjectMeta
+	spec          *porchapi.PackageRevisionSpec
+	updated       time.Time
+	updatedBy     string
+	lifecycle     porchapi.PackageRevisionLifecycle
+	extPRID       kptfile.Locator
+	latest        bool
+	deployment    bool
+	tasks         []porchapi.Task
+	resources     map[string]string
+	kptfileStatus kptfileStatus
 }
 
 func (pr *dbPackageRevision) KubeObjectName() string {

--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -37,6 +37,7 @@ func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, re
 			repositories.k8s_name,
 			repositories.directory,
 			repositories.default_ws_name,
+			repositories.deployment,
 			packages.k8s_name,
 			packages.package_path,
 			package_revisions.k8s_name,
@@ -107,6 +108,7 @@ func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevis
 			repositories.k8s_name,
 			repositories.directory,
 			repositories.default_ws_name,
+			repositories.deployment,
 			packages.k8s_name,
 			packages.package_path,
 			package_revisions.k8s_name,
@@ -154,6 +156,7 @@ func pkgRevReadPRsFromDB(ctx context.Context, pk repository.PackageKey) ([]*dbPa
 			repositories.k8s_name,
 			repositories.directory,
 			repositories.default_ws_name,
+			repositories.deployment,
 			packages.k8s_name,
 			packages.package_path,
 			package_revisions.k8s_name,
@@ -202,6 +205,7 @@ func pkgRevReadLatestPRFromDB(ctx context.Context, pk repository.PackageKey) (*d
 			repositories.k8s_name,
 			repositories.directory,
 			repositories.default_ws_name,
+			repositories.deployment,
 			packages.k8s_name,
 			packages.package_path,
 			package_revisions.k8s_name,
@@ -287,6 +291,7 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 			&pkgRev.pkgRevKey.PkgKey.RepoKey.Name,
 			&pkgRev.pkgRevKey.PkgKey.RepoKey.Path,
 			&pkgRev.pkgRevKey.PkgKey.RepoKey.PlaceholderWSname,
+			&pkgRev.deployment,
 			&pkgK8SName,
 			&pkgRev.pkgRevKey.PkgKey.Path,
 			&prK8SName,
@@ -311,11 +316,7 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 				pkgRev.repo = dbRepo
 			} else {
 				klog.Warningf("pkgRevScanRowsFromDB: repository %+v is not a dbRepository for package revision %s", pkgRev.pkgRevKey.PkgKey.RepoKey, prK8SName)
-				continue
 			}
-		} else {
-			klog.V(4).Infof("pkgRevScanRowsFromDB: repository %+v not found in cache for package revision %s", pkgRev.pkgRevKey.PkgKey.RepoKey, prK8SName)
-			continue
 		}
 		pkgRev.pkgRevKey.PkgKey.Package = repository.K8SName2PkgName(pkgK8SName)
 		pkgRev.pkgRevKey.WorkspaceName = repository.K8SName2PkgRevWSName(pkgK8SName, prK8SName)

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -195,11 +195,12 @@ func (r *dbRepository) CreatePackageRevisionDraft(ctx context.Context, newPR *po
 			Revision:      0,
 			WorkspaceName: newPR.Spec.WorkspaceName,
 		},
-		meta:      newPR.ObjectMeta,
-		spec:      &newPR.Spec,
-		lifecycle: porchapi.PackageRevisionLifecycleDraft,
-		updated:   time.Now(),
-		updatedBy: getCurrentUser(),
+		meta:       newPR.ObjectMeta,
+		spec:       &newPR.Spec,
+		lifecycle:  porchapi.PackageRevisionLifecycleDraft,
+		updated:    time.Now(),
+		updatedBy:  getCurrentUser(),
+		deployment: r.deployment,
 	}
 
 	dbPkgRev.meta.CreationTimestamp = metav1.Time{Time: time.Now()}

--- a/pkg/cache/dbcache/dbreposync.go
+++ b/pkg/cache/dbcache/dbreposync.go
@@ -251,15 +251,17 @@ func (s *repositorySync) cacheExternalPRs(ctx context.Context, externalPrMap map
 		_, extPRUpstreamLock, _ := extPR.GetLock(ctx)
 
 		dbPR := dbPackageRevision{
-			repo:      s.repo,
-			pkgRevKey: extPRKey,
-			meta:      extAPIPR.ObjectMeta,
-			spec:      &extAPIPR.Spec,
-			updated:   time.Now(),
-			lifecycle: extAPIPR.Spec.Lifecycle,
-			extPRID:   extPRUpstreamLock,
-			tasks:     extAPIPR.Spec.Tasks,
-			resources: resources,
+			repo:          s.repo,
+			pkgRevKey:     extPRKey,
+			meta:          extAPIPR.ObjectMeta,
+			spec:          &extAPIPR.Spec,
+			updated:       time.Now(),
+			lifecycle:     extAPIPR.Spec.Lifecycle,
+			extPRID:       extPRUpstreamLock,
+			tasks:         extAPIPR.Spec.Tasks,
+			resources:     resources,
+			deployment:    s.repo.deployment,
+			kptfileStatus: extractKptfileStatus(resources),
 		}
 		_, err = s.repo.savePackageRevision(ctx, &dbPR, true)
 		if err != nil {

--- a/pkg/cache/dbcache/dbsqlfiltering.go
+++ b/pkg/cache/dbcache/dbsqlfiltering.go
@@ -35,7 +35,7 @@ func pkgListFilter2WhereClause(filter repository.ListPackageFilter) string {
 	whereStatement, first = filter2SubClauseStr(whereStatement, repoKey.PlaceholderWSname, "repositories.default_ws_name", first)
 
 	pkgKey := filter.Key
-	whereStatement, first = filter2SubClauseStr(whereStatement, pkgKey.K8SName(), "packages.k8s_name", first)
+	whereStatement, first = filter2SubClauseSuffix(whereStatement, pkgKey.Package, "packages.k8s_name", first)
 	whereStatement, _ = filter2SubClauseStr(whereStatement, pkgKey.Path, "packages.package_path", first)
 
 	if whereStatement == "" {
@@ -55,11 +55,10 @@ func prListFilter2WhereClause(filter repository.ListPackageRevisionFilter) strin
 	whereStatement, first = filter2SubClauseStr(whereStatement, repoKey.PlaceholderWSname, "repositories.default_ws_name", first)
 
 	pkgKey := filter.Key.PKey()
-	whereStatement, first = filter2SubClauseStr(whereStatement, pkgKey.K8SName(), "packages.k8s_name", first)
+	whereStatement, first = filter2SubClauseSuffix(whereStatement, pkgKey.Package, "packages.k8s_name", first)
 	whereStatement, first = filter2SubClauseStr(whereStatement, pkgKey.Path, "packages.package_path", first)
 
 	prKey := filter.Key
-	whereStatement, first = filter2SubClauseStr(whereStatement, prKey.K8SName(), "package_revisions.k8s_name", first)
 	whereStatement, first = filter2SubClauseInt(whereStatement, prKey.Revision, "package_revisions.revision", first)
 	whereStatement, first = filter2SubClauseWorkspace(whereStatement, prKey.WorkspaceName, "package_revisions.k8s_name", first)
 
@@ -80,6 +79,20 @@ func filter2SubClauseStr(whereStatement, filterField, column string, first bool)
 	}
 
 	subClause := fmt.Sprintf("%s='%s'\n", column, filterField)
+
+	if first {
+		return whereStatement + subClause, false
+	} else {
+		return whereStatement + "AND " + subClause, false
+	}
+}
+
+func filter2SubClauseSuffix(whereStatement, suffix, column string, first bool) (string, bool) {
+	if suffix == "" {
+		return whereStatement, first
+	}
+
+	subClause := fmt.Sprintf("%s LIKE '%%.%s'\n", column, suffix)
 
 	if first {
 		return whereStatement + subClause, false

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -43,6 +43,7 @@ type CacheOptions struct {
 	CoreClient                 client.WithWatch
 	CacheType                  CacheType
 	DBCacheOptions             DBCacheOptions
+	CRCacheOptions             CRCacheOptions
 }
 
 const DefaultDBCacheDriver string = "pgx"
@@ -55,6 +56,11 @@ type DBCacheOptions struct {
 	MaxConnLifetime    time.Duration
 }
 
+type CRCacheOptions struct {
+	MaxConcurrentLists       int
+	ListTimeoutPerRepository time.Duration
+}
+
 type Cache interface {
 	OpenRepository(ctx context.Context, repositorySpec *configapi.Repository) (repository.Repository, error)
 	CloseRepository(ctx context.Context, repositorySpec *configapi.Repository, allRepos []configapi.Repository) error
@@ -63,6 +69,7 @@ type Cache interface {
 	UpdateRepository(ctx context.Context, repositorySpec *configapi.Repository) error
 	CheckRepositoryConnectivity(ctx context.Context, repositorySpec *configapi.Repository) error
 	FindAllUpstreamReferencesInRepositories(ctx context.Context, namespace, prName string) (string, error)
+	ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
 }
 
 var (

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -334,6 +334,10 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 				RepoSyncFrequency:          o.RepoSyncFrequency,
 				RepoOperationRetryAttempts: o.RepoOperationRetryAttempts,
 				CacheType:                  cachetypes.CacheType(o.CacheType),
+				CRCacheOptions: cachetypes.CRCacheOptions{
+					MaxConcurrentLists:       o.MaxConcurrentLists,
+					ListTimeoutPerRepository: o.ListTimeoutPerRepository,
+				},
 				DBCacheOptions: cachetypes.DBCacheOptions{
 					Driver:             o.DbCacheDriver,
 					DataSource:         o.DbCacheDataSource,
@@ -342,8 +346,6 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 					MaxConnLifetime:    o.DbMaxConnLifetime,
 				},
 			},
-			ListTimeoutPerRepository: o.ListTimeoutPerRepository,
-			MaxConcurrentLists:       o.MaxConcurrentLists,
 		},
 	}
 	return config, nil

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -48,7 +48,7 @@ type CaDEngine interface {
 
 	UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevisionResources) (repository.PackageRevision, *porchapi.RenderStatus, error)
 
-	ListPackageRevisions(ctx context.Context, repositorySpec *configapi.Repository, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
+	ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
 	CreatePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, obj *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error)
 	UpdatePackageRevision(ctx context.Context, version int, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error)
 	DeletePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, obj repository.PackageRevision) error
@@ -93,26 +93,11 @@ func (cad *cadEngine) OpenRepository(ctx context.Context, repositorySpec *config
 	return cad.cache.OpenRepository(ctx, repositorySpec)
 }
 
-func (cad *cadEngine) ListPackageRevisions(ctx context.Context, repositorySpec *configapi.Repository, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+func (cad *cadEngine) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
 	ctx, span := tracer.Start(ctx, "cadEngine::ListPackageRevisions", trace.WithAttributes())
 	defer span.End()
 
-	klog.V(3).InfoS("[CaD Engine] Opening cached repository for listing",
-		context1.LogMetadataFromWithExtras(ctx, "repository", repositorySpec.Name)...)
-	defer func() {
-		klog.V(3).InfoS("[CaD Engine] Completed listing from cached repository",
-			context1.LogMetadataFromWithExtras(ctx, "repository", repositorySpec.Name)...)
-	}()
-
-	repo, err := cad.cache.OpenRepository(ctx, repositorySpec)
-	if err != nil {
-		return nil, err
-	}
-	if repo == nil {
-		return nil, pkgerrors.New("cache OpenRepository returned nil")
-	}
-
-	return repo.ListPackageRevisions(ctx, filter)
+	return cad.cache.ListPackageRevisions(ctx, filter)
 }
 
 func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, newPr *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -292,6 +292,11 @@ func (m *mockCache) FindAllUpstreamReferencesInRepositories(ctx context.Context,
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockCache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	args := m.Called(ctx, filter)
+	return args.Get(0).([]repository.PackageRevision), args.Error(1)
+}
+
 func TestCreatePRWith2Tasks(t *testing.T) {
 	pr := &porchapi.PackageRevision{
 		Spec: porchapi.PackageRevisionSpec{

--- a/pkg/registry/porch/fieldselector.go
+++ b/pkg/registry/porch/fieldselector.go
@@ -111,11 +111,14 @@ func convertPackageRevisionFieldSelector(label, value string) (internalLabel, in
 	return "", "", fmt.Errorf("%q is not a known field selector", label)
 }
 
-// parsePackageFieldSelector parses client-provided fields.Selector into a packageFilter
-func parsePackageFieldSelector(fieldSelector fields.Selector) (repository.ListPackageFilter, error) {
+// parsePackageFieldSelector parses client-provided fields.Selector into a packageFilter.
+// If namespace is non-empty, it is applied to the filter and checked for conflicts
+// with any namespace specified via the field selector.
+func parsePackageFieldSelector(fieldSelector fields.Selector, namespace string) (repository.ListPackageFilter, error) {
 	var filter repository.ListPackageFilter
 
 	if fieldSelector == nil {
+		filter.Key.RepoKey.Namespace = namespace
 		return filter, nil
 	}
 
@@ -153,11 +156,20 @@ func parsePackageFieldSelector(fieldSelector fields.Selector) (repository.ListPa
 		}
 	}
 
+	if namespace != "" {
+		if filter.Key.RepoKey.Namespace != "" && filter.Key.RepoKey.Namespace != namespace {
+			return filter, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filter.Key.RepoKey.Namespace)
+		}
+		filter.Key.RepoKey.Namespace = namespace
+	}
+
 	return filter, nil
 }
 
-// parsePackageRevisionFieldSelector parses client-provided fields.Selector into a ListPackageRevisionFilter
-func parsePackageRevisionFieldSelector(options *metainternalversion.ListOptions) (*repository.ListPackageRevisionFilter, error) {
+// parsePackageRevisionFieldSelector parses client-provided fields.Selector into a ListPackageRevisionFilter.
+// If namespace is non-empty, it is applied to the filter and checked for conflicts
+// with any namespace specified via the field selector.
+func parsePackageRevisionFieldSelector(options *metainternalversion.ListOptions, namespace string) (*repository.ListPackageRevisionFilter, error) {
 	filter := &repository.ListPackageRevisionFilter{
 		Label: options.LabelSelector,
 		Key:   repository.PackageRevisionKey{},
@@ -165,6 +177,7 @@ func parsePackageRevisionFieldSelector(options *metainternalversion.ListOptions)
 
 	fieldSelector := options.FieldSelector
 	if fieldSelector == nil {
+		filter.Key.PkgKey.RepoKey.Namespace = namespace
 		return filter, nil
 	}
 
@@ -207,12 +220,19 @@ func parsePackageRevisionFieldSelector(options *metainternalversion.ListOptions)
 		}
 	}
 
+	if namespace != "" {
+		if filter.Key.PkgKey.RepoKey.Namespace != "" && filter.Key.PkgKey.RepoKey.Namespace != namespace {
+			return filter, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filter.Key.PkgKey.RepoKey.Namespace)
+		}
+		filter.Key.PkgKey.RepoKey.Namespace = namespace
+	}
+
 	return filter, nil
 }
 
 // parsePackageRevisionResourcesFieldSelector parses client-provided fields.Selector into a packageRevisionFilter
-func parsePackageRevisionResourcesFieldSelector(options *metainternalversion.ListOptions) (*repository.ListPackageRevisionFilter, error) {
+func parsePackageRevisionResourcesFieldSelector(options *metainternalversion.ListOptions, namespace string) (*repository.ListPackageRevisionFilter, error) {
 	// TOOD: This is a little weird, because we don't have the same fields on PackageRevisionResources.
 	// But we probably should have the key fields
-	return parsePackageRevisionFieldSelector(options)
+	return parsePackageRevisionFieldSelector(options, namespace)
 }

--- a/pkg/registry/porch/fieldselector_test.go
+++ b/pkg/registry/porch/fieldselector_test.go
@@ -218,7 +218,7 @@ func Test_parsePackageRevisionFieldSelector(t *testing.T) {
 				FieldSelector: fieldSelector,
 			}
 
-			gotFilter, err := parsePackageRevisionFieldSelector(options)
+			gotFilter, err := parsePackageRevisionFieldSelector(options, "")
 
 			require.EqualValues(t, &tt.wantFilter, gotFilter)
 			require.NoError(t, err)
@@ -259,7 +259,7 @@ func Test_parsePackageRevisionFieldSelector(t *testing.T) {
 				FieldSelector: tt.selector,
 			}
 
-			gotFilter, err := parsePackageRevisionFieldSelector(options)
+			gotFilter, err := parsePackageRevisionFieldSelector(options, "")
 
 			wantFilter := &repository.ListPackageRevisionFilter{}
 			require.EqualValues(t, wantFilter, gotFilter)
@@ -308,7 +308,7 @@ func Test_parsePackageRevisionResourcesFieldSelector(t *testing.T) {
 				FieldSelector: fieldSelector,
 			}
 
-			gotFilter, err := parsePackageRevisionResourcesFieldSelector(options)
+			gotFilter, err := parsePackageRevisionResourcesFieldSelector(options, "")
 
 			require.EqualValues(t, &tt.wantFilter, gotFilter)
 			require.NoError(t, err)

--- a/pkg/registry/porch/package.go
+++ b/pkg/registry/porch/package.go
@@ -24,6 +24,7 @@ import (
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
 
@@ -72,7 +73,9 @@ func (r *packages) List(ctx context.Context, options *metainternalversion.ListOp
 		},
 	}
 
-	filter, err := parsePackageFieldSelector(options.FieldSelector)
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+
+	filter, err := parsePackageFieldSelector(options.FieldSelector, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -385,15 +385,6 @@ func getLifecycleTransition(oldPkgRev, newPkgRev *porchapi.PackageRevision) stri
 }
 
 func (r *packageCommon) validateDelete(ctx context.Context, deleteValidation rest.ValidateObjectFunc, obj runtime.Object, name, namespace string) (*configapi.Repository, error) {
-	if pkgRev, ok := obj.(*porchapi.PackageRevision); ok {
-		if pkgRev.Spec.Lifecycle == porchapi.PackageRevisionLifecyclePublished {
-			return nil, apierrors.NewForbidden(
-				porchapi.Resource("packagerevisions"),
-				name,
-				fmt.Errorf("published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion"))
-		}
-	}
-
 	if deleteValidation != nil {
 		err := deleteValidation(ctx, obj)
 		if err != nil {

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -16,10 +16,8 @@ package porch
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	unversionedapi "github.com/nephio-project/porch/api/porch"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
@@ -29,7 +27,6 @@ import (
 	context1 "github.com/nephio-project/porch/pkg/util/context"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,130 +50,33 @@ type packageCommon struct {
 
 	cad engine.CaDEngine
 	// coreClient is a client back to the core kubernetes API server, useful for querying CRDs etc
-	coreClient               client.Client
-	gr                       schema.GroupResource
-	updateStrategy           SimpleRESTUpdateStrategy
-	createStrategy           SimpleRESTCreateStrategy
-	ListTimeoutPerRepository time.Duration
-	MaxConcurrentLists       int
+	coreClient     client.Client
+	gr             schema.GroupResource
+	updateStrategy SimpleRESTUpdateStrategy
+	createStrategy SimpleRESTCreateStrategy
 }
 
 func (r *packageCommon) listPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter,
 	callback func(ctx context.Context, p repository.PackageRevision) error) error {
 	ctx, span := tracer.Start(ctx, "packageCommon::listPackageRevisions", trace.WithAttributes())
 	defer span.End()
-
-	var opts []client.ListOption
-
-	namespace, namespaced := genericapirequest.NamespaceFrom(ctx)
-	if namespaced && namespace != "" {
-		if namespaceMatches, filteredNamespace := filter.MatchesNamespace(namespace); !namespaceMatches {
-			return fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filteredNamespace)
-		}
-
-		opts = append(opts, client.InNamespace(namespace))
+	revisions, err := r.cad.ListPackageRevisions(ctx, filter)
+	if err != nil {
+		return err
 	}
-
-	if filterRepo := filter.FilteredRepository(); filterRepo != "" {
-		opts = append(opts, client.MatchingFields(fields.Set{"metadata.name": filterRepo}))
-	}
-
-	var repoList configapi.RepositoryList
-	if err := r.coreClient.List(ctx, &repoList, opts...); err != nil {
-		return fmt.Errorf("error listing repository objects: %w", err)
-	}
-	repos := repoList.Items
-
-	type pkgRevResult struct {
-		Revisions []repository.PackageRevision
-		Err       error
-	}
-
-	repoCount := len(repos)
-	if repoCount == 0 {
-		return nil
-	}
-
-	workerCount := repoCount
-	if r.MaxConcurrentLists > 0 {
-		workerCount = min(r.MaxConcurrentLists, repoCount)
-	}
-
-	klog.V(3).Infof("Listing %d repositories with %d workers", repoCount, workerCount)
-
-	resultsCh := make(chan pkgRevResult, workerCount)
-	repoQueue := make(chan *configapi.Repository, repoCount)
-
-	for i := 0; i < workerCount; i++ {
-		go func() {
-			for repo := range repoQueue {
-				klog.V(3).Infof("[WORKER %d] Processing repository %s", i, repo.Name)
-				listCtx := ctx
-				var cancel context.CancelFunc
-				if r.ListTimeoutPerRepository != 0 {
-					listCtx, cancel = context.WithTimeout(ctx, r.ListTimeoutPerRepository)
-				}
-				revisions, err := r.cad.ListPackageRevisions(listCtx, repo, filter)
-				klog.V(3).Infof("[WORKER %d] ListPackageRevisions for %s done, len: %d, err: %v", i, repo.Name, len(revisions), err)
-				resultsCh <- pkgRevResult{Revisions: revisions, Err: err}
-				if cancel != nil {
-					cancel()
-				}
-			}
-		}()
-	}
-
-	for _, repo := range repos {
-		repoQueue <- &repo
-	}
-
-	innerCtx := ctx
-	if deadline, ok := ctx.Deadline(); ok {
-		const buffer = 5 * time.Second
-		if timeout := time.Until(deadline.Add(-buffer)); timeout > 0 {
-			var cancel context.CancelFunc
-			innerCtx, cancel = context.WithTimeout(ctx, timeout)
-			defer cancel()
+	for _, rev := range revisions {
+		if err := callback(ctx, rev); err != nil {
+			klog.Warningf("callback error for revision from repository: %+v", err)
+			continue
 		}
 	}
-
-	received := 0
-
-	for {
-		select {
-		case <-innerCtx.Done():
-			klog.Warningf("Timeout reached — returning partial results")
-			close(repoQueue)
-			return nil
-
-		case res := <-resultsCh:
-			received++
-			klog.V(4).Infof("listPackageRevisions received %d repo", received)
-			if res.Err != nil {
-				klog.Warningf("error listing package revisions: %+v", res.Err)
-			}
-			for _, rev := range res.Revisions {
-				if err := callback(ctx, rev); err != nil {
-					klog.Warningf("callback error for revision from repository: %+v", err)
-					continue
-				}
-			}
-			if received == repoCount {
-				close(repoQueue)
-				return nil
-			}
-		}
-	}
+	return nil
 }
 
 func (r *packageCommon) listPackages(ctx context.Context, filter repository.ListPackageFilter, callback func(p repository.Package) error) error {
 	var opts []client.ListOption
-	if ns, namespaced := genericapirequest.NamespaceFrom(ctx); namespaced {
+	if ns := filter.Key.RepoKey.Namespace; ns != "" {
 		opts = append(opts, client.InNamespace(ns))
-
-		if filter.Key.RKey().Namespace != "" && ns != filter.Key.RKey().Namespace {
-			return fmt.Errorf("conflicting namespaces specified: %q and %q", ns, filter.Key.RKey().Namespace)
-		}
 	}
 
 	// TODO: Filter on filter.Repository?
@@ -262,22 +162,8 @@ func (r *packageCommon) getRepoPkgRev(ctx context.Context, name string) (reposit
 		return nil, err
 	}
 
-	repositoryObj, err := r.getRepositoryObj(ctx, types.NamespacedName{Name: prKey.RKey().Name, Namespace: prKey.RKey().Namespace})
+	revisions, err := r.cad.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{Key: prKey})
 	if err != nil {
-		return nil, err
-	}
-
-	var cancel context.CancelFunc
-	if r.ListTimeoutPerRepository != 0 {
-		ctx, cancel = context.WithTimeout(ctx, r.ListTimeoutPerRepository)
-		defer cancel()
-	}
-
-	revisions, err := r.cad.ListPackageRevisions(ctx, repositoryObj, repository.ListPackageRevisionFilter{Key: prKey})
-	if err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return nil, fmt.Errorf("%v: exceeded %v seconds trying to list package revisions", ctx.Err(), r.ListTimeoutPerRepository)
-		}
 		return nil, err
 	}
 	for _, rev := range revisions {
@@ -499,6 +385,15 @@ func getLifecycleTransition(oldPkgRev, newPkgRev *porchapi.PackageRevision) stri
 }
 
 func (r *packageCommon) validateDelete(ctx context.Context, deleteValidation rest.ValidateObjectFunc, obj runtime.Object, name, namespace string) (*configapi.Repository, error) {
+	if pkgRev, ok := obj.(*porchapi.PackageRevision); ok {
+		if pkgRev.Spec.Lifecycle == porchapi.PackageRevisionLifecyclePublished {
+			return nil, apierrors.NewForbidden(
+				porchapi.Resource("packagerevisions"),
+				name,
+				fmt.Errorf("published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion"))
+		}
+	}
+
 	if deleteValidation != nil {
 		err := deleteValidation(ctx, obj)
 		if err != nil {

--- a/pkg/registry/porch/packagecommon_test.go
+++ b/pkg/registry/porch/packagecommon_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,13 +34,11 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestNamespaceFilteringWatcher(t *testing.T) {
@@ -253,10 +249,6 @@ func TestWatchPackages_WithNamespaceFilteringWatcher(t *testing.T) {
 }
 
 func TestListPackageRevisions(t *testing.T) {
-	var currentConcurrent int32
-	var maxConcurrent int32
-	var mutex sync.Mutex
-
 	tests := []struct {
 		name          string
 		setupMocks    func(*mockclient.MockClient, *mockrepo.MockPackageRevision, *mockcad.MockCaDEngine)
@@ -268,19 +260,7 @@ func TestListPackageRevisions(t *testing.T) {
 		{
 			name: "Successful package revision listing",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{
-							{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "repo1",
-								},
-							},
-						}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
 					Return([]repository.PackageRevision{pkgRev}, nil)
 			},
 			filter:        repository.ListPackageRevisionFilter{},
@@ -291,15 +271,7 @@ func TestListPackageRevisions(t *testing.T) {
 		{
 			name: "Successful namespace filtering",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, client.InNamespace("test-namespace")).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo1", Namespace: "test-ns"}},
-						}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
 					Return([]repository.PackageRevision{pkgRev}, nil)
 			},
 			filter: repository.ListPackageRevisionFilter{
@@ -316,155 +288,14 @@ func TestListPackageRevisions(t *testing.T) {
 			ctx:           genericapirequest.WithNamespace(context.Background(), "test-namespace"),
 		},
 		{
-			name:       "Conflicting namespaces",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {},
-			filter: repository.ListPackageRevisionFilter{
-				Key: repository.PackageRevisionKey{
-					PkgKey: repository.PackageKey{
-						RepoKey: repository.RepositoryKey{
-							Namespace: "namespace-1",
-						},
-					},
-				},
-			},
-			expectedError: fmt.Errorf("conflicting namespaces specified: %q and %q", "namespace-2", "namespace-1"),
-			expectedCalls: 0,
-			ctx:           genericapirequest.WithNamespace(context.Background(), "namespace-2"),
-		},
-		{
-			name: "Failed repository listing",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Return(fmt.Errorf("list error"))
-			},
-			filter:        repository.ListPackageRevisionFilter{},
-			expectedError: fmt.Errorf("error listing repository objects: list error"),
-			expectedCalls: 0,
-			ctx:           context.Background(),
-		}, {
-			name: "Successful repository filtering",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo1"}},
-						}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{pkgRev}, nil)
-			},
-			filter: repository.ListPackageRevisionFilter{
-				Key: repository.PackageRevisionKey{
-					PkgKey: repository.PackageKey{
-						RepoKey: repository.RepositoryKey{
-							Name: "repo1",
-						},
-					},
-				},
-			},
-			expectedError: nil,
-			expectedCalls: 1,
-			ctx:           context.Background(),
-		},
-		{
-			name: "Label selector filtering",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{{}}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{pkgRev}, nil)
-			},
-			filter:        repository.ListPackageRevisionFilter{Label: labels.SelectorFromSet(labels.Set{"test": "true"})},
-			expectedError: nil,
-			expectedCalls: 1,
-			ctx:           context.Background(),
-		},
-		{
-			name: "Timeout error",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{{}}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{}, context.DeadlineExceeded)
-			},
-			filter:        repository.ListPackageRevisionFilter{},
-			expectedError: nil,
-			expectedCalls: 0,
-		},
-		{
 			name: "CaD engine error",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{{}}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
 					Return([]repository.PackageRevision{}, fmt.Errorf("CaD engine error"))
 			},
 			filter:        repository.ListPackageRevisionFilter{},
-			expectedError: nil,
+			expectedError: fmt.Errorf("CaD engine error"),
 			expectedCalls: 0,
-			ctx:           context.Background(),
-		},
-		{
-			name: "Callback error",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{{}}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{pkgRev}, nil)
-			},
-			filter:        repository.ListPackageRevisionFilter{},
-			expectedError: nil,
-			expectedCalls: 1,
-			ctx:           context.Background(),
-		},
-		{
-			name: "Concurrent listing",
-			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				c.On("List", mock.Anything, &configapi.RepositoryList{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						list := args.Get(1).(*configapi.RepositoryList)
-						list.Items = []configapi.Repository{
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo1"}},
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo2"}},
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo3"}},
-							{ObjectMeta: metav1.ObjectMeta{Name: "repo4"}},
-						}
-					}).Return(nil)
-
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
-					Run(func(args mock.Arguments) {
-						atomic.AddInt32(&currentConcurrent, 1)
-						mutex.Lock()
-						if currentConcurrent > maxConcurrent {
-							maxConcurrent = currentConcurrent
-						}
-						mutex.Unlock()
-						time.Sleep(500 * time.Millisecond)
-						atomic.AddInt32(&currentConcurrent, -1)
-					}).
-					Return([]repository.PackageRevision{pkgRev}, nil)
-			},
-			filter:        repository.ListPackageRevisionFilter{},
-			expectedError: nil,
-			expectedCalls: 4,
 			ctx:           context.Background(),
 		},
 	}
@@ -476,10 +307,8 @@ func TestListPackageRevisions(t *testing.T) {
 			mockCaD := &mockcad.MockCaDEngine{}
 
 			pc := &packageCommon{
-				cad:                      mockCaD,
-				coreClient:               mockCoreClient,
-				ListTimeoutPerRepository: 1 * time.Second,
-				MaxConcurrentLists:       3,
+				cad:        mockCaD,
+				coreClient: mockCoreClient,
 			}
 
 			mockCaD.ExpectedCalls = nil
@@ -510,7 +339,6 @@ func TestListPackageRevisions(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedCalls, callCount)
-			assert.LessOrEqual(t, maxConcurrent, int32(pc.MaxConcurrentLists), "Maximum concurrent operations exceeded limit of 2")
 			mockCaD.AssertExpectations(t)
 			mockCoreClient.AssertExpectations(t)
 			mockPkgRev.AssertExpectations(t)
@@ -532,8 +360,6 @@ func TestGetRepoPkgRev(t *testing.T) {
 			pkgRevName: "repo.pkg.wsn",
 			ctx:        genericapirequest.WithNamespace(context.Background(), "test-ns"),
 			setupMocks: func(c *mockclient.MockClient, cad *mockcad.MockCaDEngine) {
-				repo := &configapi.Repository{}
-
 				pkgRev := &fakeextrepo.FakePackageRevision{
 					PrKey: repository.PackageRevisionKey{
 						PkgKey: repository.PackageKey{
@@ -544,15 +370,8 @@ func TestGetRepoPkgRev(t *testing.T) {
 					},
 				}
 
-				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"},
-					&configapi.Repository{}).
-					Run(func(args mock.Arguments) {
-						arg := args.Get(2).(*configapi.Repository)
-						*arg = *repo
-					}).Return(nil)
-
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, repo,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					Return([]repository.PackageRevision{pkgRev}, nil)
 			},
@@ -591,13 +410,14 @@ func TestGetRepoPkgRev(t *testing.T) {
 			expectedErrorMessage: "package revision kubernetes resource name invalid",
 		},
 		{
-			name:       "Repository not found",
+			name:       "Package revision not found",
 			pkgRevName: "repo.pkg.wsn",
 			ctx:        genericapirequest.WithNamespace(context.Background(), "test-ns"),
 			setupMocks: func(c *mockclient.MockClient, cad *mockcad.MockCaDEngine) {
-				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"},
-					&configapi.Repository{}, mock.Anything).
-					Return(apierrors.NewNotFound(schema.GroupResource{}, "repo"))
+				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
+				cad.On("ListPackageRevisions", mock.Anything,
+					repository.ListPackageRevisionFilter{Key: prKey}).
+					Return([]repository.PackageRevision{}, nil)
 			},
 			expectedFailure:      true,
 			expectedErrorMessage: "not found",
@@ -607,21 +427,11 @@ func TestGetRepoPkgRev(t *testing.T) {
 			pkgRevName: "repo.pkg.wsn",
 			ctx:        genericapirequest.WithNamespace(context.Background(), "test-ns"),
 			setupMocks: func(c *mockclient.MockClient, cad *mockcad.MockCaDEngine) {
-				repo := &configapi.Repository{}
-
-				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"},
-					&configapi.Repository{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						arg := args.Get(2).(*configapi.Repository)
-						*arg = *repo
-					}).Return(nil)
-
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, repo,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					After(2*time.Second).
 					Return([]repository.PackageRevision{}, fmt.Errorf("seconds trying to list package revisions"))
-
 			},
 			expectedFailure:      true,
 			expectedErrorMessage: "seconds trying to list package revisions",
@@ -631,20 +441,10 @@ func TestGetRepoPkgRev(t *testing.T) {
 			pkgRevName: "repo.pkg.wsn",
 			ctx:        genericapirequest.WithNamespace(context.Background(), "test-ns"),
 			setupMocks: func(c *mockclient.MockClient, cad *mockcad.MockCaDEngine) {
-				repo := &configapi.Repository{}
-
-				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"},
-					&configapi.Repository{}, mock.Anything).
-					Run(func(args mock.Arguments) {
-						arg := args.Get(2).(*configapi.Repository)
-						*arg = *repo
-					}).Return(nil)
-
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, repo,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					Return([]repository.PackageRevision{}, fmt.Errorf("list error"))
-
 			},
 			expectedFailure:      true,
 			expectedErrorMessage: "list error",
@@ -657,9 +457,8 @@ func TestGetRepoPkgRev(t *testing.T) {
 			mockCaDEngine := &mockcad.MockCaDEngine{}
 
 			pc := &packageCommon{
-				coreClient:               mockCoreClient,
-				cad:                      mockCaDEngine,
-				ListTimeoutPerRepository: 1 * time.Second,
+				coreClient: mockCoreClient,
+				cad:        mockCaDEngine,
 			}
 
 			tt.setupMocks(mockCoreClient, mockCaDEngine)
@@ -924,10 +723,10 @@ func TestUpdatePackageRevision(t *testing.T) {
 				}
 
 				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"}, mock.Anything).
-					Return(nil).Twice()
+					Return(nil).Once()
 
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					Return([]repository.PackageRevision{pkgRev}, nil).Once()
 
@@ -955,11 +754,8 @@ func TestUpdatePackageRevision(t *testing.T) {
 			name:       "Package not found - no forceAllowCreate",
 			pkgRevName: "repo.pkg.wsn",
 			setupMocks: func(c *mockclient.MockClient, cad *mockcad.MockCaDEngine, pkgRev *mockrepo.MockPackageRevision) {
-				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"}, mock.Anything).
-					Return(nil).Once()
-
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					Return([]repository.PackageRevision{}, nil).Once()
 			},
@@ -977,10 +773,10 @@ func TestUpdatePackageRevision(t *testing.T) {
 				}
 
 				c.On("Get", mock.Anything, types.NamespacedName{Name: "repo", Namespace: "test-ns"}, mock.Anything).
-					Return(nil).Twice()
+					Return(nil).Once()
 
 				prKey, _ := repository.PkgRevK8sName2Key("test-ns", "repo.pkg.wsn")
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything,
+				cad.On("ListPackageRevisions", mock.Anything,
 					repository.ListPackageRevisionFilter{Key: prKey}).
 					Return([]repository.PackageRevision{pkgRev}, nil).Once()
 

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -78,6 +78,8 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 
 	klog.V(3).InfoS("[API] List operation started for PackageRevisions", context1.LogMetadataFrom(ctx)...)
 
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+
 	result := &porchapi.PackageRevisionList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionList",
@@ -85,7 +87,7 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 		},
 	}
 
-	filter, err := parsePackageRevisionFieldSelector(options)
+	filter, err := parsePackageRevisionFieldSelector(options, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -89,9 +89,6 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: make(map[string]string),
 			},
-			Spec: porchapi.PackageRevisionSpec{
-				Lifecycle: porchapi.PackageRevisionLifecyclePublished,
-			},
 		},
 		Resources: &porchapi.PackageRevisionResources{
 			Spec: porchapi.PackageRevisionResourcesSpec{
@@ -275,128 +272,14 @@ func TestDelete(t *testing.T) {
 	ctx := request.WithNamespace(context.TODO(), "someDummyNamespace")
 	pkgRevName := "repo.1234567890.ws"
 
-	// Success case - Published package in DeletionProposed state
-	deletionProposedPkgRev := &fake.FakePackageRevision{
-		PrKey: repository.PackageRevisionKey{
-			PkgKey: repository.PackageKey{
-				RepoKey: repository.RepositoryKey{
-					Name: repositoryName,
-				},
-				Package: pkg,
-			},
-			Revision:      revision,
-			WorkspaceName: workspace,
-		},
-		PackageLifecycle: porchapi.PackageRevisionLifecycleDeletionProposed,
-		PackageRevision: &porchapi.PackageRevision{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: make(map[string]string),
-			},
-			Spec: porchapi.PackageRevisionSpec{
-				Lifecycle: porchapi.PackageRevisionLifecycleDeletionProposed,
-			},
-		},
-		Resources: &porchapi.PackageRevisionResources{
-			Spec: porchapi.PackageRevisionResourcesSpec{
-				PackageName:    pkg,
-				Revision:       revision,
-				RepositoryName: repositoryName,
-				Resources: map[string]string{
-					kptfilev1.KptFileName: strings.TrimSpace(`
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: example
-  annotations:
-    config.kubernetes.io/local-config: "true"
-info:
-  description: sample description
-					`),
-				},
-			},
-		},
-	}
-
-	// Need 1 Get call for validateDelete->getRepositoryObj
+	// Success case
 	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		deletionProposedPkgRev,
-	}, nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		packageRevision}, nil).Once()
 	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
 	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	result, deleted, err := packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.True(t, deleted)
-	assert.IsType(t, &porchapi.PackageRevision{}, result)
-
-	//=========================================================================================
-
-	// Failure case - Published package NOT in DeletionProposed state
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		packageRevision, // This is Published lifecycle
-	}, nil).Once()
-
-	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
-	assert.Error(t, err)
-	assert.Nil(t, result)
-	assert.False(t, deleted)
-	assert.True(t, apierrors.IsForbidden(err))
-	assert.ErrorContains(t, err, "published PackageRevisions must be proposed for deletion")
-
-	//=========================================================================================
-
-	// Success case - Draft package can be deleted without DeletionProposed
-	draftPkgRev := &fake.FakePackageRevision{
-		PrKey: repository.PackageRevisionKey{
-			PkgKey: repository.PackageKey{
-				RepoKey: repository.RepositoryKey{
-					Name: repositoryName,
-				},
-				Package: pkg,
-			},
-			Revision:      revision,
-			WorkspaceName: workspace,
-		},
-		PackageLifecycle: porchapi.PackageRevisionLifecycleDraft,
-		PackageRevision: &porchapi.PackageRevision{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: make(map[string]string),
-			},
-			Spec: porchapi.PackageRevisionSpec{
-				Lifecycle: porchapi.PackageRevisionLifecycleDraft,
-			},
-		},
-		Resources: &porchapi.PackageRevisionResources{
-			Spec: porchapi.PackageRevisionResourcesSpec{
-				PackageName:    pkg,
-				Revision:       revision,
-				RepositoryName: repositoryName,
-				Resources: map[string]string{
-					kptfilev1.KptFileName: strings.TrimSpace(`
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: example
-  annotations:
-    config.kubernetes.io/local-config: "true"
-info:
-  description: sample description
-					`),
-				},
-			},
-		},
-	}
-
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		draftPkgRev,
-	}, nil).Once()
-	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
-	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
-	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.True(t, deleted)
@@ -427,7 +310,7 @@ info:
 	// Error from DeletePackageRevision
 	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		deletionProposedPkgRev,
+		packageRevision,
 	}, nil).Once()
 	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
 	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("deletion failed")).Once()

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -89,6 +89,9 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: make(map[string]string),
 			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+			},
 		},
 		Resources: &porchapi.PackageRevisionResources{
 			Spec: porchapi.PackageRevisionResourcesSpec{
@@ -129,7 +132,7 @@ func setup(t *testing.T) (mockClient *mockclient.MockClient, mockEngine *mockeng
 
 func TestList(t *testing.T) {
 	_, mockEngine := setup(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision,
 	}, nil).Once()
 
@@ -148,7 +151,7 @@ func TestList(t *testing.T) {
 	//=========================================================================================
 
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		mockPkgRev,
 	}, nil)
 	mockPkgRev.On("KubeObjectName").Return("test-package").Maybe()
@@ -161,12 +164,11 @@ func TestList(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	mockClient, mockEngine := setup(t)
+	_, mockEngine := setup(t)
 	pkgRevName := "repo.1234567890.ws"
 
 	// Success case
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision,
 	}, nil).Once()
 
@@ -179,8 +181,7 @@ func TestGet(t *testing.T) {
 	//=========================================================================================
 
 	// Not found case
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
 
 	result, err = packagerevisions.Get(ctx, pkgRevName, &metav1.GetOptions{})
 	assert.Error(t, err)
@@ -191,8 +192,7 @@ func TestGet(t *testing.T) {
 
 	// Error from GetPackageRevision
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		mockPkgRev,
 	}, nil).Once()
 	mockPkgRev.On("KubeObjectName").Return(pkgRevName)
@@ -275,15 +275,128 @@ func TestDelete(t *testing.T) {
 	ctx := request.WithNamespace(context.TODO(), "someDummyNamespace")
 	pkgRevName := "repo.1234567890.ws"
 
-	// Success case
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		packageRevision,
+	// Success case - Published package in DeletionProposed state
+	deletionProposedPkgRev := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecycleDeletionProposed,
+		PackageRevision: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: make(map[string]string),
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleDeletionProposed,
+			},
+		},
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+
+	// Need 1 Get call for validateDelete->getRepositoryObj
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		deletionProposedPkgRev,
 	}, nil).Once()
 	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
 	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	result, deleted, err := packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, deleted)
+	assert.IsType(t, &porchapi.PackageRevision{}, result)
+
+	//=========================================================================================
+
+	// Failure case - Published package NOT in DeletionProposed state
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		packageRevision, // This is Published lifecycle
+	}, nil).Once()
+
+	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, deleted)
+	assert.True(t, apierrors.IsForbidden(err))
+	assert.ErrorContains(t, err, "published PackageRevisions must be proposed for deletion")
+
+	//=========================================================================================
+
+	// Success case - Draft package can be deleted without DeletionProposed
+	draftPkgRev := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecycleDraft,
+		PackageRevision: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: make(map[string]string),
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleDraft,
+			},
+		},
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+				Resources: map[string]string{
+					kptfilev1.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		draftPkgRev,
+	}, nil).Once()
+	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
+	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.True(t, deleted)
@@ -301,8 +414,7 @@ func TestDelete(t *testing.T) {
 	//=========================================================================================
 
 	// Package not found
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
 
 	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
 	assert.Error(t, err)
@@ -313,9 +425,9 @@ func TestDelete(t *testing.T) {
 	//=========================================================================================
 
 	// Error from DeletePackageRevision
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		packageRevision,
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		deletionProposedPkgRev,
 	}, nil).Once()
 	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
 	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("deletion failed")).Once()

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -82,7 +82,9 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 		},
 	}
 
-	filter, err := parsePackageRevisionResourcesFieldSelector(options)
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+
+	filter, err := parsePackageRevisionResourcesFieldSelector(options, ns)
 	if err != nil {
 		return nil, err
 	}
@@ -224,16 +226,11 @@ func (r *packageRevisionResources) Watch(ctx context.Context, options *metainter
 
 	ctx = context1.WithNewRequestID(ctx)
 
-	filter, err := parsePackageRevisionResourcesFieldSelector(options)
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+
+	filter, err := parsePackageRevisionResourcesFieldSelector(options, ns)
 	if err != nil {
 		return nil, err
-	}
-
-	if namespace, namespaced := genericapirequest.NamespaceFrom(ctx); namespaced {
-		if filter.Key.RKey().Namespace != "" && namespace != filter.Key.RKey().Namespace {
-			return nil, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filter.Key.RKey().Namespace)
-		}
-		filter.Key.PkgKey.RepoKey.Namespace = namespace
 	}
 
 	return createGenericWatch(ctx, r, *filter, func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {

--- a/pkg/registry/porch/packagerevisionresources_test.go
+++ b/pkg/registry/porch/packagerevisionresources_test.go
@@ -64,7 +64,7 @@ func setupResourcesTest(t *testing.T) (mockClient *mockclient.MockClient, mockEn
 
 func TestListResources(t *testing.T) {
 	_, mockEngine := setupResourcesTest(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision,
 	}, nil).Once()
 
@@ -83,7 +83,7 @@ func TestListResources(t *testing.T) {
 	//=========================================================================================
 
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		mockPkgRev,
 	}, nil)
 	mockPkgRev.On("GetResources", mock.Anything).Return(nil, errors.New("error getting API package revision")).Once()
@@ -95,12 +95,11 @@ func TestListResources(t *testing.T) {
 }
 
 func TestGetResources(t *testing.T) {
-	mockClient, mockEngine := setupResourcesTest(t)
+	_, mockEngine := setupResourcesTest(t)
 	pkgRevName := "repo.1234567890.ws"
 
 	// Success case
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision,
 	}, nil).Once()
 
@@ -113,8 +112,7 @@ func TestGetResources(t *testing.T) {
 	//=========================================================================================
 
 	// PRR Not found case
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Once()
 
 	result, err = packagerevisionresources.Get(ctx, pkgRevName, nil)
 	assert.Error(t, err)
@@ -124,8 +122,7 @@ func TestGetResources(t *testing.T) {
 
 	// Error from GetResources
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		mockPkgRev,
 	}, nil).Once()
 	mockPkgRev.On("KubeObjectName").Return(pkgRevName)
@@ -142,7 +139,7 @@ func TestWatchResources(t *testing.T) {
 	mockEngine.On("ObjectCache").Return(mockWatcherManager).Maybe()
 
 	mockWatcherManager.On("WatchPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Maybe()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Maybe()
 
 	watcher, err := packagerevisionresources.Watch(context.TODO(), &internalversion.ListOptions{})
 	assert.NoError(t, err)

--- a/pkg/registry/porch/storage.go
+++ b/pkg/registry/porch/storage.go
@@ -15,8 +15,6 @@
 package porch
 
 import (
-	"time"
-
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	"github.com/nephio-project/porch/pkg/engine"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,65 +27,55 @@ import (
 )
 
 type RESTStorageOptions struct {
-	Scheme               *runtime.Scheme
-	Codecs               serializer.CodecFactory
-	CaD                  engine.CaDEngine
-	CoreClient           client.WithWatch
-	TimeoutPerRepository time.Duration
-	MaxConcurrentLists   int
+	Scheme     *runtime.Scheme
+	Codecs     serializer.CodecFactory
+	CaD        engine.CaDEngine
+	CoreClient client.WithWatch
 }
 
 func (r *RESTStorageOptions) NewRESTStorage() (genericapiserver.APIGroupInfo, error) {
 	packages := &packages{
 		TableConvertor: packageTableConvertor,
 		packageCommon: packageCommon{
-			scheme:                   r.Scheme,
-			cad:                      r.CaD,
-			gr:                       porchapi.Resource("packages"),
-			coreClient:               r.CoreClient,
-			updateStrategy:           packageStrategy{},
-			createStrategy:           packageStrategy{},
-			ListTimeoutPerRepository: r.TimeoutPerRepository,
-			MaxConcurrentLists:       r.MaxConcurrentLists,
+			scheme:         r.Scheme,
+			cad:            r.CaD,
+			gr:             porchapi.Resource("packages"),
+			coreClient:     r.CoreClient,
+			updateStrategy: packageStrategy{},
+			createStrategy: packageStrategy{},
 		},
 	}
 
 	packageRevisions := &packageRevisions{
 		TableConvertor: packageRevisionTableConvertor,
 		packageCommon: packageCommon{
-			scheme:                   r.Scheme,
-			cad:                      r.CaD,
-			gr:                       porchapi.Resource("packagerevisions"),
-			coreClient:               r.CoreClient,
-			updateStrategy:           packageRevisionStrategy{},
-			createStrategy:           packageRevisionStrategy{},
-			ListTimeoutPerRepository: r.TimeoutPerRepository,
-			MaxConcurrentLists:       r.MaxConcurrentLists,
+			scheme:         r.Scheme,
+			cad:            r.CaD,
+			gr:             porchapi.Resource("packagerevisions"),
+			coreClient:     r.CoreClient,
+			updateStrategy: packageRevisionStrategy{},
+			createStrategy: packageRevisionStrategy{},
 		},
 	}
 
 	packageRevisionsApproval := &packageRevisionApproval{
 		packageCommon: packageCommon{
-			scheme:                   r.Scheme,
-			cad:                      r.CaD,
-			coreClient:               r.CoreClient,
-			gr:                       porchapi.Resource("packagerevisions"),
-			updateStrategy:           packageRevisionApprovalStrategy{},
-			createStrategy:           packageRevisionApprovalStrategy{},
-			ListTimeoutPerRepository: r.TimeoutPerRepository,
-			MaxConcurrentLists:       r.MaxConcurrentLists,
+			scheme:         r.Scheme,
+			cad:            r.CaD,
+			coreClient:     r.CoreClient,
+			gr:             porchapi.Resource("packagerevisions"),
+			updateStrategy: packageRevisionApprovalStrategy{},
+			createStrategy: packageRevisionApprovalStrategy{},
 		},
 	}
 
 	packageRevisionResources := &packageRevisionResources{
 		TableConvertor: packageRevisionResourcesTableConvertor,
 		packageCommon: packageCommon{
-			scheme:                   r.Scheme,
-			cad:                      r.CaD,
-			gr:                       porchapi.Resource("packagerevisionresources"),
-			coreClient:               r.CoreClient,
-			ListTimeoutPerRepository: r.TimeoutPerRepository,
-			MaxConcurrentLists:       r.MaxConcurrentLists,
+			scheme:     r.Scheme,
+			cad:        r.CaD,
+			gr:         porchapi.Resource("packagerevisionresources"),
+			coreClient: r.CoreClient,
 		},
 	}
 

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -16,7 +16,6 @@ package porch
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -58,15 +57,11 @@ func (r *packageRevisions) Watch(ctx context.Context, options *metainternalversi
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Watch", trace.WithAttributes())
 	defer span.End()
 
-	filter, err := parsePackageRevisionFieldSelector(options)
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+
+	filter, err := parsePackageRevisionFieldSelector(options, ns)
 	if err != nil {
 		return nil, err
-	}
-
-	if namespace, namespaced := genericapirequest.NamespaceFrom(ctx); namespaced {
-		if namespaceMatches, filteredNamespace := filter.MatchesNamespace(namespace); !namespaceMatches {
-			return nil, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filteredNamespace)
-		}
 	}
 
 	return createGenericWatch(ctx, r, *filter, func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {

--- a/test/mockery/mocks/porch/pkg/cache/types/mock_Cache.go
+++ b/test/mockery/mocks/porch/pkg/cache/types/mock_Cache.go
@@ -330,6 +330,74 @@ func (_c *MockCache_GetRepository_Call) RunAndReturn(run func(repositoryKey repo
 	return _c
 }
 
+// ListPackageRevisions provides a mock function for the type MockCache
+func (_mock *MockCache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	ret := _mock.Called(ctx, filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListPackageRevisions")
+	}
+
+	var r0 []repository.PackageRevision
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)); ok {
+		return returnFunc(ctx, filter)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter) []repository.PackageRevision); ok {
+		r0 = returnFunc(ctx, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]repository.PackageRevision)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, repository.ListPackageRevisionFilter) error); ok {
+		r1 = returnFunc(ctx, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockCache_ListPackageRevisions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListPackageRevisions'
+type MockCache_ListPackageRevisions_Call struct {
+	*mock.Call
+}
+
+// ListPackageRevisions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter repository.ListPackageRevisionFilter
+func (_e *MockCache_Expecter) ListPackageRevisions(ctx interface{}, filter interface{}) *MockCache_ListPackageRevisions_Call {
+	return &MockCache_ListPackageRevisions_Call{Call: _e.mock.On("ListPackageRevisions", ctx, filter)}
+}
+
+func (_c *MockCache_ListPackageRevisions_Call) Run(run func(ctx context.Context, filter repository.ListPackageRevisionFilter)) *MockCache_ListPackageRevisions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 repository.ListPackageRevisionFilter
+		if args[1] != nil {
+			arg1 = args[1].(repository.ListPackageRevisionFilter)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCache_ListPackageRevisions_Call) Return(packageRevisions []repository.PackageRevision, err error) *MockCache_ListPackageRevisions_Call {
+	_c.Call.Return(packageRevisions, err)
+	return _c
+}
+
+func (_c *MockCache_ListPackageRevisions_Call) RunAndReturn(run func(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)) *MockCache_ListPackageRevisions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OpenRepository provides a mock function for the type MockCache
 func (_mock *MockCache) OpenRepository(ctx context.Context, repositorySpec *v1alpha1.Repository) (repository.Repository, error) {
 	ret := _mock.Called(ctx, repositorySpec)

--- a/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
+++ b/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
@@ -257,8 +257,8 @@ func (_c *MockCaDEngine_FindAllUpstreamReferencesInRepositories_Call) RunAndRetu
 }
 
 // ListPackageRevisions provides a mock function for the type MockCaDEngine
-func (_mock *MockCaDEngine) ListPackageRevisions(ctx context.Context, repositorySpec *v1alpha1.Repository, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
-	ret := _mock.Called(ctx, repositorySpec, filter)
+func (_mock *MockCaDEngine) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	ret := _mock.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPackageRevisions")
@@ -266,18 +266,18 @@ func (_mock *MockCaDEngine) ListPackageRevisions(ctx context.Context, repository
 
 	var r0 []repository.PackageRevision
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)); ok {
-		return returnFunc(ctx, repositorySpec, filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)); ok {
+		return returnFunc(ctx, filter)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.ListPackageRevisionFilter) []repository.PackageRevision); ok {
-		r0 = returnFunc(ctx, repositorySpec, filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter) []repository.PackageRevision); ok {
+		r0 = returnFunc(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]repository.PackageRevision)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1alpha1.Repository, repository.ListPackageRevisionFilter) error); ok {
-		r1 = returnFunc(ctx, repositorySpec, filter)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, repository.ListPackageRevisionFilter) error); ok {
+		r1 = returnFunc(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -291,30 +291,24 @@ type MockCaDEngine_ListPackageRevisions_Call struct {
 
 // ListPackageRevisions is a helper method to define mock.On call
 //   - ctx context.Context
-//   - repositorySpec *v1alpha1.Repository
 //   - filter repository.ListPackageRevisionFilter
-func (_e *MockCaDEngine_Expecter) ListPackageRevisions(ctx interface{}, repositorySpec interface{}, filter interface{}) *MockCaDEngine_ListPackageRevisions_Call {
-	return &MockCaDEngine_ListPackageRevisions_Call{Call: _e.mock.On("ListPackageRevisions", ctx, repositorySpec, filter)}
+func (_e *MockCaDEngine_Expecter) ListPackageRevisions(ctx interface{}, filter interface{}) *MockCaDEngine_ListPackageRevisions_Call {
+	return &MockCaDEngine_ListPackageRevisions_Call{Call: _e.mock.On("ListPackageRevisions", ctx, filter)}
 }
 
-func (_c *MockCaDEngine_ListPackageRevisions_Call) Run(run func(ctx context.Context, repositorySpec *v1alpha1.Repository, filter repository.ListPackageRevisionFilter)) *MockCaDEngine_ListPackageRevisions_Call {
+func (_c *MockCaDEngine_ListPackageRevisions_Call) Run(run func(ctx context.Context, filter repository.ListPackageRevisionFilter)) *MockCaDEngine_ListPackageRevisions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *v1alpha1.Repository
+		var arg1 repository.ListPackageRevisionFilter
 		if args[1] != nil {
-			arg1 = args[1].(*v1alpha1.Repository)
-		}
-		var arg2 repository.ListPackageRevisionFilter
-		if args[2] != nil {
-			arg2 = args[2].(repository.ListPackageRevisionFilter)
+			arg1 = args[1].(repository.ListPackageRevisionFilter)
 		}
 		run(
 			arg0,
 			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -325,7 +319,7 @@ func (_c *MockCaDEngine_ListPackageRevisions_Call) Return(packageRevisions []rep
 	return _c
 }
 
-func (_c *MockCaDEngine_ListPackageRevisions_Call) RunAndReturn(run func(ctx context.Context, repositorySpec *v1alpha1.Repository, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)) *MockCaDEngine_ListPackageRevisions_Call {
+func (_c *MockCaDEngine_ListPackageRevisions_Call) RunAndReturn(run func(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)) *MockCaDEngine_ListPackageRevisions_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Cherry pick - Scalability Improvements 8: Per-repository queries should only be done against the CR cache, the DB cache should handle it as a single database query

---

## Description
<!-- Describe what this PR does and why -->
-What changed:
Moved per-repository listing logic from registry layer (packagecommon.go) to cache layer.
Added ListPackageRevisions method to Cache interface (both CR and DB cache).
Simplified CaD Engine interface: removed repositorySpec parameter from ListPackageRevisions.
DB cache now uses a single query instead of per-repository iteration.

-Why it's needed:
Performance: Eliminates the N+1 query problem and reduces overhead from iterating through repositories individually.
Better separation of concerns: Repository filtering belongs in the cache layer, not the registry layer.
Database efficiency: Single optimised query vs multiple repository-specific queries.

-How it works:
CR Cache: Handles repository iteration with worker pools and timeouts internally.
DB Cache: Uses a single database query (pkgRevListPRsFromDB) to fetch all matching package revisions at once.
Registry Layer: calls cad.ListPackageRevisions(ctx, filter) instead of complex iteration logic.
Result: Same API contract but with cache-specific optimisations (worker pools for CR, single query for DB).

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.

Examples:

- Microsoft Copilot to analyse the code
- Claude code to generate the function someNewFunctionIAdded()
- Amazon Q to generate unit tests
