### PR TITLE
Cherrypick #502 - Store kptfile meta in the DB for PackageRevision queries

### DIFF
--- a/api/sql/porch-db-1.5.3-1.5.9.sql
+++ b/api/sql/porch-db-1.5.3-1.5.9.sql
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The kpt and Nephio Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+-- Add the kptfile_status column to cache Kptfile-derived status fields
+-- (conditions, upstreamLock) needed for serving PackageRevision API queries
+-- without re-parsing the Kptfile YAML on every read.
+--
+-- Existing rows default to '{}'. The Porch server automatically backfills
+-- this column on startup by reading each Kptfile resource from the resources
+-- table, parsing it, and storing the extracted status. It also backfills
+-- the spec column with readinessGates and packageMetadata from the Kptfile.
+-- No manual resync is required.
+
+ALTER TABLE package_revisions
+    ADD COLUMN IF NOT EXISTS kptfile_status TEXT NOT NULL DEFAULT '{}';

--- a/api/sql/porch-db.sql
+++ b/api/sql/porch-db.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS package_revisions (
     ext_pr_id        TEXT NOT NULL,
     latest           BOOLEAN NOT NULL DEFAULT FALSE,
     tasks            TEXT NOT NULL,
+    kptfile_status   TEXT NOT NULL DEFAULT '{}',
     PRIMARY KEY (k8s_name_space, k8s_name),
     CONSTRAINT fk_package
         FOREIGN KEY (k8s_name_space, package_k8s_name)

--- a/deployments/porch/3-porch-postgres-bundle.yaml
+++ b/deployments/porch/3-porch-postgres-bundle.yaml
@@ -351,6 +351,7 @@ data:
         ext_pr_id        TEXT NOT NULL,
         latest           BOOLEAN NOT NULL DEFAULT FALSE,
         tasks            TEXT NOT NULL,
+        kptfile_status   TEXT NOT NULL DEFAULT '{}',
         PRIMARY KEY (k8s_name_space, k8s_name),
         CONSTRAINT fk_package
             FOREIGN KEY (k8s_name_space, package_k8s_name)

--- a/pkg/cache/dbcache/dbcachefactory.go
+++ b/pkg/cache/dbcache/dbcachefactory.go
@@ -16,6 +16,7 @@ package dbcache
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nephio-project/porch/pkg/cache/repomap"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
@@ -33,6 +34,10 @@ func (f *DBCacheFactory) NewCache(ctx context.Context, options cachetypes.CacheO
 
 	if err := OpenDB(ctx, options); err != nil {
 		return nil, err
+	}
+
+	if err := backfillKptfileMeta(ctx); err != nil {
+		return nil, fmt.Errorf("kptfile_status backfill failed: %w", err)
 	}
 
 	return &dbCache{

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -89,11 +89,6 @@ type dbPackageRevision struct {
 	resources     map[string]string
 	kptfileStatus kptfileStatus
 
-	// gitDraftPR maintains the draft in the external git repository during editing (when pushDraftsToGit is true)
-	gitPRDraft repository.PackageRevisionDraft
-
-	// gitPR is the closed package revision in git (when pushDraftsToGit is true)
-	gitPR repository.PackageRevision
 }
 
 func (pr *dbPackageRevision) specReadinessGates() []porchapi.ReadinessGate {

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -88,6 +88,26 @@ type dbPackageRevision struct {
 	tasks         []porchapi.Task
 	resources     map[string]string
 	kptfileStatus kptfileStatus
+
+	// gitDraftPR maintains the draft in the external git repository during editing (when pushDraftsToGit is true)
+	gitPRDraft repository.PackageRevisionDraft
+
+	// gitPR is the closed package revision in git (when pushDraftsToGit is true)
+	gitPR repository.PackageRevision
+}
+
+func (pr *dbPackageRevision) specReadinessGates() []porchapi.ReadinessGate {
+	if pr.spec == nil {
+		return nil
+	}
+	return pr.spec.ReadinessGates
+}
+
+func (pr *dbPackageRevision) specPackageMetadata() *porchapi.PackageMetadata {
+	if pr.spec == nil {
+		return nil
+	}
+	return pr.spec.PackageMetadata
 }
 
 func (pr *dbPackageRevision) KubeObjectName() string {
@@ -205,40 +225,29 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 		return nil, fmt.Errorf("package revision %s has no associated repository (may be deleted or not yet cached)", pr.KubeObjectName())
 	}
 
-	readPR, err := pkgRevReadFromDB(ctx, pr.Key(), false)
-	if err != nil {
-		if pr.GetMeta().DeletionTimestamp != nil || strings.Contains(err.Error(), "sql: no rows in result set") {
-			// The PR is already deleted from the DB so we just return the metadata version of this PR that is just about to be removed from memory
-			readPR = pr
-		} else {
-			return nil, fmt.Errorf("package revision read on DB failed %+v, %q", pr.Key(), err)
-		}
-	}
-
-	_, upstreamLock, _ := readPR.GetUpstreamLock(ctx)
-	_, selfLock, _ := readPR.GetLock(ctx)
-	kf, _ := readPR.GetKptfile(ctx)
+	_, upstreamLock, _ := pr.GetUpstreamLock(ctx)
+	_, selfLock, _ := pr.GetLock(ctx)
 
 	status := porchapi.PackageRevisionStatus{
 		UpstreamLock: repository.KptUpstreamLock2APIUpstreamLock(upstreamLock),
 		SelfLock:     repository.KptUpstreamLock2APIUpstreamLock(selfLock),
-		Deployment:   readPR.repo.deployment,
-		Conditions:   repository.ToAPIConditions(kf),
+		Deployment:   pr.repo.deployment,
+		Conditions:   pr.kptfileStatus.Conditions,
 	}
 
-	if porchapi.LifecycleIsPublished(readPR.Lifecycle(ctx)) {
-		if !readPR.updated.IsZero() {
-			status.PublishedAt = metav1.Time{Time: readPR.updated}
+	if porchapi.LifecycleIsPublished(pr.Lifecycle(ctx)) {
+		if !pr.updated.IsZero() {
+			status.PublishedAt = metav1.Time{Time: pr.updated}
 		}
-		if readPR.updatedBy != "" {
-			status.PublishedBy = readPR.updatedBy
+		if pr.updatedBy != "" {
+			status.PublishedBy = pr.updatedBy
 		}
 	}
 
 	// Set the "latest" label
 	labels := pr.GetMeta().Labels
 
-	if readPR.latest {
+	if pr.latest {
 		// copy the labels in case the cached object is being read by another go routine
 		newLabels := make(map[string]string, len(labels))
 		maps.Copy(newLabels, labels)
@@ -252,29 +261,26 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 			APIVersion: porchapi.SchemeGroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              readPR.KubeObjectName(),
-			Namespace:         readPR.Key().RKey().Namespace,
-			UID:               readPR.UID(),
-			ResourceVersion:   readPR.ResourceVersion(),
-			CreationTimestamp: readPR.GetMeta().CreationTimestamp,
-			DeletionTimestamp: readPR.GetMeta().DeletionTimestamp,
+			Name:              pr.KubeObjectName(),
+			Namespace:         pr.Key().RKey().Namespace,
+			UID:               pr.UID(),
+			ResourceVersion:   pr.ResourceVersion(),
+			CreationTimestamp: pr.GetMeta().CreationTimestamp,
+			DeletionTimestamp: pr.GetMeta().DeletionTimestamp,
 			Labels:            labels,
-			OwnerReferences:   readPR.GetMeta().OwnerReferences,
-			Annotations:       readPR.GetMeta().Annotations,
-			Finalizers:        readPR.GetMeta().Finalizers,
+			OwnerReferences:   pr.GetMeta().OwnerReferences,
+			Annotations:       pr.GetMeta().Annotations,
+			Finalizers:        pr.GetMeta().Finalizers,
 		},
 		Spec: porchapi.PackageRevisionSpec{
-			PackageName:    readPR.Key().PKey().ToPkgPathname(),
-			RepositoryName: readPR.Key().RKey().Name,
-			Lifecycle:      readPR.Lifecycle(ctx),
-			Tasks:          readPR.tasks,
-			ReadinessGates: repository.ToAPIReadinessGates(kf),
-			WorkspaceName:  readPR.Key().WorkspaceName,
-			Revision:       readPR.Key().Revision,
-			PackageMetadata: &porchapi.PackageMetadata{
-				Labels:      kf.Labels,
-				Annotations: kf.Annotations,
-			},
+			PackageName:     pr.Key().PKey().ToPkgPathname(),
+			RepositoryName:  pr.Key().RKey().Name,
+			Lifecycle:       pr.Lifecycle(ctx),
+			Tasks:           pr.tasks,
+			ReadinessGates:  pr.specReadinessGates(),
+			WorkspaceName:   pr.Key().WorkspaceName,
+			Revision:        pr.Key().Revision,
+			PackageMetadata: pr.specPackageMetadata(),
 		},
 		Status: status,
 	}, nil
@@ -317,16 +323,10 @@ func (pr *dbPackageRevision) GetResources(ctx context.Context) (*porchapi.Packag
 }
 
 func (pr *dbPackageRevision) GetUpstreamLock(ctx context.Context) (kptfile.Upstream, kptfile.Locator, error) {
-	kf, err := pr.GetKptfile(ctx)
-	if err != nil {
-		return kptfile.Upstream{}, kptfile.Locator{}, fmt.Errorf("cannot determine package lock; cannot retrieve resources: %w", err)
-	}
-
-	if kf.Upstream == nil || kf.UpstreamLock == nil || kf.Upstream.Git == nil {
+	if pr.kptfileStatus.UpstreamLock == nil || pr.kptfileStatus.UpstreamLock.Git == nil {
 		return kptfile.Upstream{}, kptfile.Locator{}, nil
 	}
-
-	return *kf.Upstream, *kf.UpstreamLock, nil
+	return repository.KptUpstreamLock2KptUpstream(*pr.kptfileStatus.UpstreamLock), *pr.kptfileStatus.UpstreamLock, nil
 }
 
 func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) repository.PackageRevision {
@@ -340,15 +340,16 @@ func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) reposito
 			Revision:      -1,
 			WorkspaceName: pr.Key().RKey().PlaceholderWSname,
 		},
-		meta:      metav1.ObjectMeta{},
-		spec:      &porchapi.PackageRevisionSpec{},
-		updated:   time.Now(),
-		updatedBy: getCurrentUser(),
-		lifecycle: pr.lifecycle,
-		extPRID:   pr.extPRID,
-		latest:    false,
-		tasks:     pr.tasks,
-		resources: pr.resources,
+		meta:          metav1.ObjectMeta{},
+		spec:          &porchapi.PackageRevisionSpec{},
+		updated:       time.Now(),
+		updatedBy:     getCurrentUser(),
+		lifecycle:     pr.lifecycle,
+		extPRID:       pr.extPRID,
+		latest:        false,
+		tasks:         pr.tasks,
+		resources:     pr.resources,
+		kptfileStatus: pr.kptfileStatus,
 	}
 
 	mainPR.meta.CreationTimestamp = metav1.Time{Time: time.Now()}
@@ -451,6 +452,15 @@ func (pr *dbPackageRevision) UpdateResources(ctx context.Context, new *porchapi.
 	}()
 
 	pr.resources = new.Spec.Resources
+	status, gates, pkgMeta := extractFromKptfile(pr.resources)
+	pr.kptfileStatus = status
+	if gates != nil || pkgMeta != nil {
+		if pr.spec == nil {
+			pr.spec = &porchapi.PackageRevisionSpec{}
+		}
+		pr.spec.ReadinessGates = gates
+		pr.spec.PackageMetadata = pkgMeta
+	}
 
 	if kfString, ok := new.Spec.Resources[kptfile.KptFileName]; ok {
 		if kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfString)); err == nil {

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -101,7 +101,7 @@ func (t *DbTestSuite) TestDBPackageRevision() {
 	t.Equal(porchapi.PackageRevisionLifecycleDraft, dbPR.Lifecycle(ctx))
 
 	newPrUp, newPrUpLock, err := dbPR.GetUpstreamLock(ctx)
-	t.Require().NotNil(err)
+	t.Require().NoError(err)
 	t.Require().Nil(newPrUp.Git)
 	t.Require().Nil(newPrUpLock.Git)
 
@@ -404,4 +404,214 @@ func (t *DbTestSuite) TestDBDeleteLatestRevision() {
 	// Clean up
 	err = repoDeleteFromDB(ctx, dbRepo.Key())
 	t.Require().NoError(err)
+}
+
+func (t *DbTestSuite) TestExtractFromKptfile() {
+	t.Run("WithConditions", func() {
+		resources := map[string]string{
+			"Kptfile": `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-pkg
+  labels:
+    app: web
+  annotations:
+    team: platform
+info:
+  readinessGates:
+    - conditionType: Ready
+    - conditionType: Available
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: AllGood
+      message: everything is fine`,
+		}
+		s, gates, pkgMeta := extractFromKptfile(resources)
+		t.Len(s.Conditions, 1)
+		t.Equal("Ready", s.Conditions[0].Type)
+		t.Equal(porchapi.ConditionTrue, s.Conditions[0].Status)
+		t.Len(gates, 2)
+		t.Equal("Ready", gates[0].ConditionType)
+		t.Equal("Available", gates[1].ConditionType)
+		t.Equal("web", pkgMeta.Labels["app"])
+		t.Equal("platform", pkgMeta.Annotations["team"])
+	})
+
+	t.Run("NoKptfile", func() {
+		resources := map[string]string{"other.yaml": "data: true"}
+		s, gates, pkgMeta := extractFromKptfile(resources)
+		t.Empty(s.Conditions)
+		t.Nil(gates)
+		t.Nil(pkgMeta)
+	})
+
+	t.Run("InvalidKptfile", func() {
+		resources := map[string]string{"Kptfile": "not: valid: yaml: ["}
+		s, _, _ := extractFromKptfile(resources)
+		t.Empty(s.Conditions)
+	})
+
+	t.Run("MinimalKptfile", func() {
+		resources := map[string]string{
+			"Kptfile": `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: minimal`,
+		}
+		s, gates, pkgMeta := extractFromKptfile(resources)
+		t.Empty(s.Conditions)
+		t.Nil(s.UpstreamLock)
+		t.Empty(gates)
+		t.Nil(pkgMeta.Labels)
+		t.Nil(pkgMeta.Annotations)
+	})
+
+	t.Run("WithUpstreamLock", func() {
+		resources := map[string]string{
+			"Kptfile": `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-pkg
+upstreamLock:
+  type: git
+  git:
+    repo: https://example.com/repo.git
+    directory: my-pkg
+    ref: main
+    commit: abc123`,
+		}
+		s, _, _ := extractFromKptfile(resources)
+		t.Require().NotNil(s.UpstreamLock)
+		t.Equal("https://example.com/repo.git", s.UpstreamLock.Git.Repo)
+		t.Equal("my-pkg", s.UpstreamLock.Git.Directory)
+		t.Equal("abc123", s.UpstreamLock.Git.Commit)
+	})
+}
+
+func (t *DbTestSuite) TestKptfileStatusRoundTrip() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo("kfmeta-ns", "kfmeta-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "kfmeta-pkg")
+
+	kfYAML := `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-pkg
+  labels:
+    app: web
+  annotations:
+    team: platform
+info:
+  readinessGates:
+    - conditionType: Ready
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Deployed
+      message: all good`
+
+	resources := map[string]string{"Kptfile": kfYAML}
+	status, gates, pkgMeta := extractFromKptfile(resources)
+	pr := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-1",
+			Revision:      1,
+		},
+		lifecycle:     "Published",
+		spec:          &porchapi.PackageRevisionSpec{ReadinessGates: gates, PackageMetadata: pkgMeta},
+		kptfileStatus: status,
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr))
+
+	filter := repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: dbRepo.Key()}},
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Require().Len(results, 1)
+
+	readPR := results[0]
+	t.Len(readPR.kptfileStatus.Conditions, 1)
+	t.Equal("Ready", readPR.kptfileStatus.Conditions[0].Type)
+	t.Equal(porchapi.ConditionTrue, readPR.kptfileStatus.Conditions[0].Status)
+	t.Equal("Deployed", readPR.kptfileStatus.Conditions[0].Reason)
+	t.Len(readPR.spec.ReadinessGates, 1)
+	t.Equal("Ready", readPR.spec.ReadinessGates[0].ConditionType)
+	t.Equal("web", readPR.spec.PackageMetadata.Labels["app"])
+	t.Equal("platform", readPR.spec.PackageMetadata.Annotations["team"])
+
+	t.deleteTestRepo(dbRepo.Key())
+}
+
+func (t *DbTestSuite) TestBackfillKptfileMeta() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo("backfill-ns", "backfill-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "backfill-pkg")
+
+	// Write a PR with empty kptfileMeta (simulating pre-migration row)
+	pr := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-1",
+			Revision:      1,
+		},
+		lifecycle: "Published",
+		resources: map[string]string{
+			"Kptfile": `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: backfill-test
+  labels:
+    app: backfilled
+info:
+  readinessGates:
+    - conditionType: Ready
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: OK`,
+		},
+		// kptfileStatus intentionally left empty to simulate pre-migration state
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr))
+
+	// Verify kptfile_status is empty in DB
+	filter := repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{PkgKey: repository.PackageKey{RepoKey: dbRepo.Key()}},
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Require().Len(results, 1)
+	t.Empty(results[0].kptfileStatus.Conditions)
+
+	// Run backfill
+	err = backfillKptfileMeta(t.Context())
+	t.Require().NoError(err)
+
+	// Verify kptfile_status (status) and spec are now populated
+	results, err = pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Require().Len(results, 1)
+	t.Equal("backfilled", results[0].spec.PackageMetadata.Labels["app"])
+	t.Len(results[0].spec.ReadinessGates, 1)
+	t.Equal("Ready", results[0].spec.ReadinessGates[0].ConditionType)
+	t.Len(results[0].kptfileStatus.Conditions, 1)
+	t.Equal("Ready", results[0].kptfileStatus.Conditions[0].Type)
+
+	// Run backfill again — should be a no-op (kptfile_status is no longer '{}')
+	err = backfillKptfileMeta(t.Context())
+	t.Require().NoError(err)
+
+	t.deleteTestRepo(dbRepo.Key())
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -19,6 +19,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	kptfile "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"github.com/nephio-project/porch/pkg/repository"
 	"go.opentelemetry.io/otel/trace"
