### PR TITLE
Cherrypick #539 - Fix timezone mismatch in Porch, which is causing resource conflicts

### DIFF
--- a/api/sql/porch-db-1.5.3-1.5.9.sql
+++ b/api/sql/porch-db-1.5.3-1.5.9.sql
@@ -26,3 +26,16 @@ limitations under the License.
 
 ALTER TABLE package_revisions
     ADD COLUMN IF NOT EXISTS kptfile_status TEXT NOT NULL DEFAULT '{}';
+
+-- Fix timezone handling for timestamp columns to ensure consistent UTC storage
+-- This is critical when porch-server runs in non-UTC timezones (e.g., IST)
+-- Convert existing timestamp columns to store UTC timezone explicitly
+
+ALTER TABLE repositories
+    ALTER COLUMN updated TYPE TIMESTAMPTZ USING updated AT TIME ZONE 'UTC';
+
+ALTER TABLE packages
+    ALTER COLUMN updated TYPE TIMESTAMPTZ USING updated AT TIME ZONE 'UTC';
+
+ALTER TABLE package_revisions
+    ALTER COLUMN updated TYPE TIMESTAMPTZ USING updated AT TIME ZONE 'UTC';

--- a/deployments/porch/3-porch-postgres-bundle.yaml
+++ b/deployments/porch/3-porch-postgres-bundle.yaml
@@ -286,7 +286,7 @@ data:
         default_ws_name TEXT NOT NULL,
         meta            TEXT NOT NULL,
         spec            TEXT NOT NULL,
-        updated         TIMESTAMP,
+        updated         TIMESTAMPTZ,
         updatedby       TEXT,
         deployment      BOOLEAN,
         PRIMARY KEY (k8s_name_space, k8s_name)
@@ -314,7 +314,7 @@ data:
         package_path   TEXT NOT NULL,
         meta           TEXT NOT NULL,
         spec           TEXT NOT NULL,
-        updated        TIMESTAMP NOT NULL,
+        updated        TIMESTAMPTZ NOT NULL,
         updatedby      TEXT NOT NULL,
         PRIMARY KEY (k8s_name_space, k8s_name),
         CONSTRAINT fk_repository
@@ -345,7 +345,7 @@ data:
         revision         INTEGER NOT NULL,
         meta             TEXT NOT NULL,
         spec             TEXT NOT NULL,
-        updated          TIMESTAMP NOT NULL,
+        updated          TIMESTAMPTZ NOT NULL,
         updatedby        TEXT NOT NULL,
         lifecycle        TEXT CHECK (lifecycle IN ('Draft', 'Proposed', 'Published', 'DeletionProposed')) NOT NULL,
         ext_pr_id        TEXT NOT NULL,

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -280,7 +280,11 @@ func (r *packageRevisions) Update(ctx context.Context, name string, objInfo rest
 
 	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
 
-	return r.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate)
+	runTimeObj, ok, err := r.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate)
+	if err != nil {
+		klog.ErrorS(err, "[API] PackageRevision update operation failed", context1.LogMetadataFrom(ctx)...)
+	}
+	return runTimeObj, ok, err
 }
 
 // Delete implements the GracefulDeleter interface.

--- a/pkg/registry/porch/packagerevision_approval.go
+++ b/pkg/registry/porch/packagerevision_approval.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
 )
 
 type packageRevisionApproval struct {
@@ -74,7 +75,11 @@ func (a *packageRevisionApproval) Update(ctx context.Context, name string, objIn
 	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	allowCreate := false // do not allow create on update
-	return a.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, allowCreate)
+	runTimeObj, ok, err := a.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, allowCreate)
+	if err != nil {
+		klog.ErrorS(err, "[API] PackageRevision approval operation failed", context1.LogMetadataFrom(ctx)...)
+	}
+	return runTimeObj, ok, err
 }
 
 type packageRevisionApprovalStrategy struct{}

