### PR TITLE
Add cache-wide rate limiting to db cache syncs

### DIFF
--- a/docs/content/en/docs/6_configuration_and_deployments/configurations/components/porch-server-config/_index.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/configurations/components/porch-server-config/_index.md
@@ -37,6 +37,7 @@ args:
 args:
 - --db-cache-driver=pgx                      # Database driver (pgx, mysql)
 - --db-cache-data-source=connection-string   # Database connection string
+- --max-concurrent-db-syncs=20               # Max concurrent DB cache repo syncs (0 = no limit)
 ```
 
 #### Function Runtime Arguments

--- a/pkg/cache/dbcache/dbcache.go
+++ b/pkg/cache/dbcache/dbcache.go
@@ -28,6 +28,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 	"k8s.io/klog/v2"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -38,8 +39,9 @@ var tracer = otel.Tracer("dbcache")
 var _ cachetypes.Cache = &dbCache{}
 
 type dbCache struct {
-	repositories repomap.SafeRepoMap
-	options      cachetypes.CacheOptions
+	repositories  repomap.SafeRepoMap
+	options       cachetypes.CacheOptions
+	syncSemaphore *semaphore.Weighted
 }
 
 func (c *dbCache) OpenRepository(ctx context.Context, repositorySpec *configapi.Repository) (repository.Repository, error) {
@@ -81,7 +83,7 @@ func (c *dbCache) createRepository(ctx context.Context, key repository.Repositor
 		return nil, err
 	}
 
-	dbRepo.repositorySync = newRepositorySync(dbRepo, c.options)
+	dbRepo.repositorySync = newRepositorySync(dbRepo, c.options, c.syncSemaphore)
 	return dbRepo, nil
 }
 

--- a/pkg/cache/dbcache/dbcache_test.go
+++ b/pkg/cache/dbcache/dbcache_test.go
@@ -362,7 +362,7 @@ func (t *DbTestSuite) TestDBCacheFactory_NewCacheWithoutSemaphore() {
 	t.NotNil(cache)
 	dc := cache.(*dbCache)
 	t.Nil(dc.syncSemaphore, "semaphore should be nil when MaxConcurrentSyncs == 0")
-
+}
 
 func (t *DbTestSuite) TestStreamPackageRevisions() {
 	mockCache := mockcachetypes.NewMockCache(t.T())

--- a/pkg/cache/dbcache/dbcache_test.go
+++ b/pkg/cache/dbcache/dbcache_test.go
@@ -327,3 +327,37 @@ func (t *DbTestSuite) createTestPRs(packages []dbPackage, wsNamePrefix string, c
 	}
 	return testPRs
 }
+
+func (t *DbTestSuite) TestDBCacheFactory_NewCacheWithSemaphore() {
+	ctx := t.Context()
+
+	// With MaxConcurrentSyncs > 0, semaphore should be created
+	options := cachetypes.CacheOptions{
+		RepoSyncFrequency: 60 * time.Minute,
+		DBCacheOptions: cachetypes.DBCacheOptions{
+			MaxConcurrentSyncs: 4,
+		},
+	}
+	cache, err := new(DBCacheFactory).NewCache(ctx, options)
+	t.NoError(err)
+	t.NotNil(cache)
+	dc := cache.(*dbCache)
+	t.NotNil(dc.syncSemaphore, "semaphore should be created when MaxConcurrentSyncs > 0")
+}
+
+func (t *DbTestSuite) TestDBCacheFactory_NewCacheWithoutSemaphore() {
+	ctx := t.Context()
+
+	// With MaxConcurrentSyncs == 0, no semaphore
+	options := cachetypes.CacheOptions{
+		RepoSyncFrequency: 60 * time.Minute,
+		DBCacheOptions: cachetypes.DBCacheOptions{
+			MaxConcurrentSyncs: 0,
+		},
+	}
+	cache, err := new(DBCacheFactory).NewCache(ctx, options)
+	t.NoError(err)
+	t.NotNil(cache)
+	dc := cache.(*dbCache)
+	t.Nil(dc.syncSemaphore, "semaphore should be nil when MaxConcurrentSyncs == 0")
+}

--- a/pkg/cache/dbcache/dbcachefactory.go
+++ b/pkg/cache/dbcache/dbcachefactory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nephio-project/porch/pkg/cache/repomap"
 	cachetypes "github.com/nephio-project/porch/pkg/cache/types"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 )
 
 var _ cachetypes.CacheFactory = &DBCacheFactory{}
@@ -40,8 +41,14 @@ func (f *DBCacheFactory) NewCache(ctx context.Context, options cachetypes.CacheO
 		return nil, fmt.Errorf("kptfile_status backfill failed: %w", err)
 	}
 
+	var syncSem *semaphore.Weighted
+	if options.DBCacheOptions.MaxConcurrentSyncs > 0 {
+		syncSem = semaphore.NewWeighted(int64(options.DBCacheOptions.MaxConcurrentSyncs))
+	}
+
 	return &dbCache{
-		repositories: repomap.SafeRepoMap{},
-		options:      options,
+		repositories:  repomap.SafeRepoMap{},
+		options:       options,
+		syncSemaphore: syncSem,
 	}, nil
 }

--- a/pkg/cache/dbcache/dbrepository_test.go
+++ b/pkg/cache/dbcache/dbrepository_test.go
@@ -170,7 +170,7 @@ func (t *DbTestSuite) TestDBRepositorySync() {
 		CoreClient:        fakeClient,
 	}
 
-	testRepo.repositorySync = newRepositorySync(testRepo, cacheOptions)
+	testRepo.repositorySync = newRepositorySync(testRepo, cacheOptions, nil)
 
 	err = testRepo.Refresh(ctx)
 	t.Require().True(err == nil || strings.Contains(err.Error(), "already in progress"))

--- a/pkg/cache/dbcache/dbreposync.go
+++ b/pkg/cache/dbcache/dbreposync.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nephio-project/porch/pkg/repository"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 	"k8s.io/klog/v2"
 )
 
@@ -39,6 +40,7 @@ type repositorySync struct {
 	lastExternalPRMap       map[repository.PackageRevisionKey]repository.PackageRevision
 	lastSyncStats           repositorySyncStats
 	syncManager             *sync.SyncManager
+	syncSemaphore           *semaphore.Weighted
 }
 
 type repositorySyncStats struct {
@@ -47,10 +49,11 @@ type repositorySyncStats struct {
 	both         int
 }
 
-func newRepositorySync(repo *dbRepository, options cachetypes.CacheOptions) *repositorySync {
+func newRepositorySync(repo *dbRepository, options cachetypes.CacheOptions, syncSemaphore *semaphore.Weighted) *repositorySync {
 	ctx := context.Background()
 	s := repositorySync{
-		repo: repo,
+		repo:          repo,
+		syncSemaphore: syncSemaphore,
 	}
 
 	s.syncManager = sync.NewSyncManager(&s, options.CoreClient)
@@ -66,6 +69,12 @@ func (s *repositorySync) Stop() {
 
 // SyncOnce implements the SyncHandler interface
 func (s *repositorySync) SyncOnce(ctx context.Context) error {
+	if s.syncSemaphore != nil {
+		if err := s.syncSemaphore.Acquire(ctx, 1); err != nil {
+			return fmt.Errorf("failed to acquire sync semaphore for %+v: %w", s.repo.Key(), err)
+		}
+		defer s.syncSemaphore.Release(1)
+	}
 	var err error
 	s.lastSyncStats, err = s.sync(ctx)
 	return err

--- a/pkg/cache/dbcache/dbreposync_test.go
+++ b/pkg/cache/dbcache/dbreposync_test.go
@@ -15,6 +15,7 @@
 package dbcache
 
 import (
+	"context"
 	"time"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
@@ -28,6 +29,7 @@ import (
 	"github.com/nephio-project/porch/pkg/repository"
 	mockcachetypes "github.com/nephio-project/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,7 +67,7 @@ func (t *DbTestSuite) TestDBRepoSync() {
 		CoreClient:        fakeClient,
 	}
 
-	testRepo.repositorySync = newRepositorySync(testRepo, cacheOptions)
+	testRepo.repositorySync = newRepositorySync(testRepo, cacheOptions, nil)
 	newPRDef := porchapi.PackageRevision{
 		Spec: porchapi.PackageRevisionSpec{
 			RepositoryName: repoName,
@@ -174,7 +176,7 @@ func (t *DbTestSuite) TestDBSyncRunOnceAt() {
 		CoreClient:        fakeClient,
 	}
 
-	sync := newRepositorySync(testRepo, cacheOptions)
+	sync := newRepositorySync(testRepo, cacheOptions, nil)
 	testRepo.repositorySync = sync
 
 	newPRDef := porchapi.PackageRevision{
@@ -346,7 +348,7 @@ func (t *DbTestSuite) TestNewRepositorySync() {
 		CoreClient:        fakeClient,
 	}
 
-	sync := newRepositorySync(testRepo, options)
+	sync := newRepositorySync(testRepo, options, nil)
 	defer func() {
 		if sync != nil {
 			sync.Stop()
@@ -976,4 +978,176 @@ func (t *DbTestSuite) TestCacheExternalPRs_NilResources() {
 	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
 	t.Require().NoError(err)
 	t.Empty(cachedResources, "nil resources should result in empty cached resources")
+}
+
+// TestRepositorySync_SyncOnceWithSemaphore verifies that SyncOnce acquires and releases
+// the semaphore when one is configured
+func (t *DbTestSuite) TestRepositorySync_SyncOnceWithSemaphore() {
+	ctx := t.Context()
+	externalrepo.ExternalRepoInUnitTestMode = true
+	testRepo := t.createTestRepo("test-ns", "sem-sync-repo")
+	defer t.deleteTestRepo(testRepo.Key())
+
+	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
+	t.Require().NoError(err)
+	defer func() {
+		if err := testRepo.Close(ctx); err != nil {
+			t.T().Logf("Failed to close test repo: %v", err)
+		}
+	}()
+
+	sem := semaphore.NewWeighted(1)
+	s := &repositorySync{
+		repo:          testRepo,
+		syncSemaphore: sem,
+	}
+
+	err = s.SyncOnce(ctx)
+	t.Require().NoError(err)
+
+	// Semaphore should be released — verify by acquiring it again
+	acquired := sem.TryAcquire(1)
+	t.True(acquired, "semaphore should be released after SyncOnce completes")
+	if acquired {
+		sem.Release(1)
+	}
+}
+
+// TestRepositorySync_SyncOnceSemaphoreCancelledContext verifies that SyncOnce returns
+// an error when the context is cancelled while waiting for the semaphore
+func (t *DbTestSuite) TestRepositorySync_SyncOnceSemaphoreCancelledContext() {
+	externalrepo.ExternalRepoInUnitTestMode = true
+	testRepo := t.createTestRepo("test-ns", "sem-cancel-repo")
+	defer t.deleteTestRepo(testRepo.Key())
+
+	sem := semaphore.NewWeighted(1)
+	// Exhaust the semaphore so the next acquire blocks
+	sem.Acquire(context.Background(), 1)
+
+	s := &repositorySync{
+		repo:          testRepo,
+		syncSemaphore: sem,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := s.SyncOnce(ctx)
+	t.Require().Error(err)
+	t.Contains(err.Error(), "failed to acquire sync semaphore")
+
+	sem.Release(1)
+}
+
+// TestRepositorySync_SyncOnceNilSemaphore verifies that SyncOnce works without a semaphore
+func (t *DbTestSuite) TestRepositorySync_SyncOnceNilSemaphore() {
+	ctx := t.Context()
+	externalrepo.ExternalRepoInUnitTestMode = true
+	testRepo := t.createTestRepo("test-ns", "nil-sem-repo")
+	defer t.deleteTestRepo(testRepo.Key())
+
+	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
+	t.Require().NoError(err)
+	defer func() {
+		if err := testRepo.Close(ctx); err != nil {
+			t.T().Logf("Failed to close test repo: %v", err)
+		}
+	}()
+
+	s := &repositorySync{
+		repo:          testRepo,
+		syncSemaphore: nil,
+	}
+
+	err = s.SyncOnce(ctx)
+	t.Require().NoError(err)
+}
+
+// TestNewRepositorySyncWithSemaphore verifies that newRepositorySync stores the semaphore
+func (t *DbTestSuite) TestNewRepositorySyncWithSemaphore() {
+	ctx := t.Context()
+	externalrepo.ExternalRepoInUnitTestMode = true
+	testRepo := t.createTestRepo("test-ns", "new-sync-sem-repo")
+	defer t.deleteTestRepo(testRepo.Key())
+
+	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
+	t.Require().NoError(err)
+	defer func() {
+		if err := testRepo.Close(ctx); err != nil {
+			t.T().Logf("Failed to close test repo: %v", err)
+		}
+	}()
+
+	scheme := runtime.NewScheme()
+	_ = configapi.AddToScheme(scheme)
+	fakeClient := testutil.NewFakeClientWithStatus(scheme)
+
+	sem := semaphore.NewWeighted(2)
+	options := cachetypes.CacheOptions{
+		RepoSyncFrequency: 1 * time.Second,
+		CoreClient:        fakeClient,
+	}
+
+	s := newRepositorySync(testRepo, options, sem)
+	defer func() {
+		if s != nil {
+			s.Stop()
+		}
+	}()
+
+	t.NotNil(s)
+	t.Equal(sem, s.syncSemaphore)
+}
+
+// TestRepositorySync_SyncOnceConcurrencyLimit verifies that the semaphore actually
+// limits concurrent syncs by blocking until a slot is free
+func (t *DbTestSuite) TestRepositorySync_SyncOnceConcurrencyLimit() {
+	ctx := t.Context()
+	externalrepo.ExternalRepoInUnitTestMode = true
+
+	testRepo := t.createTestRepo("test-ns", "conc-limit-repo")
+	defer t.deleteTestRepo(testRepo.Key())
+
+	err := testRepo.OpenRepository(ctx, externalrepotypes.ExternalRepoOptions{})
+	t.Require().NoError(err)
+	defer func() {
+		if err := testRepo.Close(ctx); err != nil {
+			t.T().Logf("Failed to close test repo: %v", err)
+		}
+	}()
+
+	// Create a semaphore with capacity 1
+	sem := semaphore.NewWeighted(1)
+
+	// Acquire the semaphore to simulate another sync in progress
+	sem.Acquire(ctx, 1)
+
+	s := &repositorySync{
+		repo:          testRepo,
+		syncSemaphore: sem,
+	}
+
+	// SyncOnce should block waiting for the semaphore
+	done := make(chan error, 1)
+	go func() {
+		done <- s.SyncOnce(ctx)
+	}()
+
+	// Verify it hasn't completed yet (still waiting for semaphore)
+	select {
+	case <-done:
+		t.Fail("SyncOnce should block while semaphore is held, not return immediately")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: still waiting
+	}
+
+	// Release the semaphore — SyncOnce should now proceed and complete
+	sem.Release(1)
+
+	select {
+	case err := <-done:
+		t.Require().NoError(err)
+	case <-time.After(10 * time.Second):
+		t.Fail("SyncOnce should complete after semaphore is released")
+	}
 }

--- a/pkg/cache/types/cachetypes.go
+++ b/pkg/cache/types/cachetypes.go
@@ -54,6 +54,7 @@ type DBCacheOptions struct {
 	MaxConnections     int
 	MaxIdleConnections int
 	MaxConnLifetime    time.Duration
+	MaxConcurrentSyncs int
 }
 
 type CRCacheOptions struct {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -66,6 +66,7 @@ type PorchServerOptions struct {
 	DbMaxConnections     int
 	DbMaxIdleConnections int
 	DbMaxConnLifetime    time.Duration
+	DbMaxConcurrentSyncs int
 	DbPushDrafsToGit     bool
 
 	DefaultImagePrefix       string
@@ -149,6 +150,10 @@ func (o PorchServerOptions) Validate(args []string) error {
 
 	if o.MaxConcurrentLists < 0 {
 		return fmt.Errorf("invalid value for max-parallel-repo-lists: 0 for no limit; > 0 for set limit")
+	}
+
+	if o.DbMaxConcurrentSyncs < 0 {
+		errors = append(errors, fmt.Errorf("invalid value for max-concurrent-db-syncs: 0 for no limit; > 0 for set limit"))
 	}
 
 	return utilerrors.NewAggregate(errors)
@@ -344,6 +349,7 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 					MaxConnections:     o.DbMaxConnections,
 					MaxIdleConnections: o.DbMaxIdleConnections,
 					MaxConnLifetime:    o.DbMaxConnLifetime,
+					MaxConcurrentSyncs: o.DbMaxConcurrentSyncs,
 				},
 			},
 		},
@@ -401,4 +407,5 @@ func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.RepoOperationRetryAttempts, "repo-operation-retry-attempts", 3, "Number of retry attempts for repository operations.")
 	fs.StringSliceVar(&o.RetryableGitErrors, "retryable-git-errors", nil, "Additional retryable git error patterns. Can be specified multiple times or as comma-separated values.")
 	fs.BoolVar(&o.UseUserDefinedCaBundle, "use-user-cabundle", false, "Determine whether to use a user-defined CaBundle for TLS towards the repository system.")
+	fs.IntVar(&o.DbMaxConcurrentSyncs, "max-concurrent-db-syncs", 20, "Maximum number of DB cache repository syncs that can run concurrently. 0 means no limit.")
 }

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -225,3 +225,43 @@ func TestSetupDBCacheConn(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMaxConcurrentDbSyncs(t *testing.T) {
+	opts := NewPorchServerOptions(os.Stdout, os.Stderr)
+	opts.CacheType = "DB"
+
+	// Valid: 0 means no limit
+	opts.DbMaxConcurrentSyncs = 0
+	err := opts.Validate(nil)
+	assert.NoError(t, err)
+
+	// Valid: positive value
+	opts.DbMaxConcurrentSyncs = 4
+	err = opts.Validate(nil)
+	assert.NoError(t, err)
+
+	// Invalid: negative value
+	opts.DbMaxConcurrentSyncs = -1
+	err = opts.Validate(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "max-concurrent-db-syncs")
+}
+
+func TestAddFlagsMaxConcurrentDbSyncs(t *testing.T) {
+	versions := schema.GroupVersions{
+		porchapi.SchemeGroupVersion,
+	}
+	o := PorchServerOptions{
+		RecommendedOptions: genericoptions.NewRecommendedOptions(
+			defaultEtcdPathPrefix,
+			apiserver.Codecs.LegacyCodec(versions...),
+		),
+	}
+	fs := &pflag.FlagSet{}
+	o.AddFlags(fs)
+
+	// Verify the flag exists with default value 20
+	flag := fs.Lookup("max-concurrent-db-syncs")
+	assert.NotNil(t, flag)
+	assert.Equal(t, "20", flag.DefValue)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Add cache-wide rate limiting to db cache syncs
---

## Description
<!-- Describe what this PR does and why -->
- What changed: Introduced concurrency limits for dbcache sync jobs
- Why it’s needed:  Unbounded concurrency could OOMKill Porch-server because of massive concurrency git checkouts
- How it works:  Shares a semaphore between all sync jobs.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Fixes https://github.com/nephio-project/porch/issues/950

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
[x] I have used AI in the creation of this PR.

Kiro used for implementation and unit tests