### PR TITLE
Bump kpt version in Porch to v1.0.0-beta.62.1

### DIFF
--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -23,7 +23,7 @@ inputs:
   kpt-fallback-version:
     description: "Fallback kpt version if extraction from go.mod fails"
     required: false
-    default: "v1.0.0-beta.61.1"
+    default: "v1.0.0-beta.62.1"
   go-cache:
     description: "Enable Go module caching"
     required: false

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -97,7 +97,7 @@ version_go = "v1.25.3"
 version_git = "v2.51.2"
 version_kind = "v0.30.0"
 version_kube = "v1.34.2"
-version_kpt = "v1.0.0-beta.59"
+version_kpt = "v1.0.0-beta.62.1"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,9 @@ require (
 	github.com/google/go-containerregistry v0.20.6
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
-	github.com/kptdev/kpt v1.0.0-beta.62
+	github.com/kptdev/kpt v1.0.0-beta.62.1
 	github.com/kptdev/krm-functions-catalog/functions/go/apply-replacements v0.1.5
+	github.com/kptdev/krm-functions-catalog/functions/go/apply-setters v0.2.2
 	github.com/kptdev/krm-functions-catalog/functions/go/set-namespace v0.4.5
 	github.com/kptdev/krm-functions-catalog/functions/go/starlark v0.5.5
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.2
@@ -72,7 +73,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/kptdev/krm-functions-catalog/functions/go/apply-setters v0.2.2 // indirect
 	github.com/otiai10/copy v1.14.1 // indirect
 	github.com/prep/wasmexec v0.0.0-20220807105708-6554945c1dec // indirect
 	github.com/qri-io/starlib v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uq
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/kptdev/kpt v1.0.0-beta.62 h1:2IVYP+nPn4yYibUMHtWn4XFTC9KIfwGSkuLwdeK+vYo=
-github.com/kptdev/kpt v1.0.0-beta.62/go.mod h1:aCJRkqI2f1Q2d7McbmqXp3FWRMFyJRKpmuNhF8Xj2B4=
+github.com/kptdev/kpt v1.0.0-beta.62.1 h1:TIzz/12Uysrs+KuPpNMExHGChz8o6CQNKYL6b+z8z2Q=
+github.com/kptdev/kpt v1.0.0-beta.62.1/go.mod h1:9j5Q9sEBKA0nM0+mlLIFY5FRSskaR6/uX7xGkz0/g8w=
 github.com/kptdev/krm-functions-catalog/functions/go/apply-replacements v0.1.5 h1:IBYx+h8mYZ2mqfLetP6Kwzw3DwvVswk8E6Vu8BuNcyM=
 github.com/kptdev/krm-functions-catalog/functions/go/apply-replacements v0.1.5/go.mod h1:Wxd9xCmftcHf8b8Q3dvskY1psJ5knxBAxMZWUHD4L/I=
 github.com/kptdev/krm-functions-catalog/functions/go/apply-setters v0.2.2 h1:PZ4TcVzgad1OFuH4gHg4j2LKC2KXTuzfsQWil2knSlk=

--- a/pkg/engine/options.go
+++ b/pkg/engine/options.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt and Nephio Authors
+// Copyright 2022, 2024-2026 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/kptdev/kpt/pkg/fn"
-	"github.com/kptdev/kpt/pkg/lib/kptops"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/repository"
@@ -78,13 +77,6 @@ func WithGRPCFunctionRuntime(options GRPCRuntimeOptions) EngineOption {
 func WithFunctionRuntime(runtime fn.FunctionRuntime) EngineOption {
 	return EngineOptionFunc(func(engine *cadEngine) error {
 		engine.taskHandler.SetRuntime(runtime)
-		return nil
-	})
-}
-
-func WithSimpleFunctionRuntime() EngineOption {
-	return EngineOptionFunc(func(engine *cadEngine) error {
-		engine.taskHandler.SetRuntime(kptops.NewSimpleFunctionRuntime())
 		return nil
 	})
 }

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The kpt and Nephio Authors
+// Copyright 2025-2026 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
-	"github.com/kptdev/kpt/pkg/lib/kptops"
 	kptfn "github.com/kptdev/krm-functions-sdk/go/fn"
 	kptfileko "github.com/kptdev/krm-functions-sdk/go/fn/kptfileko"
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
@@ -222,7 +221,7 @@ func TestDoPrResourceMutations(t *testing.T) {
 
 	th := &genericTaskHandler{
 		runnerOptionsResolver: ror,
-		runtime:               kptops.NewSimpleFunctionRuntime(),
+		runtime:               NewSimpleFunctionRuntime(),
 	}
 
 	repoPr := &fakeextrepo.FakePackageRevision{

--- a/pkg/task/render_test.go
+++ b/pkg/task/render_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt and Nephio Authors
+// Copyright 2022, 2024-2026 The kpt and Nephio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
-	"github.com/kptdev/kpt/pkg/lib/kptops"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"
 	"github.com/nephio-project/porch/pkg/repository"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -35,7 +34,7 @@ func TestRender(t *testing.T) {
 
 	render := &renderPackageMutation{
 		runnerOptions: runnerOptions,
-		runtime:       kptops.NewSimpleFunctionRuntime(),
+		runtime:       NewSimpleFunctionRuntime(),
 	}
 
 	testdata, err := filepath.Abs(filepath.Join(".", "testdata", "simple-render"))

--- a/pkg/task/simpleruntime_test.go
+++ b/pkg/task/simpleruntime_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The kpt and Nephio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"context"
+	"io"
+
+	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/fn"
+	"github.com/kptdev/krm-functions-catalog/functions/go/apply-setters/applysetters"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+func NewSimpleFunctionRuntime() fn.FunctionRuntime {
+	return &runtime{}
+}
+
+type runtime struct{}
+
+var _ fn.FunctionRuntime = &runtime{}
+
+var processors = map[string]framework.ResourceListProcessorFunc{
+	"ghcr.io/kptdev/krm-functions-catalog/apply-setters:v0.2.0": applySetters,
+}
+
+func (*runtime) GetRunner(ctx context.Context, f *kptfilev1.Function) (fn.FunctionRunner, error) {
+	p, ok := processors[f.Image]
+	if !ok {
+		return nil, &fn.NotFoundError{Function: *f}
+	}
+	return &runner{ctx: ctx, processor: p}, nil
+}
+
+type runner struct {
+	ctx       context.Context
+	processor framework.ResourceListProcessorFunc
+}
+
+func (r *runner) Run(in io.Reader, out io.Writer) error {
+	rw := &kio.ByteReadWriter{Reader: in, Writer: out, KeepReaderAnnotations: true}
+	return framework.Execute(r.processor, rw)
+}
+
+func applySetters(rl *framework.ResourceList) error {
+	if rl.FunctionConfig == nil {
+		return nil
+	}
+	var as applysetters.ApplySetters
+	applysetters.Decode(rl.FunctionConfig, &as)
+	items, err := as.Filter(rl.Items)
+	if err != nil {
+		return err
+	}
+	rl.Items = items
+	return nil
+}


### PR DESCRIPTION
Bumps `github.com/kptdev/kpt` to `v1.0.0-beta.62.1`.

## Changes
- Version upgraded in all required files.
-  kptdev/kpt#4481 removed `kptops.NewSimpleFunctionRuntime()`, which `pkg/task` tests used to render packages in-process without a container runtime. A minimal, test-only replacement is added so the existing tests keep working without pulling in Docker/pods.

  ## Testing
  - Unit tests are passing
  - E2E and Cli tests are passing

## AI Disclosure
 - [x] I have used AI in the creation of this PR.
  - Amazon Q to diagnose the upstream removal in kptdev/kpt#4481 and update the affected test imports.