--- a/pkg/registry/porch/packagerevision_approval_test.go
+++ b/pkg/registry/porch/packagerevision_approval_test.go
@@ -26,6 +26,7 @@ import (
 	mockengine "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -145,7 +146,7 @@ func TestApprovalUpdate(t *testing.T) {
 	}
 
 	result, created, err := approval.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.False(t, created)
 	assert.IsType(t, &porchapi.PackageRevision{}, result)
@@ -160,7 +161,6 @@ func TestApprovalUpdate(t *testing.T) {
 	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("approval update failed")).Once()
 
 	result, created, err = approval.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
-	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.False(t, created)
 	assert.True(t, apierrors.IsInternalError(err))

--- a/pkg/registry/porch/packagerevision_approval_test.go
+++ b/pkg/registry/porch/packagerevision_approval_test.go
@@ -15,9 +15,21 @@
 package porch
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	porchapi "github.com/nephio-project/porch/api/porch/v1alpha1"
+	"github.com/nephio-project/porch/pkg/externalrepo/fake"
+	"github.com/nephio-project/porch/pkg/repository"
+	mockclient "github.com/nephio-project/porch/test/mockery/mocks/external/sigs.k8s.io/controller-runtime/pkg/client"
+	mockengine "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestApprovalUpdateStrategy(t *testing.T) {
@@ -68,4 +80,102 @@ func TestApprovalUpdateStrategy(t *testing.T) {
 			testValidateUpdate(t, s, tc.old, new, false)
 		}
 	}
