### PR TITLE
Add PrrSizeBytes to v1alpha2 PackageRevision status

### DIFF
--- a/api/generated/openapi/zz_generated.openapi.go
+++ b/api/generated/openapi/zz_generated.openapi.go
@@ -1449,7 +1449,7 @@ func schema_porch_api_porch_v1alpha1_Result(ref common.ReferenceCallback) common
 					},
 					"exec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExecPath is the the absolute os-specific path to the executable file If user provides an executable file with commands, ExecPath should contain the entire input string.",
+							Description: "ExecPath is the absolute OS-specific path to the executable file. If user provides an executable file with commands, ExecPath should contain the entire input string.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
+++ b/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
@@ -373,6 +373,11 @@ spec:
                   - type
                   type: object
                 type: array
+              prrSizeBytes:
+                description: PrrSizeBytes is the total file size, in bytes, of the
+                  package revision's resources.
+                format: int64
+                type: integer
               publishedAt:
                 description: PublishedAt is the time when the package revision was
                   approved.

--- a/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
+++ b/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
@@ -373,8 +373,8 @@ spec:
                   - type
                   type: object
                 type: array
-              prrSizeBytes:
-                description: PrrSizeBytes is the total file size, in bytes, of the
+              resourcesSizeBytes:
+                description: ResourcesSizeBytes is the total file size, in bytes, of the
                   package revision's resources.
                 format: int64
                 type: integer

--- a/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
+++ b/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
@@ -373,11 +373,6 @@ spec:
                   - type
                   type: object
                 type: array
-              resourcesSizeBytes:
-                description: ResourcesSizeBytes is the total file size, in bytes, of the
-                  package revision's resources.
-                format: int64
-                type: integer
               publishedAt:
                 description: PublishedAt is the time when the package revision was
                   approved.

--- a/controllers/config/crd/bases/config.porch.kpt.dev_packagevariants.yaml
+++ b/controllers/config/crd/bases/config.porch.kpt.dev_packagevariants.yaml
@@ -444,7 +444,7 @@ spec:
                                 properties:
                                   exec:
                                     description: |-
-                                      ExecPath is the the absolute os-specific path to the executable file
+                                      ExecPath is the absolute OS-specific path to the executable file.
                                       If user provides an executable file with commands, ExecPath should
                                       contain the entire input string.
                                     type: string

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/packagerevision_controller_test.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/packagerevision_controller_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
+	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,6 +31,7 @@ func setupMockContentDefaults(m *mockrepository.MockPackageContent) {
 	m.EXPECT().GetCommitInfo().Return(time.Time{}, "").Maybe()
 	m.EXPECT().GetLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil).Maybe()
 	m.EXPECT().GetUpstreamLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil).Maybe()
+	m.EXPECT().GetResourceContents(mock.Anything).Return(map[string]string{"Kptfile": "test"}, nil).Maybe()
 }
 
 func newTestReconciler(mockClient *mockclient.MockClient, cache *mockrepository.MockContentCache) *PackageRevisionReconciler {
@@ -385,7 +386,7 @@ func TestReconcileDeletionProposedNoFinalizer(t *testing.T) {
 			*obj.(*porchv1alpha2.PackageRevision) = *pr
 		}).Return(nil)
 	// No Patch expected — finalizer already absent.
