### PR TITLE
Allow watches to run against a streaming DB list

### DIFF
--- a/pkg/cache/crcache/cache.go
+++ b/pkg/cache/crcache/cache.go
@@ -163,15 +163,25 @@ func (c *Cache) FindAllUpstreamReferencesInRepositories(ctx context.Context, nam
 }
 
 func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	result := []repository.PackageRevision{}
+	err := c.StreamPackageRevisions(ctx, filter, func(rev repository.PackageRevision) error {
+		result = append(result, rev)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
+func (c *Cache) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
 	var opts []client.ListOption
 
 	namespace, namespaced := genericapirequest.NamespaceFrom(ctx)
 	if namespaced && namespace != "" {
 		if namespaceMatches, filteredNamespace := filter.MatchesNamespace(namespace); !namespaceMatches {
-			return nil, fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filteredNamespace)
+			return fmt.Errorf("conflicting namespaces specified: %q and %q", namespace, filteredNamespace)
 		}
-
 		opts = append(opts, client.InNamespace(namespace))
 	}
 
@@ -181,18 +191,18 @@ func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.List
 
 	var repoList configapi.RepositoryList
 	if err := c.options.CoreClient.List(ctx, &repoList, opts...); err != nil {
-		return nil, fmt.Errorf("error listing repository objects: %w", err)
+		return fmt.Errorf("error listing repository objects: %w", err)
 	}
 	repos := repoList.Items
+
+	repoCount := len(repos)
+	if repoCount == 0 {
+		return nil
+	}
 
 	type pkgRevResult struct {
 		Revisions []repository.PackageRevision
 		Err       error
-	}
-
-	repoCount := len(repos)
-	if repoCount == 0 {
-		return []repository.PackageRevision{}, nil
 	}
 
 	workerCount := repoCount
@@ -247,14 +257,12 @@ func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.List
 	}
 
 	received := 0
-	resultPRs := []repository.PackageRevision{}
-
 	for {
 		select {
 		case <-innerCtx.Done():
 			klog.Warningf("Timeout reached — returning partial results")
 			close(repoQueue)
-			return resultPRs, nil
+			return nil
 
 		case res := <-resultsCh:
 			received++
@@ -263,13 +271,15 @@ func (c *Cache) ListPackageRevisions(ctx context.Context, filter repository.List
 				klog.Warningf("error listing package revisions: %+v", res.Err)
 			}
 			for _, rev := range res.Revisions {
-				resultPRs = append(resultPRs, rev)
+				if err := callback(rev); err != nil {
+					close(repoQueue)
+					return err
+				}
 			}
-
 		}
 		if received == repoCount {
 			close(repoQueue)
-			return resultPRs, nil
+			return nil
 		}
 	}
 }

--- a/pkg/cache/crcache/cache_test.go
+++ b/pkg/cache/crcache/cache_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 )
@@ -444,4 +445,149 @@ func TestFindUpstreamReference(t *testing.T) {
 			assert.Equal(t, tt.wantDep, dep)
 		})
 	}