@@ -49,7 +51,8 @@ func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, re
 			package_revisions.lifecycle,
 			package_revisions.ext_pr_id,
 			package_revisions.latest,
-			package_revisions.tasks
+			package_revisions.tasks,
+			package_revisions.kptfile_status
 		FROM package_revisions INNER JOIN packages
 			ON package_revisions.k8s_name_space=packages.k8s_name_space AND package_revisions.package_k8s_name=packages.k8s_name
 		 INNER JOIN repositories
@@ -120,7 +123,8 @@ func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevis
 			package_revisions.lifecycle,
 			package_revisions.ext_pr_id,
 			package_revisions.latest,
-			package_revisions.tasks
+			package_revisions.tasks,
+			package_revisions.kptfile_status
 		FROM package_revisions
 		INNER JOIN packages
 			ON package_revisions.k8s_name_space=packages.k8s_name_space AND package_revisions.package_k8s_name=packages.k8s_name
@@ -168,7 +172,8 @@ func pkgRevReadPRsFromDB(ctx context.Context, pk repository.PackageKey) ([]*dbPa
 			package_revisions.lifecycle,
 			package_revisions.ext_pr_id,
 			package_revisions.latest,
-			package_revisions.tasks
+			package_revisions.tasks,
+			package_revisions.kptfile_status
 		FROM package_revisions INNER JOIN packages
 			ON package_revisions.k8s_name_space=packages.k8s_name_space AND package_revisions.package_k8s_name=packages.k8s_name
 		 INNER JOIN repositories
@@ -217,7 +222,8 @@ func pkgRevReadLatestPRFromDB(ctx context.Context, pk repository.PackageKey) (*d
 			package_revisions.lifecycle,
 			package_revisions.ext_pr_id,
 			package_revisions.latest,
-			package_revisions.tasks
+			package_revisions.tasks,
+			package_revisions.kptfile_status
 		FROM package_revisions INNER JOIN packages
 			ON package_revisions.k8s_name_space=packages.k8s_name_space AND package_revisions.package_k8s_name=packages.k8s_name
 		 INNER JOIN repositories
@@ -284,7 +290,7 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 
 	for rows.Next() {
 		var pkgRev dbPackageRevision
-		var pkgK8SName, prK8SName, metaAsJSON, specAsJSON, extPRID, tasks string
+		var pkgK8SName, prK8SName, metaAsJSON, specAsJSON, extPRID, tasks, kptfileStatusJSON string
 
 		err := rows.Scan(
 			&pkgRev.pkgRevKey.PkgKey.RepoKey.Namespace,
@@ -303,7 +309,8 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 			&pkgRev.lifecycle,
 			&extPRID,
 			&pkgRev.latest,
-			&tasks)
+			&tasks,
+			&kptfileStatusJSON)
 
 		if err != nil {
 			klog.Warningf("pkgRevScanRowsFromDB: scanning rows failed: %q", err)
@@ -324,6 +331,7 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 		setValueFromJSON(specAsJSON, &pkgRev.spec)
 		setValueFromJSON(extPRID, &pkgRev.extPRID)
 		setValueFromJSON(tasks, &pkgRev.tasks)
+		setValueFromJSON(kptfileStatusJSON, &pkgRev.kptfileStatus)
 
 		dbPkgRevs = append(dbPkgRevs, &pkgRev)
 	}
@@ -338,8 +346,8 @@ func pkgRevWriteToDB(ctx context.Context, pr *dbPackageRevision) error {
 	klog.V(5).Infof("pkgRevWriteToDB: writing package revision %+v", pr.Key())
 
 	sqlStatement := `
-        INSERT INTO package_revisions (k8s_name_space, k8s_name, package_k8s_name, revision, meta, spec, updated, updatedby, lifecycle, ext_pr_id, tasks)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        INSERT INTO package_revisions (k8s_name_space, k8s_name, package_k8s_name, revision, meta, spec, updated, updatedby, lifecycle, ext_pr_id, tasks, kptfile_status)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`
 
 	klog.V(6).Infof("pkgRevWriteToDB: running query %q on package revision %+v", sqlStatement, pr)
@@ -347,7 +355,7 @@ func pkgRevWriteToDB(ctx context.Context, pr *dbPackageRevision) error {
 	if _, err := GetDB().db.Exec(ctx,
 		sqlStatement,
 		prk.K8SNS(), prk.K8SName(),
-		prk.PKey().K8SName(), prk.Revision, valueAsJSON(pr.meta), valueAsJSON(pr.spec), pr.updated, pr.updatedBy, pr.lifecycle, valueAsJSON(pr.extPRID), valueAsJSON(pr.tasks)); err == nil {
+		prk.PKey().K8SName(), prk.Revision, valueAsJSON(pr.meta), valueAsJSON(pr.spec), pr.updated, pr.updatedBy, pr.lifecycle, valueAsJSON(pr.extPRID), valueAsJSON(pr.tasks), valueAsJSON(pr.kptfileStatus)); err == nil {
 		klog.V(5).Infof("pkgRevWriteToDB: query succeeded, row created")
 	} else {
 		klog.Warningf("pkgRevWriteToDB: query failed for %+v %q", pr.Key(), err)
@@ -370,15 +378,15 @@ func pkgRevUpdateDB(ctx context.Context, pr *dbPackageRevision, updateResources 
 	klog.V(5).Infof("pkgRevUpdateDB: updating package revision %+v", pr.Key())
 
 	sqlStatement := `
-        UPDATE package_revisions SET package_k8s_name=$3, revision=$4, meta=$5, spec=$6, updated=$7, updatedby=$8, lifecycle=$9, ext_pr_id=$10, tasks=$11
+        UPDATE package_revisions SET package_k8s_name=$3, revision=$4, meta=$5, spec=$6, updated=$7, updatedby=$8, lifecycle=$9, ext_pr_id=$10, tasks=$11, kptfile_status=$12
         WHERE k8s_name_space=$1 AND k8s_name=$2
 	`
 	if pr.pkgRevKey.Revision == -1 {
 		sqlStatement = `
     INSERT INTO package_revisions (
-        k8s_name_space, k8s_name, package_k8s_name, revision, meta, spec, updated, updatedby, lifecycle, ext_pr_id, tasks
+        k8s_name_space, k8s_name, package_k8s_name, revision, meta, spec, updated, updatedby, lifecycle, ext_pr_id, tasks, kptfile_status
     ) VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
     )
     ON CONFLICT (k8s_name_space, k8s_name)
     DO UPDATE SET
@@ -390,7 +398,8 @@ func pkgRevUpdateDB(ctx context.Context, pr *dbPackageRevision, updateResources 
         updatedby        = EXCLUDED.updatedby,
         lifecycle        = EXCLUDED.lifecycle,
         ext_pr_id        = EXCLUDED.ext_pr_id,
-        tasks            = EXCLUDED.tasks;
+        tasks            = EXCLUDED.tasks,
+        kptfile_status     = EXCLUDED.kptfile_status;
 	`
 	}
 
@@ -399,7 +408,7 @@ func pkgRevUpdateDB(ctx context.Context, pr *dbPackageRevision, updateResources 
 	result, err := GetDB().db.Exec(ctx,
 		sqlStatement,
 		prk.K8SNS(), prk.K8SName(),
-		prk.PKey().K8SName(), prk.Revision, valueAsJSON(pr.meta), valueAsJSON(pr.spec), pr.updated, pr.updatedBy, pr.lifecycle, valueAsJSON(pr.extPRID), valueAsJSON(pr.tasks))
+		prk.PKey().K8SName(), prk.Revision, valueAsJSON(pr.meta), valueAsJSON(pr.spec), pr.updated, pr.updatedBy, pr.lifecycle, valueAsJSON(pr.extPRID), valueAsJSON(pr.tasks), valueAsJSON(pr.kptfileStatus))
 
 	if err == nil {
 		if rowsAffected, _ := result.RowsAffected(); rowsAffected == 1 {
@@ -479,4 +488,63 @@ func findUpstreamRefsFromDB(ctx context.Context, namespace, prName string) (stri
 		return "", err
 	}
 	return downstreamName, nil
+}
+
+// backfillKptfileMeta populates the kptfile_status column for any package
+// revisions that still have the default empty value. It reads the Kptfile
+// resource for each such row, parses it, and stores the extracted status
+// (conditions, upstreamLock) and updates the spec (readinessGates, packageMetadata).
+// This runs once on startup to handle rows created before the column existed.
+func backfillKptfileMeta(ctx context.Context) error {
+	tx, err := GetDB().db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("backfillKptfileMeta: begin transaction failed: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	sqlSelect := `
+		SELECT pr.k8s_name_space, pr.k8s_name, pr.spec, r.resource_value
+		FROM package_revisions pr
+		JOIN resources r ON pr.k8s_name_space = r.k8s_name_space AND pr.k8s_name = r.k8s_name
+		WHERE pr.kptfile_status = '{}' AND r.resource_key = 'Kptfile'
+	`
+	rows, err := tx.QueryContext(ctx, sqlSelect)
+	if err != nil {
+		return fmt.Errorf("backfillKptfileMeta: query failed: %w", err)
+	}
+
+	type row struct{ ns, name, specJSON, kfYAML string }
+	var pending []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.ns, &r.name, &r.specJSON, &r.kfYAML); err != nil {
+			rows.Close()
+			return fmt.Errorf("backfillKptfileMeta: scan failed: %w", err)
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+
+	sqlUpdate := `UPDATE package_revisions SET kptfile_status = $3, spec = $4 WHERE k8s_name_space = $1 AND k8s_name = $2`
+	for _, r := range pending {
+		resources := map[string]string{kptfile.KptFileName: r.kfYAML}
+		status, gates, pkgMeta := extractFromKptfile(resources)
+
+		var spec porchapi.PackageRevisionSpec
+		setValueFromJSON(r.specJSON, &spec)
+		spec.ReadinessGates = gates
+		spec.PackageMetadata = pkgMeta
+
+		if _, err := tx.ExecContext(ctx, sqlUpdate, r.ns, r.name, valueAsJSON(status), valueAsJSON(spec)); err != nil {
+			return fmt.Errorf("backfillKptfileMeta: update failed for %s/%s: %w", r.ns, r.name, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("backfillKptfileMeta: commit failed: %w", err)
+	}
+	if len(pending) > 0 {
+		klog.Infof("backfillKptfileMeta: populated kptfile_status for %d package revisions", len(pending))
+	}
+	return nil
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -467,6 +467,68 @@ func (t *DbTestSuite) TestPackageRevisionFilter() {
 	t.Empty(t.readRepoPkgPRs(dbRepoPkgs))
 }
 
+func (t *DbTestSuite) TestPackageRevisionFilterByKptfileLabels() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo("label-ns", "label-repo")
+	dbPkg := t.createTestPkg(dbRepo.Key(), "label-pkg")
+
+	pr := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-1",
+			Revision:      1,
+		},
+		lifecycle: "Published",
+		spec: &porchapi.PackageRevisionSpec{
+			PackageMetadata: &porchapi.PackageMetadata{
+				Labels: map[string]string{"app": "web", "env": "prod"},
+			},
+		},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr))
+
+	pr2 := dbPackageRevision{
+		pkgRevKey: repository.PackageRevisionKey{
+			PkgKey:        dbPkg.Key(),
+			WorkspaceName: "ws-2",
+			Revision:      2,
+		},
+		lifecycle: "Published",
+		spec: &porchapi.PackageRevisionSpec{
+			PackageMetadata: &porchapi.PackageMetadata{
+				Labels: map[string]string{"app": "api", "env": "prod"},
+			},
+		},
+	}
+	t.Require().NoError(pkgRevWriteToDB(t.Context(), &pr2))
+
+	// Filter by matching label
+	filter := repository.ListPackageRevisionFilter{
+		KptfileLabels: map[string]string{"app": "web"},
+	}
+	results, err := pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 1)
+	t.Equal("ws-1", results[0].Key().WorkspaceName)
+
+	// Filter by shared label
+	filter.KptfileLabels = map[string]string{"env": "prod"}
+	results, err = pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Len(results, 2)
+
+	// Filter by non-existent label
+	filter.KptfileLabels = map[string]string{"app": "missing"}
+	results, err = pkgRevListPRsFromDB(t.Context(), filter)
+	t.Require().NoError(err)
+	t.Empty(results)
+
+	t.deleteTestRepo(dbRepo.Key())
+}
+
 func (t *DbTestSuite) TestMultiPackageRevisionList() {
 	mockCache := mockcachetypes.NewMockCache(t.T())
 	cachetypes.CacheInstance = mockCache

--- a/pkg/cache/dbcache/dbsql.go
+++ b/pkg/cache/dbcache/dbsql.go
@@ -22,6 +22,7 @@ import (
 
 type dbSQLInterface interface {
 	Close() error
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	Exec(ctx context.Context, query string, args ...any) (sql.Result, error)
 	Query(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRow(ctx context.Context, query string, args ...any) *sql.Row
@@ -38,6 +39,14 @@ func (ds *dbSQL) Close() error {
 		return ds.db.Close()
 	} else {
 		return fmt.Errorf("cannot close database, database is not initialized")
+	}
+}
+
+func (ds *dbSQL) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	if ds.db != nil {
+		return ds.db.BeginTx(ctx, opts)
+	} else {
+		return nil, fmt.Errorf("cannot begin transaction, database is not initialized")
 	}
 }
 

--- a/test/mockery/mocks/porch/pkg/cache/dbcache/mock_dbSQLInterface.go
+++ b/test/mockery/mocks/porch/pkg/cache/dbcache/mock_dbSQLInterface.go
@@ -38,6 +38,74 @@ func (_m *MockdbSQLInterface) EXPECT() *MockdbSQLInterface_Expecter {
 	return &MockdbSQLInterface_Expecter{mock: &_m.Mock}
 }
 
+// BeginTx provides a mock function for the type MockdbSQLInterface
+func (_mock *MockdbSQLInterface) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	ret := _mock.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BeginTx")
+	}
+
+	var r0 *sql.Tx
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *sql.TxOptions) (*sql.Tx, error)); ok {
+		return returnFunc(ctx, opts)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *sql.TxOptions) *sql.Tx); ok {
+		r0 = returnFunc(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Tx)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *sql.TxOptions) error); ok {
+		r1 = returnFunc(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockdbSQLInterface_BeginTx_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BeginTx'
+type MockdbSQLInterface_BeginTx_Call struct {
+	*mock.Call
+}
+
+// BeginTx is a helper method to define mock.On call
+//   - ctx context.Context
+//   - opts *sql.TxOptions
+func (_e *MockdbSQLInterface_Expecter) BeginTx(ctx interface{}, opts interface{}) *MockdbSQLInterface_BeginTx_Call {
+	return &MockdbSQLInterface_BeginTx_Call{Call: _e.mock.On("BeginTx", ctx, opts)}
+}
+
+func (_c *MockdbSQLInterface_BeginTx_Call) Run(run func(ctx context.Context, opts *sql.TxOptions)) *MockdbSQLInterface_BeginTx_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *sql.TxOptions
+		if args[1] != nil {
+			arg1 = args[1].(*sql.TxOptions)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockdbSQLInterface_BeginTx_Call) Return(tx *sql.Tx, err error) *MockdbSQLInterface_BeginTx_Call {
+	_c.Call.Return(tx, err)
+	return _c
+}
+
+func (_c *MockdbSQLInterface_BeginTx_Call) RunAndReturn(run func(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)) *MockdbSQLInterface_BeginTx_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function for the type MockdbSQLInterface
 func (_mock *MockdbSQLInterface) Close() error {
 	ret := _mock.Called()


### PR DESCRIPTION
## Title
<!-- Short, descriptive title for the PR -->
Store kptfile meta in the DB for PackageRevision queries

---

## Description
<!-- Describe what this PR does and why -->

-What changed: KPTFile metadata that's needed for serving PackageRevision requests
-Why it’s needed: Parsing Kptfiles for each of the PackageRevision query requests is expensive
-How it works: Extracts Kptfile info at update.
---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  https://github.com/nephio-project/porch/issues/796

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---