-	
+
 	// updateLatestRevisionLabels is called after finalizer removal
 	mockClient.EXPECT().List(mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevisionList"), mock.Anything, mock.Anything).Return(nil)
 
@@ -715,7 +716,7 @@ func TestReconcileOwnerRefRepoLookupFails(t *testing.T) {
 
 	pr := &porchv1alpha2.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pr", Namespace: "default"},
-		Spec: porchv1alpha2.PackageRevisionSpec{RepositoryName: "missing-repo"},
+		Spec:       porchv1alpha2.PackageRevisionSpec{RepositoryName: "missing-repo"},
 	}
 
 	mockClient := mockclient.NewMockClient(t)
@@ -1206,7 +1207,6 @@ func TestReconcileNoSource(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
-
 // mockRenderer is a test double for the renderer interface.
 type mockRenderer struct {
 	resources   map[string]string
@@ -1293,7 +1293,6 @@ func TestReconcileRenderAlreadyRendered(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, result)
 }
-
 
 func TestReconcileRenderSourceTrigger(t *testing.T) {
 	ctx := t.Context()
@@ -1553,7 +1552,6 @@ func TestReconcileSourceCloseDraftFails(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
-
 func TestReconcileRenderErrorSetsStatus(t *testing.T) {
 	// Reconcile should handle reconcileRender returning an error
 	// by logging and returning (no crash, no requeue).
@@ -1665,7 +1663,6 @@ func TestWriteRenderedResourcesCloseDraftFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "close draft after render")
 }
 
-
 func TestReconcileRenderPipelineFailureNoPush(t *testing.T) {
 	ctx := t.Context()
 
@@ -1759,7 +1756,6 @@ func TestReconcileRenderPipelineFailureWithPushWriteFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "render pipeline failed")
 	assert.Nil(t, result)
 }
-
 
 func TestRenderWithConcurrencyLimitRequeues(t *testing.T) {
 	limiter := make(chan struct{}, 1)

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
@@ -62,7 +62,7 @@ func (r *PackageRevisionReconciler) updateStatus(ctx context.Context, pr *porchv
 			status.UpstreamLock = porchv1alpha2.KptLocatorToLocator(upstreamLock)
 		}
 		if resources, err := content.GetResourceContents(ctx); err == nil {
-			status.PrrSizeBytes = repository.CalculateResourcesSize(resources)
+			status.ResourcesSizeBytes = repository.CalculateResourcesSize(resources)
 		}
 	}
 

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
@@ -61,6 +61,9 @@ func (r *PackageRevisionReconciler) updateStatus(ctx context.Context, pr *porchv
 		if _, upstreamLock, err := content.GetUpstreamLock(ctx); err == nil {
 			status.UpstreamLock = porchv1alpha2.KptLocatorToLocator(upstreamLock)
 		}
+		if resources, err := content.GetResourceContents(ctx); err == nil {
+			status.PrrSizeBytes = repository.CalculateResourcesSize(resources)
+		}
 	}
 
 	applyObj := &porchv1alpha2.PackageRevision{

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
@@ -100,7 +100,7 @@ func TestUpdateStatusWithPublishedContent(t *testing.T) {
 	assert.Equal(t, 5, captured.Revision)
 	assert.Equal(t, "user@example.com", captured.PublishedBy)
 	assert.NotNil(t, captured.PublishedAt)
-	assert.Equal(t, int64(8), captured.PrrSizeBytes)
+	assert.Equal(t, int64(8), captured.ResourcesSizeBytes)
 }
 
 func TestUpdateStatusWithDraftContent(t *testing.T) {
@@ -121,7 +121,7 @@ func TestUpdateStatusWithDraftContent(t *testing.T) {
 	assert.Equal(t, 0, captured.Revision)
 	assert.Empty(t, captured.PublishedBy)
 	assert.Nil(t, captured.PublishedAt)
-	assert.Equal(t, int64(13), captured.PrrSizeBytes)
+	assert.Equal(t, int64(13), captured.ResourcesSizeBytes)
 }
 
 func TestUpdateRenderStatusInProgress(t *testing.T) {

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
@@ -88,6 +88,7 @@ func TestUpdateStatusWithPublishedContent(t *testing.T) {
 	content.EXPECT().GetCommitInfo().Return(commitTime, "user@example.com")
 	content.EXPECT().GetLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil)
 	content.EXPECT().GetUpstreamLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil)
+	content.EXPECT().GetResourceContents(mock.Anything).Return(map[string]string{"Kptfile": "abc", "cm.yaml": "defgh"}, nil)
 
 	r := &PackageRevisionReconciler{Client: mockClient}
 	pr := basePR()
@@ -99,6 +100,7 @@ func TestUpdateStatusWithPublishedContent(t *testing.T) {
 	assert.Equal(t, 5, captured.Revision)
 	assert.Equal(t, "user@example.com", captured.PublishedBy)
 	assert.NotNil(t, captured.PublishedAt)
+	assert.Equal(t, int64(8), captured.PrrSizeBytes)
 }
 
 func TestUpdateStatusWithDraftContent(t *testing.T) {
@@ -109,6 +111,7 @@ func TestUpdateStatusWithDraftContent(t *testing.T) {
 	content.EXPECT().Lifecycle(mock.Anything).Return("Draft")
 	content.EXPECT().GetLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil)
 	content.EXPECT().GetUpstreamLock(mock.Anything).Return(kptfilev1.Upstream{}, kptfilev1.Locator{}, nil)
+	content.EXPECT().GetResourceContents(mock.Anything).Return(map[string]string{"Kptfile": "draft-content"}, nil)
 
 	r := &PackageRevisionReconciler{Client: mockClient}
 	pr := basePR()
@@ -118,6 +121,7 @@ func TestUpdateStatusWithDraftContent(t *testing.T) {
 	assert.Equal(t, 0, captured.Revision)
 	assert.Empty(t, captured.PublishedBy)
 	assert.Nil(t, captured.PublishedAt)
+	assert.Equal(t, int64(13), captured.PrrSizeBytes)
 }
 
 func TestUpdateRenderStatusInProgress(t *testing.T) {
@@ -179,7 +183,6 @@ func TestSetRenderFailed(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, renderPatch.Conditions[0].Status)
 	assert.Equal(t, porchv1alpha2.ReasonRenderFailed, renderPatch.Conditions[0].Reason)
 }
-
 
 func TestUpdateKptfileFields(t *testing.T) {
 	mockClient := mockclient.NewMockClient(t)

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
@@ -199,9 +199,19 @@ func (r *RepositoryReconciler) applySeedFields(ctx context.Context, repo *config
 func packageRevisionUpToDate(existing, desired *porchv1alpha2.PackageRevision) bool {
 	return equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
 		existing.Status.Deployment == desired.Status.Deployment &&
-		existing.Status.ResourcesSizeBytes == desired.Status.ResourcesSizeBytes &&
+		resourcesSizeBytesUpToDate(existing.Status.ResourcesSizeBytes, desired.Status.ResourcesSizeBytes) &&
 		equality.Semantic.DeepEqual(existing.Status.UpstreamLock, desired.Status.UpstreamLock) &&
 		equality.Semantic.DeepEqual(existing.Status.SelfLock, desired.Status.SelfLock)
+}
+
+// resourcesSizeBytesUpToDate returns true if the size field doesn't need updating.
+// When desired is 0 (size couldn't be computed, e.g. GetResources failed), we
+// treat the existing value as up-to-date to avoid patch churn.
+func resourcesSizeBytesUpToDate(existing, desired int64) bool {
+	if desired == 0 {
+		return true
+	}
+	return existing == desired
 }
 
 // buildPackageRevision constructs a PackageRevision resource containing only

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
@@ -199,7 +199,7 @@ func (r *RepositoryReconciler) applySeedFields(ctx context.Context, repo *config
 func packageRevisionUpToDate(existing, desired *porchv1alpha2.PackageRevision) bool {
 	return equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
 		existing.Status.Deployment == desired.Status.Deployment &&
-		existing.Status.PrrSizeBytes == desired.Status.PrrSizeBytes &&
+		existing.Status.ResourcesSizeBytes == desired.Status.ResourcesSizeBytes &&
 		equality.Semantic.DeepEqual(existing.Status.UpstreamLock, desired.Status.UpstreamLock) &&
 		equality.Semantic.DeepEqual(existing.Status.SelfLock, desired.Status.SelfLock)
 }
@@ -220,9 +220,9 @@ func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRe
 		// PackageConditions omitted — PR controller owns after first render.
 	}
 
-	// Calculate resource size for status.prrSizeBytes.
+	// Calculate resource size for status.resourcesSizeBytes.
 	if prr, err := pkgRev.GetResources(ctx); err == nil && prr != nil && prr.Spec.Resources != nil {
-		status.PrrSizeBytes = repository.CalculateResourcesSize(prr.Spec.Resources)
+		status.ResourcesSizeBytes = repository.CalculateResourcesSize(prr.Spec.Resources)
 	}
 
 	crd := &porchv1alpha2.PackageRevision{

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
@@ -199,6 +199,7 @@ func (r *RepositoryReconciler) applySeedFields(ctx context.Context, repo *config
 func packageRevisionUpToDate(existing, desired *porchv1alpha2.PackageRevision) bool {
 	return equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
 		existing.Status.Deployment == desired.Status.Deployment &&
+		existing.Status.PrrSizeBytes == desired.Status.PrrSizeBytes &&
 		equality.Semantic.DeepEqual(existing.Status.UpstreamLock, desired.Status.UpstreamLock) &&
 		equality.Semantic.DeepEqual(existing.Status.SelfLock, desired.Status.SelfLock)
 }
@@ -217,6 +218,11 @@ func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRe
 		SelfLock:     porchv1alpha2.KptLocatorToLocator(selfLock),
 		Deployment:   repo.Spec.Deployment,
 		// PackageConditions omitted — PR controller owns after first render.
+	}
+
+	// Calculate resource size for status.prrSizeBytes.
+	if prr, err := pkgRev.GetResources(ctx); err == nil && prr != nil && prr.Spec.Resources != nil {
+		status.PrrSizeBytes = repository.CalculateResourcesSize(prr.Spec.Resources)
 	}
 
 	crd := &porchv1alpha2.PackageRevision{

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -228,7 +228,7 @@ func TestBuildPackageRevision(t *testing.T) {
 		assert.Nil(t, crd.Status.SelfLock)
 	})
 
-	t.Run("PrrSizeBytes calculated from resources", func(t *testing.T) {
+	t.Run("ResourcesSizeBytes calculated from resources", func(t *testing.T) {
 		pkgRev := newFakePkgRev("sized-pkg", "ws1", porchv1alpha2.PackageRevisionLifecyclePublished)
 		pkgRev.resources = map[string]string{
 			"Kptfile": "abc",   // 3 bytes
@@ -238,15 +238,15 @@ func TestBuildPackageRevision(t *testing.T) {
 
 		crd, err := buildPackageRevision(ctx, repo, pkgRev)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(10), crd.Status.PrrSizeBytes)
+		assert.Equal(t, int64(10), crd.Status.ResourcesSizeBytes)
 	})
 
-	t.Run("PrrSizeBytes zero when no resources", func(t *testing.T) {
+	t.Run("ResourcesSizeBytes zero when no resources", func(t *testing.T) {
 		pkgRev := newFakePkgRev("empty-pkg", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
 
 		crd, err := buildPackageRevision(ctx, repo, pkgRev)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), crd.Status.PrrSizeBytes)
+		assert.Equal(t, int64(0), crd.Status.ResourcesSizeBytes)
 	})
 }
 
@@ -282,8 +282,8 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 		{name: "annotations differ - still up to date", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Annotations = map[string]string{"foo": "bar"}
 		}, expected: true},
-		{name: "PrrSizeBytes changed", modify: func(pr *porchv1alpha2.PackageRevision) {
-			pr.Status.PrrSizeBytes = 12345
+		{name: "ResourcesSizeBytes changed", modify: func(pr *porchv1alpha2.PackageRevision) {
+			pr.Status.ResourcesSizeBytes = 12345
 		}, expected: false},
 	}
 

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -298,6 +298,26 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 	}
 }
 
+func TestResourcesSizeBytesUpToDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing int64
+		desired  int64
+		expected bool
+	}{
+		{name: "both zero", existing: 0, desired: 0, expected: true},
+		{name: "equal non-zero", existing: 100, desired: 100, expected: true},
+		{name: "desired changed", existing: 100, desired: 200, expected: false},
+		{name: "desired zero (unknown) - skip comparison", existing: 500, desired: 0, expected: true},
+		{name: "existing zero, desired non-zero", existing: 0, desired: 100, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, resourcesSizeBytesUpToDate(tt.existing, tt.desired))
+		})
+	}
+}
+
 // --- Tests: packageRevisionLabels ---
 
 func TestPackageRevisionLabels(t *testing.T) {

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -91,6 +91,7 @@ type fakePackageRevision struct {
 	commitTime   time.Time
 	commitAuthor string
 	isLatest     bool
+	resources    map[string]string
 }
 
 func (f *fakePackageRevision) KubeObjectNamespace() string                          { return f.key.RKey().Namespace }
@@ -110,6 +111,13 @@ func (f *fakePackageRevision) GetPackageRevision(_ context.Context) (*porchv1alp
 	return nil, nil
 }
 func (f *fakePackageRevision) GetResources(_ context.Context) (*porchv1alpha1.PackageRevisionResources, error) {
+	if f.resources != nil {
+		return &porchv1alpha1.PackageRevisionResources{
+			Spec: porchv1alpha1.PackageRevisionResourcesSpec{
+				Resources: f.resources,
+			},
+		}, nil
+	}
 	return nil, nil
 }
 func (f *fakePackageRevision) GetUpstreamLock(_ context.Context) (kptfilev1.Upstream, kptfilev1.Locator, error) {
@@ -219,6 +227,27 @@ func TestBuildPackageRevision(t *testing.T) {
 		assert.Nil(t, crd.Status.UpstreamLock)
 		assert.Nil(t, crd.Status.SelfLock)
 	})
+
+	t.Run("PrrSizeBytes calculated from resources", func(t *testing.T) {
+		pkgRev := newFakePkgRev("sized-pkg", "ws1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		pkgRev.resources = map[string]string{
+			"Kptfile": "abc",   // 3 bytes
+			"cm.yaml": "defgh", // 5 bytes
+			"ns.yaml": "ij",    // 2 bytes
+		}
+
+		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(10), crd.Status.PrrSizeBytes)
+	})
+
+	t.Run("PrrSizeBytes zero when no resources", func(t *testing.T) {
+		pkgRev := newFakePkgRev("empty-pkg", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
+
+		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), crd.Status.PrrSizeBytes)
+	})
 }
 
 // --- Tests: packageRevisionUpToDate ---
@@ -253,6 +282,9 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 		{name: "annotations differ - still up to date", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Annotations = map[string]string{"foo": "bar"}
 		}, expected: true},
+		{name: "PrrSizeBytes changed", modify: func(pr *porchv1alpha2.PackageRevision) {
+			pr.Status.PrrSizeBytes = 12345
+		}, expected: false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -212,6 +212,16 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 	return false, nil
 }
 
+// CalculateResourcesSize returns the total byte size of a package's resource
+// file contents. This is used to populate status.prrSizeBytes on the CRD.
+func CalculateResourcesSize(resources map[string]string) int64 {
+	var total int64
+	for _, v := range resources {
+		total += int64(len(v))
+	}
+	return total
+}
+
 func WriteResourcesToFS(fs filesys.FileSystem, rootDir string, resources map[string]string) (string, error) {
 	if rootDir != "" {
 		if err := fs.MkdirAll(rootDir); err != nil {

--- a/pkg/repository/util.go
+++ b/pkg/repository/util.go
@@ -213,7 +213,7 @@ func PackageRevisionIsPlaceholder(ctx context.Context, namespace string, referen
 }
 
 // CalculateResourcesSize returns the total byte size of a package's resource
-// file contents. This is used to populate status.prrSizeBytes on the CRD.
+// file contents. This is used to populate status.resourcesSizeBytes on the CRD.
 func CalculateResourcesSize(resources map[string]string) int64 {
 	var total int64
 	for _, v := range resources {

--- a/pkg/repository/util_test.go
+++ b/pkg/repository/util_test.go
@@ -217,6 +217,51 @@ func TestPathsOverlap(t *testing.T) {
 	assert.False(t, PathsOverlap("pkg", "pkg-other"))
 }
 
+func TestCalculateResourcesSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources map[string]string
+		want      int64
+	}{
+		{
+			name:      "nil map",
+			resources: nil,
+			want:      0,
+		},
+		{
+			name:      "empty map",
+			resources: map[string]string{},
+			want:      0,
+		},
+		{
+			name:      "single file",
+			resources: map[string]string{"Kptfile": "hello"},
+			want:      5,
+		},
+		{
+			name: "multiple files",
+			resources: map[string]string{
+				"Kptfile":    "abc",
+				"cm.yaml":    "defgh",
+				"nested.txt": "ij",
+			},
+			want: 10,
+		},
+		{
+			name:      "multi-byte UTF-8 characters",
+			resources: map[string]string{"file.yaml": "héllo"}, // é is 2 bytes in UTF-8
+			want:      6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateResourcesSize(tt.resources)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidatePackagePathOverlap(t *testing.T) {
 	newPr := &porchapi.PackageRevision{
 		Spec: porchapi.PackageRevisionSpec{

--- a/test/e2e/crd/clone_test.go
+++ b/test/e2e/crd/clone_test.go
@@ -58,6 +58,9 @@ var _ = Describe("Clone", Ordered, Label("lifecycle"), func() {
 		Expect(pr.Status.SelfLock).NotTo(BeNil())
 		Expect(pr.Status.SelfLock.Git).NotTo(BeNil())
 		Expect(pr.Status.SelfLock.Git.Commit).NotTo(BeEmpty())
+
+		By("verifying PrrSizeBytes is populated")
+		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should clone into a deployment repository", func() {

--- a/test/e2e/crd/clone_test.go
+++ b/test/e2e/crd/clone_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Clone", Ordered, Label("lifecycle"), func() {
 		Expect(pr.Status.SelfLock.Git).NotTo(BeNil())
 		Expect(pr.Status.SelfLock.Git.Commit).NotTo(BeEmpty())
 
-		By("verifying PrrSizeBytes is populated")
-		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
+		By("verifying ResourcesSizeBytes is populated")
+		Expect(pr.Status.ResourcesSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should clone into a deployment repository", func() {

--- a/test/e2e/crd/init_test.go
+++ b/test/e2e/crd/init_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Init", Ordered, Label("lifecycle"), func() {
 		resources := getPRRResources(env.Ctx, env.Namespace, pr.Name)
 		Expect(resources).To(HaveKey("Kptfile"))
 
-		By("verifying PrrSizeBytes is populated")
-		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
+		By("verifying ResourcesSizeBytes is populated")
+		Expect(pr.Status.ResourcesSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should init a package with full metadata", func() {

--- a/test/e2e/crd/init_test.go
+++ b/test/e2e/crd/init_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Init", Ordered, Label("lifecycle"), func() {
 		By("verifying Kptfile exists in package content")
 		resources := getPRRResources(env.Ctx, env.Namespace, pr.Name)
 		Expect(resources).To(HaveKey("Kptfile"))
+
+		By("verifying PrrSizeBytes is populated")
+		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should init a package with full metadata", func() {

--- a/test/e2e/crd/push_test.go
+++ b/test/e2e/crd/push_test.go
@@ -37,6 +37,10 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 		waitForReady(env.Ctx, pr)
 		waitForPRRVisible(env.Ctx, env.Namespace, pr.Name)
 
+		By("recording initial PrrSizeBytes")
+		initialSize := pr.Status.PrrSizeBytes
+		Expect(initialSize).To(BeNumerically(">", int64(0)))
+
 		By("pushing a new ConfigMap via PRR")
 		updatePRRResources(env.Ctx, env.Namespace, pr.Name, map[string]string{
 			"configmap.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: push-test-cm\ndata:\n  key: value\n",
@@ -51,6 +55,12 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 			g.Expect(resources).To(HaveKey("configmap.yaml"))
 			g.Expect(resources["configmap.yaml"]).To(ContainSubstring("push-test-cm"))
 			g.Expect(resources).To(HaveKey("Kptfile"))
+		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
+
+		By("verifying PrrSizeBytes increased after push")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKeyFromObject(pr), pr)).To(Succeed())
+			g.Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", initialSize))
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 	})
 
@@ -78,7 +88,11 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 
 		By("pushing Kptfile with set-namespace:v0.4.5 (builtin) using configMap")
 		updatePRRResources(env.Ctx, env.Namespace, pr.Name, map[string]string{
+<<<<<<< HEAD
 			"Kptfile":         "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: render-push\npipeline:\n  mutators:\n  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.5\n    configMap:\n      namespace: render-push-ns\n",
+=======
+			"Kptfile":         "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: render-push\npipeline:\n  mutators:\n  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1\n    configMap:\n      namespace: render-push-ns\n",
+>>>>>>> ff83f5be (Add PrrSizeBytes to v1alpha2 PackageRevision status)
 			"deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test-deploy\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: test\n  template:\n    metadata:\n      labels:\n        app: test\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:latest\n",
 		})
 

--- a/test/e2e/crd/push_test.go
+++ b/test/e2e/crd/push_test.go
@@ -37,8 +37,8 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 		waitForReady(env.Ctx, pr)
 		waitForPRRVisible(env.Ctx, env.Namespace, pr.Name)
 
-		By("recording initial PrrSizeBytes")
-		initialSize := pr.Status.PrrSizeBytes
+		By("recording initial ResourcesSizeBytes")
+		initialSize := pr.Status.ResourcesSizeBytes
 		Expect(initialSize).To(BeNumerically(">", int64(0)))
 
 		By("pushing a new ConfigMap via PRR")
@@ -57,10 +57,10 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 			g.Expect(resources).To(HaveKey("Kptfile"))
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 
-		By("verifying PrrSizeBytes increased after push")
+		By("verifying ResourcesSizeBytes increased after push")
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKeyFromObject(pr), pr)).To(Succeed())
-			g.Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", initialSize))
+			g.Expect(pr.Status.ResourcesSizeBytes).To(BeNumerically(">", initialSize))
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 	})
 
@@ -88,11 +88,7 @@ var _ = Describe("Push", Ordered, Label("content"), func() {
 
 		By("pushing Kptfile with set-namespace:v0.4.5 (builtin) using configMap")
 		updatePRRResources(env.Ctx, env.Namespace, pr.Name, map[string]string{
-<<<<<<< HEAD
 			"Kptfile":         "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: render-push\npipeline:\n  mutators:\n  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.5\n    configMap:\n      namespace: render-push-ns\n",
-=======
-			"Kptfile":         "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: render-push\npipeline:\n  mutators:\n  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1\n    configMap:\n      namespace: render-push-ns\n",
->>>>>>> ff83f5be (Add PrrSizeBytes to v1alpha2 PackageRevision status)
 			"deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test-deploy\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: test\n  template:\n    metadata:\n      labels:\n        app: test\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:latest\n",
 		})
 

--- a/test/e2e/crd/repository_test.go
+++ b/test/e2e/crd/repository_test.go
@@ -328,8 +328,8 @@ var _ = Describe("Repository", Ordered, Label("infra"), func() {
 		Expect(pr.Spec.RepositoryName).To(Equal(testBlueprintsRepo))
 		Expect(pr.Spec.Lifecycle).To(Equal(porchv1alpha2.PackageRevisionLifecyclePublished))
 
-		By("verifying PrrSizeBytes is populated for discovered package")
-		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
+		By("verifying ResourcesSizeBytes is populated for discovered package")
+		Expect(pr.Status.ResourcesSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should seed lifecycle and revision for discovered published packages", func() {

--- a/test/e2e/crd/repository_test.go
+++ b/test/e2e/crd/repository_test.go
@@ -327,6 +327,9 @@ var _ = Describe("Repository", Ordered, Label("infra"), func() {
 		Expect(pr.Spec.PackageName).To(Equal("basens"))
 		Expect(pr.Spec.RepositoryName).To(Equal(testBlueprintsRepo))
 		Expect(pr.Spec.Lifecycle).To(Equal(porchv1alpha2.PackageRevisionLifecyclePublished))
+
+		By("verifying PrrSizeBytes is populated for discovered package")
+		Expect(pr.Status.PrrSizeBytes).To(BeNumerically(">", int64(0)))
 	})
 
 	It("should seed lifecycle and revision for discovered published packages", func() {


### PR DESCRIPTION
## Description
- What changed: PR controller and repo controller now calculate and set `status.prrSizeBytes` on v1alpha2 CRDs
- Why: Users need to see package resource size without fetching content — enables client-side filtering for oversized packages
- How: Both controllers calculate size from the in-memory resource map (already loaded) and include it in their SSA status patches

## Related Issue(s)
- Fixes https://github.com/nephio-project/porch/issues/572
- Related to #954 (v1alpha1 implementation)

## Type of Change
- [x] New feature
- [x] Tests

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

## Testing Instructions
1. Deploy porch with this change
2. Create a v1alpha2 package (init, clone, or push)
3. `kubectl get packagerevision <name> -o yaml` — verify `status.prrSizeBytes > 0`
4. Push new content — verify size increases

## Additional Notes
- Independent of PR #954 (v1alpha1 impl) — only needs the v1alpha2 type definition which is included here
- Size is calculated from in-memory resource map, no extra DB queries
- E2E covers init, clone, push, and repo discovery paths

## AI Disclosure
[x] I have used AI in the creation of this PR.

- Kiro to implement the feature, write unit tests, and extend E2E tests
- The author has fully verified all code