### PR TITLE
Cherry pick #1102 - Fix upgrade CLI to run get to find package revision  (#547)

### DIFF
--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -386,6 +386,9 @@ func (r *runner) findUpstreamName(pr *porchapi.PackageRevision) string {
 			return n
 		}
 		if pr.Status.UpstreamLock != nil {
+			if err := r.listPackageRevisions(); err != nil {
+				return ""
+			}
 			if up := r.findUpstreamByLock(pr.Status.UpstreamLock); up != nil {
 				return up.Name
 			}
@@ -402,18 +405,25 @@ func (r *runner) findEditOrigin(currentPr *porchapi.PackageRevision) string {
 	pr := currentPr
 	for pr != nil && pr.Spec.Tasks[0].Type == porchapi.TaskTypeEdit {
 		sourceName := pr.Spec.Tasks[0].Edit.Source.Name
-		pr = nil
-		for _, p := range r.prs {
-			if p.Name == sourceName {
-				pr = &p
-				break
-			}
-		}
+		pr = r.findPackageRevision(sourceName)
 	}
 	if pr != nil {
 		return r.findUpstreamName(pr)
 	}
 	return ""
+}
+
+func (r *runner) listPackageRevisions() error {
+	packageRevisionList := porchapi.PackageRevisionList{}
+	listOpts := []client.ListOption{}
+	if r.cfg.Namespace != nil && *r.cfg.Namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(*r.cfg.Namespace))
+	}
+	if err := r.client.List(r.ctx, &packageRevisionList, listOpts...); err != nil {
+		return err
+	}
+	r.prs = packageRevisionList.Items
+	return nil
 }
 
 func (r *runner) findUpstreamByLock(lock *porchapi.Locator) *porchapi.PackageRevision {

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -335,7 +335,8 @@ func TestFindEditOrigin(t *testing.T) {
 	const ns = "ns"
 	downstreamv1 := porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "downstream.v1",
+			Name:      "downstream.v1",
+			Namespace: ns,
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			Tasks: []porchapi.Task{
@@ -354,7 +355,8 @@ func TestFindEditOrigin(t *testing.T) {
 	}
 	downstreamv2 := porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "downstream.v2",
+			Name:      "downstream.v2",
+			Namespace: ns,
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			Tasks: []porchapi.Task{
@@ -372,13 +374,18 @@ func TestFindEditOrigin(t *testing.T) {
 	downstreamv3 := *downstreamv2.DeepCopy()
 	downstreamv3.Name = "downstream.v3"
 	downstreamv3.Spec.Tasks[0].Edit.Source = &porchapi.PackageRevisionRef{Name: "downstream.v2"}
-	prs := []porchapi.PackageRevision{
-		downstreamv1,
-		downstreamv2,
-		downstreamv3,
-	}
 
-	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+	scheme := runtime.NewScheme()
+	if err := porchapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add porch API to scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&downstreamv1, &downstreamv2, &downstreamv3).
+		Build()
+
+	// empty prs to force GET-based traversal in findEditOrigin
+	r := createRunner(context.Background(), c, []porchapi.PackageRevision{}, ns, 0)
 
 	found := r.findUpstreamName(&downstreamv3)
 	assert.Equal(t, "upstream.v1", found)
@@ -901,7 +908,8 @@ func TestFindUpstreamInEditTaskWithUpstreamLock(t *testing.T) {
 
 	editPr := porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "broken-edit-pr",
+			Name:      "broken-edit-pr",
+			Namespace: ns,
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			Tasks: []porchapi.Task{
@@ -928,7 +936,8 @@ func TestFindUpstreamInEditTaskWithUpstreamLock(t *testing.T) {
 
 	upstreamPr := porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "upstream-pr-v2",
+			Name:      "upstream-pr-v2",
+			Namespace: ns,
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			Revision:  2,
@@ -945,8 +954,26 @@ func TestFindUpstreamInEditTaskWithUpstreamLock(t *testing.T) {
 		},
 	}
 
-	prs := []porchapi.PackageRevision{editPr, upstreamPr}
-	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+	scheme := runtime.NewScheme()
+	if err := porchapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add porch API to scheme: %v", err)
+	}
+	interceptorFuncs := interceptor.Funcs{
+		List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if prList, ok := list.(*porchapi.PackageRevisionList); ok {
+				prList.Items = []porchapi.PackageRevision{editPr, upstreamPr}
+			}
+			return nil
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&editPr, &upstreamPr).
+		WithInterceptorFuncs(interceptorFuncs).
+		Build()
+
+	// empty prs to force listPackageRevisions call
+	r := createRunner(context.Background(), c, []porchapi.PackageRevision{}, ns, 0)
 
 	result := r.findUpstreamName(&editPr)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Fix the upgrade CLI to run get to find the package revision
---

## Description
<!-- Describe what this PR does and why -->
- What changed:  
 findEditOrigin now uses findPackageRevision (API GET) instead of searching r.prs to traverse the edit chain. listPackageRevisions has been added as a lazy loader for the findUpstreamByLock fallback.
Updated tests to not pre-populate the runner.
- Why it’s needed: 
Why it’s needed: r.prs is only populated in discover mode. In normal upgrade mode, it's empty, so the edit chain traversal always failed with "upstream source not found".
- How it works:  
findEditOrigin walks back through edit tasks one step at a time using GET calls until it hits a clone/upgrade task, then returns the upstream name. If the chain is broken (source deleted), it falls back to findUpstreamByLock, which lazily loads all package revisions via a single List call and matches by git lock info.
---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  https://github.com/nephio-project/porch/issues/808

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.

Examples:

- Microsoft Copilot to analyse the code
- Claude code to generate the function someNewFunctionIAdded()
- Amazon Q to generate unit tests
