### PR TITLE
Removing ability to Watch on PackageRevisionResources

### DIFF
--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
@@ -45,7 +44,6 @@ var _ rest.Getter = &packageRevisionResources{}
 var _ rest.Scoper = &packageRevisionResources{}
 var _ rest.Updater = &packageRevisionResources{}
 var _ rest.SingularNameProvider = &packageRevisionResources{}
-var _ rest.Watcher = &packageRevisionResources{}
 
 // GetSingularName implements the SingularNameProvider interface
 func (r *packageRevisionResources) GetSingularName() string {
@@ -217,23 +215,4 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 	klog.InfoS("[API] Update operation completed for PackageRevisionResources", context1.LogMetadataFrom(ctx)...)
 
 	return created, false, nil
-}
-
-// Watch supports watching for PackageRevisionResources changes.
-func (r *packageRevisionResources) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	ctx, span := tracer.Start(ctx, "[START]::packageRevisionResources::Watch", trace.WithAttributes())
-	defer span.End()
-
-	ctx = context1.WithNewRequestID(ctx)
-
-	ns, _ := genericapirequest.NamespaceFrom(ctx)
-
-	filter, err := parsePackageRevisionResourcesFieldSelector(options, ns)
-	if err != nil {
-		return nil, err
-	}
-
-	return createGenericWatch(ctx, r, *filter, func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {
-		return pr.GetResources(ctx)
-	}, options)
 }

--- a/pkg/registry/porch/packagerevisionresources_test.go
+++ b/pkg/registry/porch/packagerevisionresources_test.go
@@ -132,35 +132,3 @@ func TestGetResources(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
-
-func TestWatchResources(t *testing.T) {
-	_, mockEngine := setupResourcesTest(t)
-	mockWatcherManager := mockengine.NewMockWatcherManager(t)
-	mockEngine.On("ObjectCache").Return(mockWatcherManager).Maybe()
-
-	mockWatcherManager.On("WatchPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil).Maybe()
-
-	watcher, err := packagerevisionresources.Watch(context.TODO(), &internalversion.ListOptions{})
-	assert.NoError(t, err)
-	if watcher != nil {
-		watcher.Stop()
-	}
-
-	//=========================================================================================
-
-	watcher, err = packagerevisionresources.Watch(context.TODO(), &internalversion.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("invalid.field", "somethingOffTheWall"),
-	})
-	assert.Equal(t, nil, watcher)
-	assert.ErrorContains(t, err, "unknown fieldSelector field")
-
-	//=========================================================================================
-
-	ctxWithConflictNamespace := genericapirequest.WithNamespace(context.TODO(), "foo")
-	watcher, err = packagerevisionresources.Watch(ctxWithConflictNamespace, &internalversion.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("metadata.namespace", "somethingOffTheWall"),
-	})
-	assert.Equal(t, nil, watcher)
-	assert.ErrorContains(t, err, "conflicting namespaces specified")
-}

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -110,7 +110,7 @@ type packageReader interface {
 }
 
 // objectExtractor transforms a repository.PackageRevision into the appropriate
-// resource (PackageRevision or PackageRevisionResources).
+// resource (PackageRevision or others when implemented).
 type objectExtractor func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error)
 
 // listAndWatch implements watch by doing a list, then sending any observed changes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Removing ability to Watch on PackageRevisionResources

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  https://github.com/nephio-project/porch/pull/388/changes brought in by @r-yabyab  `--watch` for prr resource type along with tests and restructure of watch.go to be generic (not just packageRevision but also packageRevisionResources). 
- Why it’s needed:  Creates a lot of noise on the network as every resource change is watched
- How it works:  i removed the watch and test for PRR side. PR's should be unaffected kept the refactor on watch.go

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes https://github.com/nephio-project/porch/issues/802

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  try `kubectl get packagerevisionresources --watch ...` and you should get an unsupported message such as `Error from server (MethodNotAllowed): the server does not allow this method on the requested resource (get packagerevisionresources.porch.kpt.dev)`

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
I have not used AI in the creation of this PR.
