### PR TITLE
Make function to dump PackageRevisionResources a utility function

### DIFF
--- a/controllers/packagerevisions/pkg/controllers/packagerevision/render.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/render.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	iofs "io/fs"
-	"path"
 	"strings"
 
 	fnresult "github.com/kptdev/kpt/pkg/api/fnresult/v1"
@@ -66,7 +65,7 @@ func newKptRenderer(runtime fn.FunctionRuntime, opts runneroptions.RunnerOptions
 
 func (r *kptRenderer) Render(ctx context.Context, resources map[string]string) (*renderResult, error) {
 	fs := filesys.MakeFsInMemory()
-	pkgPath, err := writeResourcesToFS(fs, resources)
+	pkgPath, err := repository.WriteResourcesToFS(fs, "", resources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write resources for render: %w", err)
 	}
@@ -93,28 +92,6 @@ func (r *kptRenderer) Render(ctx context.Context, resources map[string]string) (
 		results:   resultList,
 		err:       renderErr,
 	}, nil
-}
-
-func writeResourcesToFS(fs filesys.FileSystem, resources map[string]string) (string, error) {
-	var packageDir string
-	for k, v := range resources {
-		dir := path.Dir(k)
-		if dir == "." {
-			dir = "/"
-		}
-		if err := fs.MkdirAll(dir); err != nil {
-			return "", err
-		}
-		if err := fs.WriteFile(path.Join(dir, path.Base(k)), []byte(v)); err != nil {
-			return "", err
-		}
-		if path.Base(k) == "Kptfile" {
-			if packageDir == "" || dir == "/" || strings.HasPrefix(packageDir, dir+"/") {
-				packageDir = dir
-			}
-		}
-	}
-	return packageDir, nil
 }
 
 func readResourcesFromFS(fs filesys.FileSystem) (map[string]string, error) {
@@ -149,7 +126,6 @@ func renderTrigger(pr *porchv1alpha2.PackageRevision) (requested string, annotat
 	source = pr.Status.CreationSource != "" && !isRenderedTrue(pr)
 	return
 }
-
 
 // isRenderStale returns true if the annotation changed during render.
 func isRenderStale(currentAnnotation, rendered string) bool {

--- a/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
+++ b/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
@@ -55,7 +55,10 @@ into your Starlark script, which will cause an error and trigger the output:
 
 ## Dumping resources to disk while debugging rendering in Porch
 
-It is difficult to see what is happening with `PckageRevisionResources` during rendering, especially if a mutation pipeline is buggy. During debugging of rendering in Porch it can be convenient to dump the resources to disk so that regular comparison tools can be used to spot inconsistencies.
+It can be difficult to see what is happening with `PackageRevisionResources` during rendering,
+especially if a mutation pipeline is buggy. During debugging of rendering in Porch it can be
+convenient to dump the resources to disk so that regular comparison tools can be used to
+spot inconsistencies.
 
 For example, the code fragment below calls a render:
 

--- a/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
+++ b/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
@@ -52,3 +52,38 @@ into your Starlark script, which will cause an error and trigger the output:
 
   i = 10/0 # Deliberate division by zero error
 ```
+
+## Dumping resources to disk while debugging rendering in Porch
+
+It is difficult to see what is happening with `PckageRevisionResources` during rendering, especially if a mutation pipeline is buggy. During debugging of rendering in Porch it can be convenient to dump the resources to disk so that regular comparison tools can be used to spot inconsistencies.
+
+For example, the code fragment below calls a render:
+
+```go
+		resources, _, err = th.renderMutation(draftMeta.GetNamespace()).apply(ctx, resources)
+		if err != nil {
+			klog.Error(err)
+			return renderError(err)
+		}
+```
+
+You can temporarily add a call to the `WriteResourcesToFS()` function to dump the "before" and "after" resources to disk for comparison.
+
+```go
+		_, err = repository.WriteResourcesToFS(filesys.MakeFsOnDisk(), "/tmp/before", resources.Contents)
+		if err != nil {
+			klog.Error(err)
+			return renderError(err)
+		}
+
+		resources, _, err = th.renderMutation(draftMeta.GetNamespace()).apply(ctx, resources)
+		if err != nil {
+			klog.Error(err)
+			return renderError(err)
+		}
+		_, err = repository.WriteResourcesToFS(filesys.MakeFsOnDisk(), "/tmp/after", resources.Contents)
+		if err != nil {
+			klog.Error(err)
+			return renderError(err)
+		}
+```

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -17,6 +17,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/nephio-project/porch/pkg/util"
 	pkgerrors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 func ToAPIReadinessGates(kf kptfilev1.KptFile) []porchapi.ReadinessGate {
@@ -208,4 +210,32 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 	}
 
 	return false, nil
+}
+
+func WriteResourcesToFS(fs filesys.FileSystem, rootDir string, resources map[string]string) (string, error) {
+	if err := fs.MkdirAll(rootDir); err != nil {
+		return "", err
+	}
+
+	var packageDir string
+	for k, v := range resources {
+		dir := path.Dir(k)
+		if dir == "." {
+			dir = "/"
+		}
+
+		fullDir := path.Join(rootDir, dir)
+		if err := fs.MkdirAll(fullDir); err != nil {
+			return "", err
+		}
+		if err := fs.WriteFile(path.Join(fullDir, path.Base(k)), []byte(v)); err != nil {
+			return "", err
+		}
+		if path.Base(k) == "Kptfile" {
+			if packageDir == "" || fullDir == "/" || strings.HasPrefix(packageDir, fullDir+"/") {
+				packageDir = dir
+			}
+		}
+	}
+	return packageDir, nil
 }

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -213,8 +213,10 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 }
 
 func WriteResourcesToFS(fs filesys.FileSystem, rootDir string, resources map[string]string) (string, error) {
-	if err := fs.MkdirAll(rootDir); err != nil {
-		return "", err
+	if rootDir != "" {
+		if err := fs.MkdirAll(rootDir); err != nil {
+			return "", err
+		}
 	}
 
 	var packageDir string

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -234,7 +234,7 @@ func WriteResourcesToFS(fs filesys.FileSystem, rootDir string, resources map[str
 			return "", err
 		}
 		if path.Base(k) == "Kptfile" {
-			if packageDir == "" || fullDir == "/" || strings.HasPrefix(packageDir, fullDir+"/") {
+			if packageDir == "" || dir == "/" || strings.HasPrefix(packageDir, dir+"/") {
 				packageDir = dir
 			}
 		}

--- a/pkg/repository/util_test.go
+++ b/pkg/repository/util_test.go
@@ -24,6 +24,7 @@ import (
 	configapi "github.com/nephio-project/porch/api/porchconfig/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 func TestRevision2Int(t *testing.T) {
@@ -248,6 +249,85 @@ func TestValidatePackagePathOverlap(t *testing.T) {
 		packageName: "new",
 	}
 	assert.NoError(t, ValidatePackagePathOverlap(newPr, []PackageRevision{differentRepoRev}))
+}
+
+func TestWriteResourcesToFS(t *testing.T) {
+	tests := []struct {
+		name       string
+		rootDir    string
+		resources  map[string]string
+		wantPkgDir string
+		wantFiles  map[string]string
+	}{
+		{
+			name:       "empty resources",
+			resources:  map[string]string{},
+			wantPkgDir: "",
+		},
+		{
+			name:       "single file at root",
+			resources:  map[string]string{"foo.yaml": "content"},
+			wantPkgDir: "",
+			wantFiles:  map[string]string{"/foo.yaml": "content"},
+		},
+		{
+			name:       "Kptfile at root",
+			resources:  map[string]string{"Kptfile": "kpt-content"},
+			wantPkgDir: "/",
+			wantFiles:  map[string]string{"/Kptfile": "kpt-content"},
+		},
+		{
+			name:       "nested file",
+			resources:  map[string]string{"sub/dir/file.yaml": "nested"},
+			wantPkgDir: "",
+			wantFiles:  map[string]string{"/sub/dir/file.yaml": "nested"},
+		},
+		{
+			name:       "Kptfile in subdir",
+			resources:  map[string]string{"pkg/Kptfile": "kpt"},
+			wantPkgDir: "pkg",
+			wantFiles:  map[string]string{"/pkg/Kptfile": "kpt"},
+		},
+		{
+			name: "Kptfile at root takes precedence over nested",
+			resources: map[string]string{
+				"Kptfile":        "root-kpt",
+				"sub/Kptfile":    "sub-kpt",
+				"sub/file.yaml":  "data",
+			},
+			wantPkgDir: "/",
+			wantFiles: map[string]string{
+				"/Kptfile":       "root-kpt",
+				"/sub/Kptfile":   "sub-kpt",
+				"/sub/file.yaml": "data",
+			},
+		},
+		{
+			name:      "with rootDir",
+			rootDir:   "root",
+			resources: map[string]string{"Kptfile": "kpt", "file.yaml": "data"},
+			wantPkgDir: "/",
+			wantFiles: map[string]string{
+				"/root/Kptfile":   "kpt",
+				"/root/file.yaml": "data",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := filesys.MakeFsInMemory()
+			gotPkgDir, err := WriteResourcesToFS(fs, tt.rootDir, tt.resources)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPkgDir, gotPkgDir)
+
+			for path, wantContent := range tt.wantFiles {
+				data, err := fs.ReadFile(path)
+				assert.NoError(t, err, "reading %s", path)
+				assert.Equal(t, wantContent, string(data))
+			}
+		})
+	}
 }
 
 type fakeReferenceResolver struct {


### PR DESCRIPTION
## Make function to dump PackageRevisionResources a utility function

---

## Description
- What changed:  The `writeResourcesToFS()` function already existed in the package rendering code. This PR moves it out to a utility function and makes it globally visible as `WriteResourcesToFS()`.
- Why it’s needed:  This function is very useful for dumping the `PackageRevisionResources` for a PR to disk while debugging
- How it works:  The existing function is moved and made visible.

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

## AI Disclosure
[x] I have used AI in the creation of this PR.

- I used Amazon Q ti generate the unit tests for the `WriteResourcesToFS()` function, the original function had no test coverage.

