### PR TITLE
Reverse logic on DoPRMutations to reduce indentation

### DIFF
--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -130,41 +130,41 @@ func (th *genericTaskHandler) DoPRMutations(
 	defer span.End()
 
 	// Update package contents only if the package is in draft state
-	if oldObj.Spec.Lifecycle == porchapi.PackageRevisionLifecycleDraft {
-		apiResources, err := repoPR.GetResources(ctx)
-		if err != nil {
-			return fmt.Errorf("cannot get package resources: %w", err)
-		}
-		resources := repository.PackageResources{
-			Contents: apiResources.Spec.Resources,
-		}
-
-		newKptfileContent, changed, err := PatchKptfile(ctx, repoPR, newObj)
-		if err != nil {
-			return err
-		}
-		if changed && newKptfileContent != "" && newKptfileContent != "{}\n" {
-			resources.Contents[kptfilev1.KptFileName] = newKptfileContent
-		}
-
-		// render
-		draftMeta := draft.GetMeta()
-		resources, _, err = th.renderMutation(draftMeta.GetNamespace()).apply(ctx, resources)
-		if err != nil {
-			klog.Error(err)
-			return renderError(err)
-		}
-
-		prr := &porchapi.PackageRevisionResources{
-			Spec: porchapi.PackageRevisionResourcesSpec{
-				Resources: resources.Contents,
-			},
-		}
-
-		return draft.UpdateResources(ctx, prr, &porchapi.Task{Type: porchapi.TaskTypeRender})
+	if oldObj.Spec.Lifecycle != porchapi.PackageRevisionLifecycleDraft {
+		return nil
 	}
 
-	return nil
+	apiResources, err := repoPR.GetResources(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get package resources: %w", err)
+	}
+	resources := repository.PackageResources{
+		Contents: apiResources.Spec.Resources,
+	}
+
+	newKptfileContent, changed, err := PatchKptfile(ctx, repoPR, newObj)
+	if err != nil {
+		return err
+	}
+	if changed && newKptfileContent != "" && newKptfileContent != "{}\n" {
+		resources.Contents[kptfilev1.KptFileName] = newKptfileContent
+	}
+
+	// render
+	draftMeta := draft.GetMeta()
+	resources, _, err = th.renderMutation(draftMeta.GetNamespace()).apply(ctx, resources)
+	if err != nil {
+		klog.Error(err)
+		return renderError(err)
+	}
+
+	prr := &porchapi.PackageRevisionResources{
+		Spec: porchapi.PackageRevisionResourcesSpec{
+			Resources: resources.Contents,
+		},
+	}
+
+	return draft.UpdateResources(ctx, prr, &porchapi.Task{Type: porchapi.TaskTypeRender})
 }
 
 func (th *genericTaskHandler) DoPRResourceMutations(


### PR DESCRIPTION
## Reverse logic on DoPRMutations to reduce indentation


---

## Description
- What changed:  Reversed logic in `pkg/task/generictaskhandler.go` function `DoPRMutations`
- Why it’s needed:  To simplify code
- How it works:  Same as it did before

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## AI Disclosure
[ ] I have used AI in the creation of this PR.
