### PR TITLE
Fix latest=true flag handling in dbpackagerevision publishPR function

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -537,6 +537,10 @@ func (pr *dbPackageRevision) publishPR(ctx context.Context, newLifecycle porchap
 		return pkgerrors.Wrapf(err, "dbPackageRevision:publishPR: failed to save package revision %+v to database after push to external repo", pr.Key())
 	}
 
+	// The DB trigger sets latest=TRUE for the newly published revision.
+	// Reflect that in memory so notifications carry the correct label.
+	pr.latest = true
+
 	return pr.publishPlaceholderPRForPR(ctx)
 }
 

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -147,6 +147,7 @@ info:
 
 	err = dbPR.UpdateLifecycle(ctx, porchapi.PackageRevisionLifecyclePublished)
 	t.Require().NoError(err)
+	t.Require().True(dbPR.(*dbPackageRevision).latest, "expected latest to be true after publishing")
 
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
 	t.Require().NoError(err)
@@ -221,14 +222,15 @@ upstreamLock:
     ref: drafts/basens-edit/update-1
     commit: 960e1b80b5245874e46ba2b3090b27deaa61eb9a`
 
-	newDBPR2 := dbPR.(*dbPackageRevision)
+	newDBPR2, err := pkgRevReadFromDB(ctx, dbPR.Key(), true)
+	t.Require().NoError(err)
 
 	err = newDBPR2.UpdateResources(ctx, prResources, &porchapi.Task{})
 	t.Require().NoError(err)
 
 	t.Require().False(newDBPR2.IsLatestRevision())
 
-	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
+	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, newDBPR2, 0)
 	t.Require().NoError(err)
 	t.Require().NotNil(dbPR)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Fix latest=true flag handling in dbpackagerevision publishPR function

---

## Description
<!-- Describe what this PR does and why -->
-What changed: In publishPR(), set pr.latest = true in memory after assigning the new revision number and lifecycle, so the in-memory object reflects what the DB trigger will set.

-Why it's needed: When a package revision is published, a PostgreSQL trigger sets latest=TRUE on the row. However, the in-memory dbPackageRevision object was never updated to reflect this. Watch notifications sent immediately after publish used this stale in-memory object (with latest=false), so watchers never received the kpt.dev/latest-revision=true label on the Modified event.

-How it works: publishPR always publishes as latestRev + 1 — the highest revision — so it's guaranteed to be the latest at that point. Setting pr.latest = true before the DB write ensures the object used in subsequent notifications (via NotifyPackageRevisionChange) carries the correct label. The placeholder (.main) is unaffected because ToMainPackageRevision() hardcodes latest: false.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

If so, please describe how:
  - E.g. Microsoft Copilot to analyse the code.
  - E.g. Claude code to generate the function someNewFunctionIAdded().
  - E.g. Kiro to generate unit tests.