+}
+
+func TestApprovalUpdate(t *testing.T) {
+	// Setup approval instance
+	approval := &packageRevisionApproval{
+		packageCommon: packageCommon{
+			scheme:         runtime.NewScheme(),
+			gr:             porchapi.Resource("packagerevisions"),
+			coreClient:     nil,
+			updateStrategy: packageRevisionApprovalStrategy{},
+			createStrategy: packageRevisionApprovalStrategy{},
+		},
+	}
+
+	mockClient := mockclient.NewMockClient(t)
+	approval.coreClient = mockClient
+	mockEngine := mockengine.NewMockCaDEngine(t)
+	approval.cad = mockEngine
+
+	ctx := request.WithNamespace(context.TODO(), "someDummyNamespace")
+	pkgRevName := "repo.1234567890.ws"
+
+	// Create a proposed package revision for testing approval
+	proposedPackageRevision := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecycleProposed,
+		PackageRevision: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:          make(map[string]string),
+				ResourceVersion: "123",
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleProposed,
+			},
+		},
+	}
+
+	// Success case
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		proposedPackageRevision,
+	}, nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(proposedPackageRevision, nil).Once()
+
+	objInfo := &mockApprovalUpdatedObjectInfo{
+		updatedObj: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "123",
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecyclePublished,
+			},
+		},
+	}
+
+	result, created, err := approval.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, created)
+	assert.IsType(t, &porchapi.PackageRevision{}, result)
+
+	//=========================================================================================
+
+	// Error case - updatePackageRevision fails
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		proposedPackageRevision,
+	}, nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("approval update failed")).Once()
+
+	result, created, err = approval.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, created)
+	assert.True(t, apierrors.IsInternalError(err))
+	assert.ErrorContains(t, err, "approval update failed")
+}
+
+// mockApprovalUpdatedObjectInfo is a mock implementation of rest.UpdatedObjectInfo for approval tests
+type mockApprovalUpdatedObjectInfo struct {
+	updatedObj runtime.Object
+}
+
+func (m *mockApprovalUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+	return m.updatedObj, nil
+}
+
+func (m *mockApprovalUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
+	return nil
 }

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -687,3 +687,112 @@ func TestCheckIfUpstreamIsReferenced(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	mockClient, mockEngine := setup(t)
+	ctx := request.WithNamespace(context.TODO(), "someDummyNamespace")
+	pkgRevName := "repo.1234567890.ws"
+
+	// Create a draft package revision for testing
+	draftPackageRevision := &fake.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: repositoryName,
+				},
+				Package: pkg,
+			},
+			Revision:      revision,
+			WorkspaceName: workspace,
+		},
+		PackageLifecycle: porchapi.PackageRevisionLifecycleDraft,
+		PackageRevision: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:          make(map[string]string),
+				ResourceVersion: "123",
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleDraft,
+			},
+		},
+	}
+
+	// Success case
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		draftPackageRevision,
+	}, nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(draftPackageRevision, nil).Once()
+
+	objInfo := &mockUpdatedObjectInfo{
+		updatedObj: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "123",
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleProposed,
+			},
+		},
+	}
+
+	result, created, err := packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, created)
+	assert.IsType(t, &porchapi.PackageRevision{}, result)
+
+	//=========================================================================================
+
+	// Error case 1- generic updatePackageRevision fails
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		draftPackageRevision,
+	}, nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("update failed")).Once()
+
+	result, created, err = packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, created)
+	assert.True(t, apierrors.IsInternalError(err))
+	assert.ErrorContains(t, err, "update failed")
+
+	// Error case 2 - resource version mismatch updatePackageRevision failure
+
+	objInfo = &mockUpdatedObjectInfo{
+		updatedObj: &porchapi.PackageRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "321",
+			},
+			Spec: porchapi.PackageRevisionSpec{
+				Lifecycle: porchapi.PackageRevisionLifecycleProposed,
+			},
+		},
+	}
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		draftPackageRevision,
+	}, nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, apierrors.NewConflict(porchapi.Resource("packagerevisions"), pkgRevName, fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"))).Once()
+
+	result, created, err = packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, created)
+	assert.True(t, apierrors.IsInternalError(err))
+	assert.ErrorContains(t, err, "the object has been modified; please apply your changes to the latest version and try again")
+
+}
+
+// mockUpdatedObjectInfo is a mock implementation of rest.UpdatedObjectInfo
+type mockUpdatedObjectInfo struct {
+	updatedObj runtime.Object
+}
+
+func (m *mockUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+	return m.updatedObj, nil
+}
+
+func (m *mockUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
+	return nil
+}

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -31,6 +31,7 @@ import (
 	mockrepo "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -736,7 +737,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	result, created, err := packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.False(t, created)
 	assert.IsType(t, &porchapi.PackageRevision{}, result)
@@ -751,7 +752,6 @@ func TestUpdate(t *testing.T) {
 	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("update failed")).Once()
 
 	result, created, err = packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
-	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.False(t, created)
 	assert.True(t, apierrors.IsInternalError(err))
@@ -776,7 +776,6 @@ func TestUpdate(t *testing.T) {
 	mockEngine.On("UpdatePackageRevision", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, apierrors.NewConflict(porchapi.Resource("packagerevisions"), pkgRevName, fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"))).Once()
 
 	result, created, err = packagerevisions.Update(ctx, pkgRevName, objInfo, nil, nil, false, &metav1.UpdateOptions{})
-	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.False(t, created)
 	assert.True(t, apierrors.IsInternalError(err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Cherrypick #539 - Fix timezone mismatch in Porch, which is causing resource conflicts


---

## Description
<!-- Describe what this PR does and why -->
What changed:
Database columns: TIMESTAMP → TIMESTAMPTZ for all updated fields
Update operation errors are now logged in the porch-server

Why it’s needed:
Porch Server was creating inconsistent resource versions due to timezone interpretation differences between operations
(server and DB on different Timezones)
errors were only returned to the client and not logged in the server logs

How it works:
TIMESTAMPTZ stores timestamps with timezone info
Go code now gets consistent time.Time objects
pr.updated.UnixMicro() returns the same value for the same database row
Resource version calculations are now timezone-independent

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.
N/A