+}
+
+func TestStreamPackageRevisions(t *testing.T) {
+	ctx := context.Background()
+	testPath := filepath.Join("..", "..", "externalrepo", "git", "testdata")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	tempdir := t.TempDir()
+	tarfile := filepath.Join(testPath, "nested-repository.tar")
+	_, address := gitserver.ServeGitRepository(t, tarfile, tempdir)
+
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested", Namespace: "default"},
+		Spec: v1alpha1.RepositorySpec{
+			Type: v1alpha1.RepositoryTypeGit,
+			Git:  &v1alpha1.GitRepository{Repo: address},
+		},
+	}
+
+	fakeClient := k8sfake.NewClientBuilder().WithScheme(scheme).WithObjects(repo).Build()
+
+	cache := &Cache{
+		repositories: repomap.SafeRepoMap{},
+		metadataStore: &fakemeta.MemoryMetadataStore{
+			Metas: []metav1.ObjectMeta{},
+		},
+		options: cachetypes.CacheOptions{
+			ExternalRepoOptions: externalrepotypes.ExternalRepoOptions{
+				LocalDirectory:             t.TempDir(),
+				UseUserDefinedCaBundle:     true,
+				CredentialResolver:         &fakecache.CredentialResolver{},
+				RepoOperationRetryAttempts: 3,
+			},
+			CoreClient:           fakeClient,
+			RepoSyncFrequency:    60 * time.Second,
+			RepoPRChangeNotifier: &fakecache.ObjectNotifier{},
+		},
+	}
+
+	t.Run("streams all revisions", func(t *testing.T) {
+		var streamed []repository.PackageRevision
+		err := cache.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+			streamed = append(streamed, rev)
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Greater(t, len(streamed), 0)
+
+		// ListPackageRevisions should return the same count
+		listed, err := cache.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
+		require.NoError(t, err)
+		assert.Equal(t, len(streamed), len(listed))
+	})
+
+	t.Run("callback error stops streaming", func(t *testing.T) {
+		count := 0
+		testErr := fmt.Errorf("stop early")
+		err := cache.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+			count++
+			return testErr
+		})
+		assert.ErrorIs(t, err, testErr)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("empty repo list returns nil", func(t *testing.T) {
+		emptyClient := k8sfake.NewClientBuilder().WithScheme(scheme).Build()
+		emptyCache := &Cache{
+			options: cachetypes.CacheOptions{CoreClient: emptyClient},
+		}
+		called := false
+		err := emptyCache.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+			called = true
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, called)
+
+		listed, err := emptyCache.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
+		assert.NoError(t, err)
+		assert.Equal(t, []repository.PackageRevision{}, listed)
+	})
+
+	t.Run("conflicting namespaces returns error", func(t *testing.T) {
+		nsCtx := genericapirequest.WithNamespace(ctx, "ns-a")
+		filter := repository.ListPackageRevisionFilter{
+			Key: repository.PackageRevisionKey{
+				PkgKey: repository.PackageKey{
+					RepoKey: repository.RepositoryKey{Namespace: "ns-b"},
+				},
+			},
+		}
+		err := cache.StreamPackageRevisions(nsCtx, filter, func(rev repository.PackageRevision) error {
+			return nil
+		})
+		assert.ErrorContains(t, err, "conflicting namespaces")
+	})
+
+	t.Run("with MaxConcurrentLists", func(t *testing.T) {
+		limitedCache := &Cache{
+			repositories:  cache.repositories,
+			metadataStore: cache.metadataStore,
+			options: cachetypes.CacheOptions{
+				ExternalRepoOptions: cache.options.ExternalRepoOptions,
+				CoreClient:          fakeClient,
+				RepoSyncFrequency:   60 * time.Second,
+				RepoPRChangeNotifier: &fakecache.ObjectNotifier{},
+				CRCacheOptions: cachetypes.CRCacheOptions{
+					MaxConcurrentLists: 1,
+				},
+			},
+		}
+		var count int
+		err := limitedCache.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+			count++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Greater(t, count, 0)
+	})
+
+	t.Run("with ListTimeoutPerRepository", func(t *testing.T) {
+		timedCache := &Cache{
+			repositories:  cache.repositories,
+			metadataStore: cache.metadataStore,
+			options: cachetypes.CacheOptions{
+				ExternalRepoOptions: cache.options.ExternalRepoOptions,
+				CoreClient:          fakeClient,
+				RepoSyncFrequency:   60 * time.Second,
+				RepoPRChangeNotifier: &fakecache.ObjectNotifier{},
+				CRCacheOptions: cachetypes.CRCacheOptions{
+					ListTimeoutPerRepository: 30 * time.Second,
+				},
+			},
+		}
+		var count int
+		err := timedCache.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+			count++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Greater(t, count, 0)
+	})
 }

--- a/pkg/cache/dbcache/dbcache.go
+++ b/pkg/cache/dbcache/dbcache.go
@@ -157,14 +157,17 @@ func (c *dbCache) FindAllUpstreamReferencesInRepositories(ctx context.Context, n
 }
 
 func (c *dbCache) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
