### PR TITLE
Clean up missed nephio references

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE_TAG  ?= latest
-IMAGE_REPO ?= docker.io/nephio
+IMAGE_REPO ?= ghcr.io/kptdev
 IMAGE_NAME ?= porch-server
 PORCHDIR = $(abspath $(CURDIR)/..)
 ALPINE_VERSION ?= 3.23.3

--- a/scripts/get-kind-metallb-subnet.sh
+++ b/scripts/get-kind-metallb-subnet.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2026 The kpt and Nephio Authors
+# Copyright 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Clean up missed Nephio references

---

## Description
- What changed:  Two references to Nephio that were missed are converted to kpt references
- Why it’s needed:  Porch has been moved from Nephio
- How it works:  References changed

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.
