### PR TITLE
Cherry-Pick: Prune empty git subtrees after package deletion in subdirectories to 1.5

### DIFF
--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -36,6 +36,9 @@ const (
 	porchSignatureEmail = "porch@kpt.dev"
 )
 
+// emptyGitTreeHash is the well-known git hash for an empty tree object.
+var emptyGitTreeHash = plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+
 type commitHelper struct {
 	repository *git.Repository
 
@@ -337,6 +340,7 @@ func (h *commitHelper) storeBlobHashInTrees(fullPath string, hash plumbing.Hash)
 }
 
 // storeTrees writes the tree at treePath to git, first writing all child trees.
+// Empty subtrees are pruned so that deleting a package does not leave behind empty ancestor directories
 func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 	tree, ok := h.trees[treePath]
 	if !ok {
@@ -348,22 +352,23 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
 	})
 
-	// Store all child trees and get their hashes
+	// Store all child trees, pruning any that resolve to empty
+	remaining := entries[:0]
 	for i := range entries {
 		e := &entries[i]
-		if e.Mode != filemode.Dir {
-			continue
+		if e.Mode == filemode.Dir && e.Hash.IsZero() {
+			hash, err := h.storeTrees(path.Join(treePath, e.Name))
+			if err != nil {
+				return plumbing.Hash{}, err
+			}
+			if hash == emptyGitTreeHash {
+				continue
+			}
+			e.Hash = hash
 		}
-		if !e.Hash.IsZero() {
-			continue
-		}
-
-		hash, err := h.storeTrees(path.Join(treePath, e.Name))
-		if err != nil {
-			return plumbing.Hash{}, err
-		}
-		e.Hash = hash
+		remaining = append(remaining, *e)
 	}
+	tree.Entries = remaining
 
 	treeHash, err := storeTree(h.repository, tree)
 	if err != nil {

--- a/pkg/externalrepo/git/commit_test.go
+++ b/pkg/externalrepo/git/commit_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/nephio-project/porch/pkg/repository"
@@ -239,5 +240,97 @@ func TestCommitWithUser(t *testing.T) {
 		if got, want := commit.Message, message; got != want {
 			t.Errorf("Commit.Message: got %q, want %q", got, want)
 		}
+	}
+}
+
+func createPackageCommit(t *testing.T, repo *gogit.Repository, parentHash plumbing.Hash, packagePath string) plumbing.Hash {
+	t.Helper()
+	ch, err := newCommitHelper(repo, nil, parentHash, packagePath, plumbing.ZeroHash)
+	if err != nil {
+		t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
+	}
+	if err := ch.storeFile(path.Join(packagePath, "Kptfile"), "apiVersion: kpt.dev/v1"); err != nil {
+		t.Fatalf("storeFile failed: %v", err)
+	}
+	hash, _, err := ch.commit(context.Background(), fmt.Sprintf("Create %s", packagePath), packagePath)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+	return hash
+}
+
+func deletePackageCommit(t *testing.T, repo *gogit.Repository, parentHash plumbing.Hash, packagePath string) plumbing.Hash {
+	t.Helper()
+	ch, err := newCommitHelper(repo, nil, parentHash, packagePath, plumbing.ZeroHash)
+	if err != nil {
+		t.Fatalf("newCommitHelper(%q) for deletion failed: %v", packagePath, err)
+	}
+	hash, _, err := ch.commit(context.Background(), fmt.Sprintf("Delete %s", packagePath), packagePath)
+	if err != nil {
+		t.Fatalf("delete commit failed: %v", err)
+	}
+	return hash
+}
+
+func TestStoreTreesPrunesEmptySubdirectory(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	createHash := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "subdir/testpkg")
+	deleteHash := deletePackageCommit(t, gitRepo, createHash, "subdir/testpkg")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	for _, entry := range root.Entries {
+		if entry.Name == "subdir" {
+			t.Errorf("expected 'subdir' to be pruned from root tree, but it still exists")
+		}
+	}
+}
+
+func TestStoreTreesPrunesNestedEmptySubdirectories(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	createHash := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "level1/level2/testpkg")
+	deleteHash := deletePackageCommit(t, gitRepo, createHash, "level1/level2/testpkg")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	for _, entry := range root.Entries {
+		if entry.Name == "level1" {
+			t.Errorf("expected 'level1' to be pruned from root tree, but it still exists")
+		}
+	}
+}
+
+func TestStoreTreesRetainsNonEmptySubdirectory(t *testing.T) {
+	tempdir := t.TempDir()
+	gitRepo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "empty-repository.tar"), tempdir)
+
+	commitA := createPackageCommit(t, gitRepo, plumbing.ZeroHash, "subdir/pkg-a")
+	commitB := createPackageCommit(t, gitRepo, commitA, "subdir/pkg-b")
+	deleteHash := deletePackageCommit(t, gitRepo, commitB, "subdir/pkg-a")
+
+	root := getCommitTree(t, gitRepo, deleteHash)
+	subdirEntry := findTreeEntry(t, root, "subdir")
+	if subdirEntry == nil {
+		t.Fatalf("expected 'subdir' to still exist since pkg-b is still there")
+	}
+
+	subdirTree, err := object.GetTree(gitRepo.Storer, subdirEntry.Hash)
+	if err != nil {
+		t.Fatalf("failed to get subdir tree: %v", err)
+	}
+
+	foundPkgB := false
+	for _, entry := range subdirTree.Entries {
+		if entry.Name == "pkg-a" {
+			t.Errorf("expected 'pkg-a' to be deleted but it still exists")
+		}
+		if entry.Name == "pkg-b" {
+			foundPkgB = true
+		}
+	}
+	if !foundPkgB {
+		t.Errorf("expected 'pkg-b' to still exist in subdir")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Cherry-Pick: Prune empty git subtrees after package deletion in subdirectories to 1.5

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  brought changes from #546 into 1.5 branch
- Why it’s needed:  bugfix for 1.5
- How it works:  just a cherry pick

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure
- [ ] I have used AI in the creation of this PR.