-	dbprs, err := pkgRevListPRsFromDB(ctx, filter)
+	result := []repository.PackageRevision{}
+	err := c.StreamPackageRevisions(ctx, filter, func(rev repository.PackageRevision) error {
+		result = append(result, rev)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	var prs []repository.PackageRevision
-	prs = make([]repository.PackageRevision, len(dbprs))
-	for i, dbpr := range dbprs {
-		prs[i] = dbpr
-	}
-	return prs, nil
+	return result, nil
+}
+
+func (c *dbCache) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	return pkgRevStreamPRsFromDB(ctx, filter, callback)
 }

--- a/pkg/cache/dbcache/dbcache_test.go
+++ b/pkg/cache/dbcache/dbcache_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/nephio-project/porch/pkg/externalrepo"
 	"github.com/nephio-project/porch/pkg/repository"
 	mockdbcache "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/dbcache"
+	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -326,4 +328,60 @@ func (t *DbTestSuite) createTestPRs(packages []dbPackage, wsNamePrefix string, c
 		}
 	}
 	return testPRs
+}
+
+func (t *DbTestSuite) TestStreamPackageRevisions() {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{}).Maybe()
+
+	dbRepo := t.createTestRepo("stream-ns", "stream-repo")
+	pkgs := t.createTestPkgs(dbRepo.Key(), "stream-pkg", 2)
+	t.createTestPRs(pkgs, "ws", 3)
+
+	cache := &dbCache{}
+
+	// StreamPackageRevisions should invoke callback per revision
+	var streamed []repository.PackageRevision
+	err := cache.StreamPackageRevisions(t.Context(), repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{Namespace: "stream-ns", Name: "stream-repo"},
+			},
+		},
+	}, func(rev repository.PackageRevision) error {
+		streamed = append(streamed, rev)
+		return nil
+	})
+	t.NoError(err)
+	t.Equal(6, len(streamed))
+
+	// ListPackageRevisions should return the same count
+	listed, err := cache.ListPackageRevisions(t.Context(), repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{Namespace: "stream-ns", Name: "stream-repo"},
+			},
+		},
+	})
+	t.NoError(err)
+	t.Equal(len(streamed), len(listed))
+
+	// Callback error should stop streaming
+	count := 0
+	testErr := fmt.Errorf("stop early")
+	err = cache.StreamPackageRevisions(t.Context(), repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{Namespace: "stream-ns", Name: "stream-repo"},
+			},
+		},
+	}, func(rev repository.PackageRevision) error {
+		count++
+		return testErr
+	})
+	t.ErrorIs(err, testErr)
+	t.Equal(1, count)
+
+	t.deleteTestRepo(dbRepo.Key())
 }

--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -99,12 +99,7 @@ func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, re
 	return readPr, err
 }
 
