### PR TITLE
Cherrypick #536 - Move deletion validation out of the webhook and into delete request validations

### DIFF
--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,7 +37,6 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"go.opentelemetry.io/otel"
 
-	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/nephio-project/porch/pkg/util"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -52,29 +50,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type WebhookType string
-
-const (
-	WebhookTypeService           WebhookType = "service"
-	WebhookTypeUrl               WebhookType = "url"
-	serverEndpoint                           = "/validate-deletion"
-	repositoryValidationEndpoint             = "/validate-repository"
-)
+const repositoryValidationEndpoint = "/validate-repository"
 
 var (
 	cert        tls.Certificate
 	certModTime time.Time
 )
 
-var tracer = otel.Tracer("deletion-webhook")
+var tracer = otel.Tracer("repository-webhook")
 
-// WebhookConfig defines the configuration for the PackageRevision deletion webhook
+// WebhookConfig defines the configuration for the Repository validation webhook
 type WebhookConfig struct {
-	Type                 WebhookType
-	ServiceName          string // only used if Type == WebhookTypeService
-	ServiceNamespace     string // only used if Type == WebhookTypeService
-	Host                 string // only used if Type == WebhookTypeUrl
-	Path                 string
 	Port                 int32
 	RepositoryPath       string
 	RepoServiceName      string
@@ -88,22 +74,6 @@ type WebhookConfig struct {
 // newWebhookConfig creates a new WebhookConfig object filled with values read from environment variables
 func newWebhookConfig(ctx context.Context) *WebhookConfig {
 	var cfg WebhookConfig
-	// NOTE: CERT_NAMESPACE is supported for backward compatibility.
-	// TODO: We may consider using only WEBHOOK_SERVICE_NAMESPACE instead.
-	if hasEnv("CERT_NAMESPACE") ||
-		hasEnv("WEBHOOK_SERVICE_NAME") ||
-		hasEnv("WEBHOOK_SERVICE_NAMESPACE") ||
-		!hasEnv("WEBHOOK_HOST") {
-
-		cfg.Type = WebhookTypeService
-		cfg.ServiceName, cfg.ServiceNamespace = webhookServiceName(ctx)
-		cfg.Host = fmt.Sprintf("%s.%s.svc", cfg.ServiceName, cfg.ServiceNamespace)
-	} else {
-		cfg.Type = WebhookTypeUrl
-		cfg.Host = getEnv("WEBHOOK_HOST", "localhost")
-	}
-	cfg.Path = serverEndpoint
-	// Always use the WebhookTypeService for repository webhook validation
 	cfg.RepositoryPath = repositoryValidationEndpoint
 	cfg.RepoServiceName, cfg.RepoServiceNamespace = webhookServiceName(ctx)
 	cfg.RepoHost = fmt.Sprintf("%s.%s.svc", cfg.RepoServiceName, cfg.RepoServiceNamespace)
@@ -167,6 +137,10 @@ func webhookServiceName(ctx context.Context) (serviceName, serviceNamespace stri
 
 func setupWebhooks(ctx context.Context, clientReader client.Reader) error {
 	cfg := newWebhookConfig(ctx)
+	// TODO: Refactor webhook setup to support optional webhooks and better separation of concerns.
+	// Currently webhooks are always enabled and required for Repository validation.
+	// Consider: 1) Making webhooks optional via explicit flag, 2) Separating cert management from webhook lifecycle,
+	// 3) Supporting webhook-less mode for development/testing.
 	if !cfg.CertManWebhook {
 		caBytes, err := createCerts(cfg)
 		if err != nil {
@@ -184,17 +158,9 @@ func setupWebhooks(ctx context.Context, clientReader client.Reader) error {
 }
 
 func createCerts(cfg *WebhookConfig) ([]byte, error) {
-	klog.Infof("creating self-signing TLS cert and key for %q in directory %s", cfg.Host, cfg.CertStorageDir)
-	commonName := cfg.Host
+	klog.Infof("creating self-signing TLS cert and key for %q in directory %s", cfg.RepoHost, cfg.CertStorageDir)
+	commonName := cfg.RepoHost
 	dnsNames := []string{commonName}
-	if cfg.Type == WebhookTypeService {
-		dnsNames = append(dnsNames, cfg.ServiceName)
-		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s", cfg.ServiceName, cfg.ServiceNamespace))
-		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.svc", cfg.ServiceName, cfg.ServiceNamespace))
-		dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.svc.cluster.local", cfg.ServiceName, cfg.ServiceNamespace))
-	}
-
-	// DNS names for CA config - repository-validating-webhook
 	dnsNames = append(dnsNames, cfg.RepoServiceName)
 	dnsNames = append(dnsNames, fmt.Sprintf("%s.%s", cfg.RepoServiceName, cfg.RepoServiceNamespace))
 	dnsNames = append(dnsNames, fmt.Sprintf("%s.%s.svc", cfg.RepoServiceName, cfg.RepoServiceNamespace))
@@ -296,7 +262,7 @@ func WriteFile(filepath string, c []byte) error {
 
 func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []byte) error {
 
-	klog.Infof("Creating validating webhook for %s:%d", cfg.Host, cfg.Port)
+	klog.Infof("Creating validating webhook for %s:%d", cfg.RepoHost, cfg.Port)
 
 	kubeConfig := ctrl.GetConfigOrDie()
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
@@ -306,38 +272,10 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 	// Set max timeout value for ValidatingWebhooks
 	cfg.timeout = 30
 	var (
-		validationCfgName = "packagerev-deletion-validating-webhook"
 		repositoryCfgName = "repository-validating-webhook"
 		fail              = admissionregistrationv1.Fail
 		none              = admissionregistrationv1.SideEffectClassNone
 	)
-
-	// Webhook for PackageRevision deletion
-	validateConfig := &admissionregistrationv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: validationCfgName,
-		},
-		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
-			Name: "packagerevdeletion.google.com",
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				CABundle: caCert,
-			},
-			Rules: []admissionregistrationv1.RuleWithOperations{{
-				Operations: []admissionregistrationv1.OperationType{
-					admissionregistrationv1.Delete,
-				},
-				Rule: admissionregistrationv1.Rule{
-					APIGroups:   []string{porchapi.SchemeGroupVersion.Group},
-					APIVersions: []string{porchapi.SchemeGroupVersion.Version},
-					Resources:   []string{porchapi.PackageRevisionGVR.Resource},
-				},
-			}},
-			AdmissionReviewVersions: []string{"v1"},
-			SideEffects:             &none,
-			FailurePolicy:           &fail,
-			TimeoutSeconds:          &cfg.timeout,
-		}},
-	}
 
 	// Webhook for Repository validation
 	repositoryWebhook := admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -367,22 +305,7 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 		}},
 	}
 
-	// Set service or URL for both webhooks
-	switch cfg.Type {
-	case WebhookTypeService:
-		validateConfig.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
-			Name:      cfg.ServiceName,
-			Namespace: cfg.ServiceNamespace,
-			Path:      &cfg.Path,
-			Port:      &cfg.Port,
-		}
-	case WebhookTypeUrl:
-		url := fmt.Sprintf("https://%s%s", net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port)), cfg.Path)
-		validateConfig.Webhooks[0].ClientConfig.URL = &url
-	default:
-		return fmt.Errorf("invalid webhook type: %s", cfg.Type)
-	}
-
+	// Set service for repository webhook
 	repositoryWebhook.Webhooks[0].ClientConfig.Service = &admissionregistrationv1.ServiceReference{
 		Name:      cfg.RepoServiceName,
 		Namespace: cfg.RepoServiceNamespace,
@@ -390,13 +313,8 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 		Port:      &cfg.Port,
 	}
 