-func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]*dbPackageRevision, error) {
-	_, span := tracer.Start(ctx, "dbrepositorysql::pkgRevListPRsFromDB", trace.WithAttributes())
-	defer span.End()
-
-	klog.V(5).Infof("pkgRevListPRsFromDB: listing package revisions for filter %+v", filter)
-
+func pkgRevListQuery(filter repository.ListPackageRevisionFilter) string {
 	sqlStatement := `
 		SELECT
 			repositories.k8s_name_space,
@@ -131,12 +126,20 @@ func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevis
 		INNER JOIN repositories
 			ON packages.k8s_name_space=repositories.k8s_name_space AND packages.repo_k8s_name=repositories.k8s_name
 	`
-
 	sqlStatement += prListFilter2WhereClause(filter)
-
 	sqlStatement += `
 			ORDER BY package_revisions.k8s_name_space, package_revisions.k8s_name
 	`
+	return sqlStatement
+}
+
+func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]*dbPackageRevision, error) {
+	_, span := tracer.Start(ctx, "dbrepositorysql::pkgRevListPRsFromDB", trace.WithAttributes())
+	defer span.End()
+
+	klog.V(5).Infof("pkgRevListPRsFromDB: listing package revisions for filter %+v", filter)
+
+	sqlStatement := pkgRevListQuery(filter)
 
 	klog.V(6).Infof("pkgRevListPRsFromDB: running query %q on package revisions with filter %+v", sqlStatement, filter)
 	rows, err := GetDB().db.Query(ctx, sqlStatement)
@@ -146,6 +149,26 @@ func pkgRevListPRsFromDB(ctx context.Context, filter repository.ListPackageRevis
 	}
 
 	return pkgRevScanRowsFromDB(ctx, rows)
+}
+
+func pkgRevStreamPRsFromDB(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	_, span := tracer.Start(ctx, "dbrepositorysql::pkgRevStreamPRsFromDB", trace.WithAttributes())
+	defer span.End()
+
+	klog.V(5).Infof("pkgRevStreamPRsFromDB: streaming package revisions for filter %+v", filter)
+
+	sqlStatement := pkgRevListQuery(filter)
+
+	klog.V(6).Infof("pkgRevStreamPRsFromDB: running query %q on package revisions with filter %+v", sqlStatement, filter)
+	rows, err := GetDB().db.Query(ctx, sqlStatement)
+	if err != nil {
+		klog.Warningf("pkgRevStreamPRsFromDB: reading package revision list for filter %+v returned err: %q", filter, err)
+		return err
+	}
+
+	return pkgRevScanRowsFromDBFunc(ctx, rows, func(pr *dbPackageRevision) error {
+		return callback(pr)
+	})
 }
 
 func pkgRevReadPRsFromDB(ctx context.Context, pk repository.PackageKey) ([]*dbPackageRevision, error) {
@@ -279,14 +302,24 @@ func pkgRevReadPRListFromDB(ctx context.Context, pk repository.PackageKey, sqlSt
 }
 
 func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevision, error) {
-	_, span := tracer.Start(ctx, "dbpackagesql::pkgScanRowsFromDB", trace.WithAttributes())
+	var dbPkgRevs []*dbPackageRevision
+	err := pkgRevScanRowsFromDBFunc(ctx, rows, func(pr *dbPackageRevision) error {
+		dbPkgRevs = append(dbPkgRevs, pr)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dbPkgRevs, nil
+}
+
+func pkgRevScanRowsFromDBFunc(ctx context.Context, rows *sql.Rows, callback func(*dbPackageRevision) error) error {
+	_, span := tracer.Start(ctx, "dbpackagesql::pkgRevScanRowsFromDBFunc", trace.WithAttributes())
 	defer span.End()
 
 	defer rows.Close()
 
-	klog.V(5).Info("pkgRevScanRowsFromDB: scanning rows returned from query")
-
-	var dbPkgRevs []*dbPackageRevision
+	klog.V(5).Info("pkgRevScanRowsFromDBFunc: scanning rows returned from query")
 
 	for rows.Next() {
 		var pkgRev dbPackageRevision
@@ -313,8 +346,8 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 			&kptfileStatusJSON)
 
 		if err != nil {
-			klog.Warningf("pkgRevScanRowsFromDB: scanning rows failed: %q", err)
-			return nil, err
+			klog.Warningf("pkgRevScanRowsFromDBFunc: scanning rows failed: %q", err)
+			return err
 		}
 
 		repo := cachetypes.CacheInstance.GetRepository(pkgRev.pkgRevKey.PkgKey.RepoKey)
@@ -322,7 +355,7 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 			if dbRepo, ok := repo.(*dbRepository); ok {
 				pkgRev.repo = dbRepo
 			} else {
-				klog.Warningf("pkgRevScanRowsFromDB: repository %+v is not a dbRepository for package revision %s", pkgRev.pkgRevKey.PkgKey.RepoKey, prK8SName)
+				klog.Warningf("pkgRevScanRowsFromDBFunc: repository %+v is not a dbRepository for package revision %s", pkgRev.pkgRevKey.PkgKey.RepoKey, prK8SName)
 			}
 		}
 		pkgRev.pkgRevKey.PkgKey.Package = repository.K8SName2PkgName(pkgK8SName)
@@ -333,10 +366,12 @@ func pkgRevScanRowsFromDB(ctx context.Context, rows *sql.Rows) ([]*dbPackageRevi
 		setValueFromJSON(tasks, &pkgRev.tasks)
 		setValueFromJSON(kptfileStatusJSON, &pkgRev.kptfileStatus)
 
-		dbPkgRevs = append(dbPkgRevs, &pkgRev)
+		if err := callback(&pkgRev); err != nil {
+			return err
+		}
 	}
 
-	return dbPkgRevs, nil
+	return nil
 }
 
 func pkgRevWriteToDB(ctx context.Context, pr *dbPackageRevision) error {

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -70,6 +70,7 @@ type Cache interface {
 	CheckRepositoryConnectivity(ctx context.Context, repositorySpec *configapi.Repository) error
 	FindAllUpstreamReferencesInRepositories(ctx context.Context, namespace, prName string) (string, error)
 	ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
+	StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error
 }
 
 var (

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -49,6 +49,7 @@ type CaDEngine interface {
 	UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevisionResources) (repository.PackageRevision, *porchapi.RenderStatus, error)
 
 	ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
+	StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error
 	CreatePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, obj *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error)
 	UpdatePackageRevision(ctx context.Context, version int, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error)
 	DeletePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, obj repository.PackageRevision) error
@@ -98,6 +99,13 @@ func (cad *cadEngine) ListPackageRevisions(ctx context.Context, filter repositor
 	defer span.End()
 
 	return cad.cache.ListPackageRevisions(ctx, filter)
+}
+
+func (cad *cadEngine) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	ctx, span := tracer.Start(ctx, "cadEngine::StreamPackageRevisions", trace.WithAttributes())
+	defer span.End()
+
+	return cad.cache.StreamPackageRevisions(ctx, filter, callback)
 }
 
 func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *configapi.Repository, newPr *porchapi.PackageRevision, parent repository.PackageRevision) (repository.PackageRevision, error) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -297,6 +297,32 @@ func (m *mockCache) ListPackageRevisions(ctx context.Context, filter repository.
 	return args.Get(0).([]repository.PackageRevision), args.Error(1)
 }
 
+func (m *mockCache) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	args := m.Called(ctx, filter, callback)
+	return args.Error(0)
+}
+
+func TestStreamPackageRevisions(t *testing.T) {
+	ctx := context.Background()
+	mc := new(mockCache)
+	engine := &cadEngine{cache: mc}
+
+	mc.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			cb := args.Get(2).(func(repository.PackageRevision) error)
+			cb(&mockrepo.MockPackageRevision{})
+		}).Return(nil).Once()
+
+	count := 0
+	err := engine.StreamPackageRevisions(ctx, repository.ListPackageRevisionFilter{}, func(rev repository.PackageRevision) error {
+		count++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	mc.AssertExpectations(t)
+}
+
 func TestCreatePRWith2Tasks(t *testing.T) {
 	pr := &porchapi.PackageRevision{
 		Spec: porchapi.PackageRevisionSpec{

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -60,17 +60,12 @@ func (r *packageCommon) listPackageRevisions(ctx context.Context, filter reposit
 	callback func(ctx context.Context, p repository.PackageRevision) error) error {
 	ctx, span := tracer.Start(ctx, "packageCommon::listPackageRevisions", trace.WithAttributes())
 	defer span.End()
-	revisions, err := r.cad.ListPackageRevisions(ctx, filter)
-	if err != nil {
-		return err
-	}
-	for _, rev := range revisions {
+	return r.cad.StreamPackageRevisions(ctx, filter, func(rev repository.PackageRevision) error {
 		if err := callback(ctx, rev); err != nil {
 			klog.Warningf("callback error for revision from repository: %+v", err)
-			continue
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (r *packageCommon) listPackages(ctx context.Context, filter repository.ListPackageFilter, callback func(p repository.Package) error) error {

--- a/pkg/registry/porch/packagecommon_test.go
+++ b/pkg/registry/porch/packagecommon_test.go
@@ -260,8 +260,11 @@ func TestListPackageRevisions(t *testing.T) {
 		{
 			name: "Successful package revision listing",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{pkgRev}, nil)
+				cad.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						cb := args.Get(2).(func(repository.PackageRevision) error)
+						cb(pkgRev)
+					}).Return(nil)
 			},
 			filter:        repository.ListPackageRevisionFilter{},
 			expectedError: nil,
@@ -271,8 +274,11 @@ func TestListPackageRevisions(t *testing.T) {
 		{
 			name: "Successful namespace filtering",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{pkgRev}, nil)
+				cad.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						cb := args.Get(2).(func(repository.PackageRevision) error)
+						cb(pkgRev)
+					}).Return(nil)
 			},
 			filter: repository.ListPackageRevisionFilter{
 				Key: repository.PackageRevisionKey{
@@ -290,8 +296,8 @@ func TestListPackageRevisions(t *testing.T) {
 		{
 			name: "CaD engine error",
 			setupMocks: func(c *mockclient.MockClient, pkgRev *mockrepo.MockPackageRevision, cad *mockcad.MockCaDEngine) {
-				cad.On("ListPackageRevisions", mock.Anything, mock.Anything).
-					Return([]repository.PackageRevision{}, fmt.Errorf("CaD engine error"))
+				cad.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+					Return(fmt.Errorf("CaD engine error"))
 			},
 			filter:        repository.ListPackageRevisionFilter{},
 			expectedError: fmt.Errorf("CaD engine error"),

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -129,9 +129,11 @@ func setup(t *testing.T) (mockClient *mockclient.MockClient, mockEngine *mockeng
 
 func TestList(t *testing.T) {
 	_, mockEngine := setup(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		packageRevision,
-	}, nil).Once()
+	mockEngine.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			cb := args.Get(2).(func(repository.PackageRevision) error)
+			cb(packageRevision)
+		}).Return(nil).Once()
 
 	result, err := packagerevisions.List(context.TODO(), &internalversion.ListOptions{})
 	assert.NoError(t, err)
@@ -148,9 +150,11 @@ func TestList(t *testing.T) {
 	//=========================================================================================
 
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		mockPkgRev,
-	}, nil)
+	mockEngine.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			cb := args.Get(2).(func(repository.PackageRevision) error)
+			cb(mockPkgRev)
+		}).Return(nil)
 	mockPkgRev.On("KubeObjectName").Return("test-package").Maybe()
 	mockPkgRev.On("GetPackageRevision", mock.Anything).Return(nil, errors.New("error getting API package revision")).Once()
 	result, err = packagerevisions.List(context.TODO(), &internalversion.ListOptions{})

--- a/pkg/registry/porch/packagerevisionresources_test.go
+++ b/pkg/registry/porch/packagerevisionresources_test.go
@@ -64,9 +64,11 @@ func setupResourcesTest(t *testing.T) (mockClient *mockclient.MockClient, mockEn
 
 func TestListResources(t *testing.T) {
 	_, mockEngine := setupResourcesTest(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		packageRevision,
-	}, nil).Once()
+	mockEngine.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			cb := args.Get(2).(func(repository.PackageRevision) error)
+			cb(packageRevision)
+		}).Return(nil).Once()
 
 	result, err := packagerevisionresources.List(context.TODO(), &internalversion.ListOptions{})
 	assert.NoError(t, err)
@@ -83,9 +85,11 @@ func TestListResources(t *testing.T) {
 	//=========================================================================================
 
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
-	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
-		mockPkgRev,
-	}, nil)
+	mockEngine.On("StreamPackageRevisions", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			cb := args.Get(2).(func(repository.PackageRevision) error)
+			cb(mockPkgRev)
+		}).Return(nil)
 	mockPkgRev.On("GetResources", mock.Anything).Return(nil, errors.New("error getting API package revision")).Once()
 	result, err = packagerevisionresources.List(context.TODO(), &internalversion.ListOptions{})
 	assert.NoError(t, err)

--- a/test/mockery/mocks/porch/pkg/cache/types/mock_Cache.go
+++ b/test/mockery/mocks/porch/pkg/cache/types/mock_Cache.go
@@ -466,6 +466,69 @@ func (_c *MockCache_OpenRepository_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
+// StreamPackageRevisions provides a mock function for the type MockCache
+func (_mock *MockCache) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	ret := _mock.Called(ctx, filter, callback)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StreamPackageRevisions")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter, func(repository.PackageRevision) error) error); ok {
+		r0 = returnFunc(ctx, filter, callback)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockCache_StreamPackageRevisions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StreamPackageRevisions'
+type MockCache_StreamPackageRevisions_Call struct {
+	*mock.Call
+}
+
+// StreamPackageRevisions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter repository.ListPackageRevisionFilter
+//   - callback func(repository.PackageRevision) error
+func (_e *MockCache_Expecter) StreamPackageRevisions(ctx interface{}, filter interface{}, callback interface{}) *MockCache_StreamPackageRevisions_Call {
+	return &MockCache_StreamPackageRevisions_Call{Call: _e.mock.On("StreamPackageRevisions", ctx, filter, callback)}
+}
+
+func (_c *MockCache_StreamPackageRevisions_Call) Run(run func(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error)) *MockCache_StreamPackageRevisions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 repository.ListPackageRevisionFilter
+		if args[1] != nil {
+			arg1 = args[1].(repository.ListPackageRevisionFilter)
+		}
+		var arg2 func(repository.PackageRevision) error
+		if args[2] != nil {
+			arg2 = args[2].(func(repository.PackageRevision) error)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCache_StreamPackageRevisions_Call) Return(err error) *MockCache_StreamPackageRevisions_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockCache_StreamPackageRevisions_Call) RunAndReturn(run func(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error) *MockCache_StreamPackageRevisions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateRepository provides a mock function for the type MockCache
 func (_mock *MockCache) UpdateRepository(ctx context.Context, repositorySpec *v1alpha1.Repository) error {
 	ret := _mock.Called(ctx, repositorySpec)

--- a/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
+++ b/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
@@ -444,6 +444,69 @@ func (_c *MockCaDEngine_ObjectCache_Call) RunAndReturn(run func() engine.Watcher
 	return _c
 }
 
+// StreamPackageRevisions provides a mock function for the type MockCaDEngine
+func (_mock *MockCaDEngine) StreamPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error {
+	ret := _mock.Called(ctx, filter, callback)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StreamPackageRevisions")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, repository.ListPackageRevisionFilter, func(repository.PackageRevision) error) error); ok {
+		r0 = returnFunc(ctx, filter, callback)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockCaDEngine_StreamPackageRevisions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StreamPackageRevisions'
+type MockCaDEngine_StreamPackageRevisions_Call struct {
+	*mock.Call
+}
+
+// StreamPackageRevisions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter repository.ListPackageRevisionFilter
+//   - callback func(repository.PackageRevision) error
+func (_e *MockCaDEngine_Expecter) StreamPackageRevisions(ctx interface{}, filter interface{}, callback interface{}) *MockCaDEngine_StreamPackageRevisions_Call {
+	return &MockCaDEngine_StreamPackageRevisions_Call{Call: _e.mock.On("StreamPackageRevisions", ctx, filter, callback)}
+}
+
+func (_c *MockCaDEngine_StreamPackageRevisions_Call) Run(run func(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error)) *MockCaDEngine_StreamPackageRevisions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 repository.ListPackageRevisionFilter
+		if args[1] != nil {
+			arg1 = args[1].(repository.ListPackageRevisionFilter)
+		}
+		var arg2 func(repository.PackageRevision) error
+		if args[2] != nil {
+			arg2 = args[2].(func(repository.PackageRevision) error)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCaDEngine_StreamPackageRevisions_Call) Return(err error) *MockCaDEngine_StreamPackageRevisions_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockCaDEngine_StreamPackageRevisions_Call) RunAndReturn(run func(ctx context.Context, filter repository.ListPackageRevisionFilter, callback func(repository.PackageRevision) error) error) *MockCaDEngine_StreamPackageRevisions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePackageResources provides a mock function for the type MockCaDEngine
 func (_mock *MockCaDEngine) UpdatePackageResources(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources) (repository.PackageRevision, *v1alpha10.RenderStatus, error) {
 	ret := _mock.Called(ctx, repositoryObj, oldPackage, old, new)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Allow watches to run against a streaming DB list

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Initial phas Watch requests read row by row, saving memory on not having to have all the packagerevisions in memory at once
- Why it’s needed:  Saves memory during the opening of a watch request
- How it works:  Read from the db response is parsed and sent out to the listener row by row, so PackageRevision objects can be recycled during go gc.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  https://github.com/nephio-project/porch/issues/903

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated: N/A  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[x] I have used AI in the creation of this PR.

Kiro for both code generation and testing. Based on a previous PoC implementation: https://github.com/Nordix/porch/tree/db-improvements-2