-	// Delete and recreate both webhook to allow updates in webhook configurations
-	_ = kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, validationCfgName, metav1.DeleteOptions{})
+	// Delete and recreate repository webhook to allow updates in webhook configurations
 	_ = kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, repositoryCfgName, metav1.DeleteOptions{})
-
-	if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, validateConfig, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create package revision webhook: %w", err)
-	}
 
 	if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, &repositoryWebhook, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create repository validation webhook: %w", err)
@@ -485,9 +403,6 @@ func runWebhookServer(ctx context.Context, cfg *WebhookConfig, clientReader clie
 		go watchCertificates(ctx, cfg.CertStorageDir, certFile, keyFile)
 	}
 	klog.Infoln("Starting webhook server")
-	http.HandleFunc(cfg.Path, func(w http.ResponseWriter, r *http.Request) {
-		validateDeletion(w, r, clientReader)
-	})
 	http.HandleFunc(cfg.RepositoryPath, func(w http.ResponseWriter, r *http.Request) {
 		validateRepository(w, r, clientReader)
 	})
@@ -507,66 +422,6 @@ func runWebhookServer(ctx context.Context, cfg *WebhookConfig, clientReader clie
 	}()
 	return err
 
-}
-
-func validateDeletion(w http.ResponseWriter, r *http.Request, clientReader client.Reader) {
-	ctx, span := tracer.Start(r.Context(), "validateDeletion")
-	defer span.End()
-	klog.Infoln("received request to validate deletion")
-
-	admissionReviewRequest, err := decodeAdmissionReview(r)
-	if err != nil {
-		errMsg := fmt.Sprintf("error getting admission review from request: %v", err)
-		writeErr(errMsg, &w)
-		return
-	}
-
-	// Verify that we have a PackageRevision resource
-	if admissionReviewRequest.Request.Resource != util.SchemaToMetaGVR(porchapi.PackageRevisionGVR) {
-		errMsg := fmt.Sprintf("did not receive PackageRevision, got %s", admissionReviewRequest.Request.Resource.Resource)
-		writeErr(errMsg, &w)
-		return
-	}
-
-	// Get the package revision using the name and namespace from the request.
-	pr := porchapi.PackageRevision{}
-	if err := clientReader.Get(ctx, client.ObjectKey{
-		Namespace: admissionReviewRequest.Request.Namespace,
-		Name:      admissionReviewRequest.Request.Name,
-	}, &pr); err != nil {
-		klog.Errorf("could not get package revision: %s", err.Error())
-	}
-
-	admissionResponse := &admissionv1.AdmissionResponse{}
-	if pr.Spec.Lifecycle == porchapi.PackageRevisionLifecyclePublished {
-		admissionResponse.Allowed = false
-		admissionResponse.Result = &metav1.Status{
-			Status:  "Failure",
-			Message: fmt.Sprintf("failed to delete package revision %q: published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion", pr.Name),
-			Reason:  "Published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion.",
-		}
-	} else {
-		admissionResponse.Allowed = true
-		admissionResponse.Result = &metav1.Status{
-			Status:  "Success",
-			Message: fmt.Sprintf("Successfully deleted package revision %q", pr.Name),
-		}
-	}
-
-	resp, err := constructResponse(admissionResponse, admissionReviewRequest)
-	if err != nil {
-		errMsg := fmt.Sprintf("error constructing response: %v", err)
-		writeErr(errMsg, &w)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(resp) // #nosec G705
-	if err != nil {
-		errMsg := fmt.Sprintf("error writing response: %v", err)
-		writeErr(errMsg, &w)
-		return
-	}
 }
 
 func decodeAdmissionReview(r *http.Request) (*admissionv1.AdmissionReview, error) {
@@ -652,6 +507,9 @@ func getEnvInt32(key string, defaultValue int32) int32 {
 }
 
 func validateRepository(w http.ResponseWriter, r *http.Request, clientReader client.Reader) {
+	ctx, span := tracer.Start(r.Context(), "validateRepository")
+	defer span.End()
+
 	admissionReviewRequest, err := decodeAdmissionReview(r)
 	if err != nil {
 		writeErr(fmt.Sprintf("error decoding admission review: %v", err), &w)
@@ -689,7 +547,7 @@ func validateRepository(w http.ResponseWriter, r *http.Request, clientReader cli
 	}
 
 	var repoList configapi.RepositoryList
-	if err := clientReader.List(context.Background(), &repoList); err != nil {
+	if err := clientReader.List(ctx, &repoList); err != nil {
 		klog.Errorf("failed to list repositories: %v", err)
 		writeErr(fmt.Sprintf("could not list repositories: %v", err), &w)
 		return

--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -469,10 +469,6 @@ func writeErr(errMsg string, w *http.ResponseWriter) {
 	}
 }
 
-func hasEnv(key string) bool {
-	_, found := os.LookupEnv(key)
-	return found
-}
 
 func getEnv(key string, defaultValue string) string {
 	value, found := os.LookupEnv(key)

--- a/pkg/apiserver/webhooks_test.go
+++ b/pkg/apiserver/webhooks_test.go
@@ -38,8 +38,7 @@ import (
 
 func TestCreateCerts(t *testing.T) {
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -73,8 +72,7 @@ func TestLoadCertificate(t *testing.T) {
 	//what do i need to test.
 	// first create dummy certs for testing
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -149,8 +147,7 @@ func TestWatchCertificatesInvalidDirectory(t *testing.T) {
 	}
 	// Set up the temp directory with dummy certificate files
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -189,8 +186,7 @@ func TestWatchCertificatesSuccessfulReload(t *testing.T) {
 	}
 	// Set up the temp directory with dummy certificate files
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -238,8 +234,7 @@ func TestWatchCertificatesInvalidCertReload(t *testing.T) {
 	}
 	// Set up the temp directory with dummy certificate files
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -286,8 +281,7 @@ func TestWatchCertificatesGracefulTermination(t *testing.T) {
 	}
 	// Set up the temp directory with dummy certificate files
 	webhookCfg := WebhookConfig{
-		Type:           WebhookTypeUrl,
-		Host:           "localhost",
+		RepoHost:       "localhost",
 		CertStorageDir: t.TempDir(),
 	}
 	defer func() {
@@ -317,64 +311,6 @@ func TestWatchCertificatesGracefulTermination(t *testing.T) {
 	t.Log(graceful_termination_logs)
 	err = assertLogMessages(graceful_termination_logs)
 	require.NoError(t, err)
-}
-
-func TestValidateDeletion(t *testing.T) {
-	scheme := runtime.NewScheme()
-	configapi.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	t.Run("invalid content-type", func(t *testing.T) {
-		request, err := http.NewRequest(http.MethodPost, serverEndpoint, nil)
-		require.NoError(t, err)
-		request.Header.Set("Content-Type", "foo")
-		response := httptest.NewRecorder()
-
-		validateDeletion(response, request, fakeClient)
-		require.Equal(t,
-			"error getting admission review from request: expected Content-Type 'application/json'",
-			response.Body.String())
-	})
-	t.Run("valid content-type, but no body", func(t *testing.T) {
-		request, err := http.NewRequest(http.MethodPost, serverEndpoint, nil)
-		require.NoError(t, err)
-		request.Header.Set("Content-Type", "application/json")
-		response := httptest.NewRecorder()
-
-		validateDeletion(response, request, fakeClient)
-		require.Equal(t,
-			"error getting admission review from request: admission review request is empty",
-			response.Body.String())
-	})
-	t.Run("wrong GVK in request", func(t *testing.T) {
-		request, err := http.NewRequest(http.MethodPost, serverEndpoint, nil)
-		require.NoError(t, err)
-
-		request.Header.Set("Content-Type", "application/json")
-		response := httptest.NewRecorder()
-
-		admissionReviewRequest := admissionv1.AdmissionReview{
-			TypeMeta: v1.TypeMeta{
-				Kind:       "AdmissionReview",
-				APIVersion: "admission.k8s.io/v1",
-			},
-			Request: &admissionv1.AdmissionRequest{
-				Resource: v1.GroupVersionResource{
-					Group:    "porch.kpt.dev",
-					Version:  "v1alpha1",
-					Resource: "not-a-package-revision",
-				},
-			},
-		}
-
-		body, err := json.Marshal(admissionReviewRequest)
-		require.NoError(t, err)
-
-		request.Body = io.NopCloser(bytes.NewReader(body))
-		validateDeletion(response, request, fakeClient)
-		require.Equal(t,
-			"did not receive PackageRevision, got not-a-package-revision",
-			response.Body.String())
-	})
 }
 
 func TestValidateRepository(t *testing.T) {

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -380,9 +380,18 @@ func getLifecycleTransition(oldPkgRev, newPkgRev *porchapi.PackageRevision) stri
 }
 
 func (r *packageCommon) validateDelete(ctx context.Context, deleteValidation rest.ValidateObjectFunc, obj runtime.Object, name, namespace string) (*configapi.Repository, error) {
+	// Check if the PackageRevision is Published and not in DeletionProposed state
+	if pkgRev, ok := obj.(*porchapi.PackageRevision); ok {
+		if pkgRev.Spec.Lifecycle == porchapi.PackageRevisionLifecyclePublished {
+			return nil, apierrors.NewForbidden(
+				porchapi.Resource("packagerevisions"),
+				name,
+				fmt.Errorf("published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion"))
+		}
+	}
+
 	if deleteValidation != nil {
-		err := deleteValidation(ctx, obj)
-		if err != nil {
+		if err := deleteValidation(ctx, obj); err != nil {
 			klog.Infof("delete failed validation: %v", err)
 			return nil, err
 		}

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -277,6 +277,8 @@ func TestDelete(t *testing.T) {
 	pkgRevName := "repo.1234567890.ws"
 
 	// Success case
+	// set packagerevision to DeletionProposed lifecycle
+	packageRevision.PackageRevision.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
 	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision}, nil).Once()
@@ -291,6 +293,65 @@ func TestDelete(t *testing.T) {
 
 	//=========================================================================================
 
+	// Failure case - Published package NOT in DeletionProposed state
+	// set packagerevision to Published lifecycle
+	packageRevision.PackageRevision.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		packageRevision, // This is Published lifecycle
+	}, nil).Once()
+
+	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, deleted)
+	assert.True(t, apierrors.IsForbidden(err))
+	assert.ErrorContains(t, err, "published PackageRevisions must be proposed for deletion")
+
+	//=========================================================================================
+
+	// Success case - Draft package can be deleted without DeletionProposed
+	draftPkgRev := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecycleDraft,
+		PackageRevision: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: make(map[string]string),
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleDraft,
+			},
+		},
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
+			},
+		}}
+
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		draftPkgRev,
+	}, nil).Once()
+	mockEngine.On("FindAllUpstreamReferencesInRepositories", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Once()
+	mockEngine.On("DeletePackageRevision", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	result, deleted, err = packagerevisions.Delete(ctx, pkgRevName, nil, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, deleted)
+	assert.IsType(t, &porchapi.PackageRevision{}, result)
+
+	//=========================================================================================
 	// Missing namespace
 	result, deleted, err = packagerevisions.Delete(context.TODO(), pkgRevName, nil, &metav1.DeleteOptions{})
 	assert.Error(t, err)
@@ -312,6 +373,7 @@ func TestDelete(t *testing.T) {
 	//=========================================================================================
 
 	// Error from DeletePackageRevision
+	packageRevision.PackageRevision.Spec.Lifecycle = porchapi.PackageRevisionLifecycleDeletionProposed
 	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		packageRevision,

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -392,10 +392,12 @@ func TestWatch(t *testing.T) {
 	_, mockEngine := setup(t)
 	mockWatcherManager := mockengine.NewMockWatcherManager(t)
 	mockEngine.On("ObjectCache").Return(mockWatcherManager).Maybe()
-
 	mockWatcherManager.On("WatchPackageRevisions", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("error starting watch")).Maybe()
 
-	_, err := packagerevisions.Watch(context.TODO(), &internalversion.ListOptions{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := packagerevisions.Watch(ctx, &internalversion.ListOptions{})
 	assert.NoError(t, err)
 
 	//=========================================================================================

--- a/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
+++ b/test/e2e/cli/testdata/rpkg-lifecycle/config.yaml
@@ -109,7 +109,7 @@ commands:
       - delete
       - git.lifecycle-package.lifecycle
       - --namespace=rpkg-lifecycle
-    stderr: "git.lifecycle-package.lifecycle failed (admission webhook \"packagerevdeletion.google.com\" denied the request: failed to delete package revision \"git.lifecycle-package.lifecycle\": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion)\nError: errors:\n  admission webhook \"packagerevdeletion.google.com\" denied the request: failed to delete package revision \"git.lifecycle-package.lifecycle\": published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion \n"
+    stderr: "git.lifecycle-package.lifecycle failed (packagerevisions.porch.kpt.dev \"git.lifecycle-package.lifecycle\" is forbidden: published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion)\nError: errors:\n  packagerevisions.porch.kpt.dev \"git.lifecycle-package.lifecycle\" is forbidden: published PackageRevisions must be proposed for deletion by setting spec.lifecycle to 'DeletionProposed' prior to deletion \n"
     exitCode: 1
   - args:
       - porchctl


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Move deletion validation out of the webhook and into delete request validations

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  
Removed PackageRevision deletion validation webhook from webhooks.go
Moved validation logic directly into API server's validateDelete() method in packagecommon.go

- Why it’s needed:  
Simplifies architecture by eliminating webhook complexity and operational overhead
Improves performance and reliability by removing network round-trips and certificate management - 30 seconds hardcoded limit in the library

- How it works:  
Validation now runs directly in the API server during DELETE operations
Maintains the same business logic: Published PackageRevisions must be DeletionProposed before deletion
Preserves API compatibility with the same error responses

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  https://github.com/nephio-project/porch/issues/902

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.

Examples:

- Microsoft Copilot to analyse the code
- Claude code to generate the function someNewFunctionIAdded()
- Amazon Q to generate unit tests
