### PR TITLE
Rename all import aliases of `pkg/util/context` to `pctx`

### DIFF
--- a/controllers/repositories/pkg/controllers/repository/repository_controller.go
+++ b/controllers/repositories/pkg/controllers/repository/repository_controller.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	porchcontext "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,7 +86,7 @@ func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	log := log.FromContext(ctx)
 	log.V(2).Info("Repository reconcile triggered")
 
-	ctx = porchcontext.WithNewRequestID(ctx)
+	ctx = pctx.WithNewRequestID(ctx)
 
 	// Check if cache is available - this should never happen if SetupWithManager succeeded
 	if r.Cache == nil {
@@ -234,7 +234,7 @@ func (r *RepositoryReconciler) performFullSync(ctx context.Context, repo *api.Re
 			// Use background context for async operation (prevents cancellation)
 			asyncCtx := ctrl.LoggerInto(context.Background(), log)
 			// Pass original request ID
-			asyncCtx = porchcontext.WithRequestID(asyncCtx, porchcontext.GetRequestID(ctx))
+			asyncCtx = pctx.WithRequestID(asyncCtx, pctx.GetRequestID(ctx))
 			// Make a copy to avoid race conditions with caller's repo object
 			repoCopy := repo.DeepCopy()
 			sync := &Sync{reconciler: r}

--- a/pkg/cache/crcache/repository.go
+++ b/pkg/cache/crcache/repository.go
@@ -23,7 +23,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/cache/crcache/meta"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 
 	cachetypes "github.com/kptdev/porch/pkg/cache/types"
 	"github.com/kptdev/porch/pkg/repository"
@@ -109,10 +109,10 @@ func (r *cachedRepository) BranchCommitHash(ctx context.Context) (string, error)
 
 func (r *cachedRepository) ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
 	klog.V(3).InfoS("[CR Cache] Retrieving cached package revisions and enriching with PackageRev CR metadata from etcd for repository",
-		context1.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
+		pctx.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
 	defer func() {
 		klog.V(3).InfoS("[CR Cache] Completed retrieving and enriching package revisions with PackageRev CR metadata for repository",
-			context1.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
+			pctx.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
 	}()
 
 	packages, err := r.getPackageRevisions(ctx, filter, false)
@@ -202,9 +202,9 @@ func (r *cachedRepository) getCachedPackages(ctx context.Context, forceRefresh b
 }
 
 func (r *cachedRepository) CreatePackageRevisionDraft(ctx context.Context, obj *porchapi.PackageRevision) (repository.PackageRevisionDraft, error) {
-	klog.InfoS("[CR Cache] Creating draft and preparing to save to Git for PackageRevision", context1.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Creating draft and preparing to save to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft created and saved to Git for PackageRevision", context1.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft created and saved to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	}()
 
 	return r.repo.CreatePackageRevisionDraft(ctx, obj)
@@ -214,9 +214,9 @@ func (r *cachedRepository) ClosePackageRevisionDraft(ctx context.Context, prd re
 	ctx, span := tracer.Start(ctx, "cachedRepository::ClosePackageRevisionDraft", trace.WithAttributes())
 	defer span.End()
 
-	klog.InfoS("[CR Cache] Closing draft and pushing lifecycle change to Git for PackageRevision", context1.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Closing draft and pushing lifecycle change to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft closed and lifecycle change pushed to Git for PackageRevision", context1.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft closed and lifecycle change pushed to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	}()
 
 	v, err := r.Version(ctx)
@@ -285,9 +285,9 @@ func (r *cachedRepository) ClosePackageRevisionDraft(ctx context.Context, prd re
 }
 
 func (r *cachedRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
-	klog.InfoS("[CR Cache] Loading draft for update from Git for PackageRevision", context1.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Loading draft for update from Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft loaded and ready for modifications for PackageRevision", context1.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft loaded and ready for modifications for PackageRevision", pctx.LogMetadataFrom(ctx))
 	}()
 
 	// Unwrap
@@ -407,9 +407,9 @@ func (r *cachedRepository) DeletePackageRevision(ctx context.Context, prToDelete
 	// terminating state.
 	// But we only delete the PackageRevision from the repo once all finalizers
 	// have been removed.
-	klog.InfoS("[CR Cache] Deleting PackageRev CR from etcd and branch from Git for PackageRevision", context1.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Deleting PackageRev CR from etcd and branch from Git for PackageRevision", pctx.LogMetadataFrom(ctx))
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] PackageRev CR and Git branch deleted for PackageRevision", context1.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] PackageRev CR and Git branch deleted for PackageRevision", pctx.LogMetadataFrom(ctx))
 	}()
 
 	namespacedName := types.NamespacedName{

--- a/pkg/cache/crcache/repository.go
+++ b/pkg/cache/crcache/repository.go
@@ -202,9 +202,9 @@ func (r *cachedRepository) getCachedPackages(ctx context.Context, forceRefresh b
 }
 
 func (r *cachedRepository) CreatePackageRevisionDraft(ctx context.Context, obj *porchapi.PackageRevision) (repository.PackageRevisionDraft, error) {
-	klog.InfoS("[CR Cache] Creating draft and preparing to save to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Creating draft and preparing to save to Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft created and saved to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft created and saved to Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	return r.repo.CreatePackageRevisionDraft(ctx, obj)
@@ -214,9 +214,9 @@ func (r *cachedRepository) ClosePackageRevisionDraft(ctx context.Context, prd re
 	ctx, span := tracer.Start(ctx, "cachedRepository::ClosePackageRevisionDraft", trace.WithAttributes())
 	defer span.End()
 
-	klog.InfoS("[CR Cache] Closing draft and pushing lifecycle change to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Closing draft and pushing lifecycle change to Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft closed and lifecycle change pushed to Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft closed and lifecycle change pushed to Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	v, err := r.Version(ctx)
@@ -285,9 +285,9 @@ func (r *cachedRepository) ClosePackageRevisionDraft(ctx context.Context, prd re
 }
 
 func (r *cachedRepository) UpdatePackageRevision(ctx context.Context, old repository.PackageRevision) (repository.PackageRevisionDraft, error) {
-	klog.InfoS("[CR Cache] Loading draft for update from Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Loading draft for update from Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] Draft loaded and ready for modifications for PackageRevision", pctx.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] Draft loaded and ready for modifications for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	// Unwrap
@@ -407,9 +407,9 @@ func (r *cachedRepository) DeletePackageRevision(ctx context.Context, prToDelete
 	// terminating state.
 	// But we only delete the PackageRevision from the repo once all finalizers
 	// have been removed.
-	klog.InfoS("[CR Cache] Deleting PackageRev CR from etcd and branch from Git for PackageRevision", pctx.LogMetadataFrom(ctx))
+	klog.InfoS("[CR Cache] Deleting PackageRev CR from etcd and branch from Git for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[CR Cache] PackageRev CR and Git branch deleted for PackageRevision", pctx.LogMetadataFrom(ctx))
+		klog.V(3).InfoS("[CR Cache] PackageRev CR and Git branch deleted for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	namespacedName := types.NamespacedName{

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kptdev/porch/pkg/engine"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -187,20 +187,20 @@ func (pr *dbPackageRevision) UpdateLifecycle(ctx context.Context, newLifecycle p
 	// Only Approve (Proposed → Published) pushes to external repo
 	if pr.lifecycle == porchapi.PackageRevisionLifecycleProposed && newLifecycle == porchapi.PackageRevisionLifecyclePublished {
 		klog.InfoS("[DB Cache] Updating lifecycle in database and pushing to external repo for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] Lifecycle updated in database and pushed to external repo for PackageRevision",
-				context1.LogMetadataFrom(ctx)...)
+				pctx.LogMetadataFrom(ctx)...)
 		}()
 	} else if pr.repo.pushDraftsToGit && pr.gitPRDraft != nil {
-		klog.InfoS("[DB Cache] Updating lifecycle in database and in Git draft for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.InfoS("[DB Cache] Updating lifecycle in database and in Git draft for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		defer func() {
-			klog.V(3).InfoS("[DB Cache] Lifecycle updated in database and in Git draft for PackageRevision", context1.LogMetadataFrom(ctx)...)
+			klog.V(3).InfoS("[DB Cache] Lifecycle updated in database and in Git draft for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		}()
 	} else {
-		klog.InfoS("[DB Cache] Updating lifecycle in database for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.InfoS("[DB Cache] Updating lifecycle in database for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		defer func() {
-			klog.V(3).InfoS("[DB Cache] Lifecycle updated in database for PackageRevision", context1.LogMetadataFrom(ctx)...)
+			klog.V(3).InfoS("[DB Cache] Lifecycle updated in database for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		}()
 	}
 
@@ -463,14 +463,14 @@ func (pr *dbPackageRevision) UpdateResources(ctx context.Context, new *porchapi.
 	}
 
 	if pr.repo.pushDraftsToGit && pr.gitPRDraft != nil {
-		klog.InfoS("[DB Cache] Updating resources in memory and in Git draft for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.InfoS("[DB Cache] Updating resources in memory and in Git draft for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		defer func() {
-			klog.V(3).InfoS("[DB Cache] Resources updated in memory and in Git draft for PackageRevision", context1.LogMetadataFrom(ctx)...)
+			klog.V(3).InfoS("[DB Cache] Resources updated in memory and in Git draft for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		}()
 	} else {
-		klog.InfoS("[DB Cache] Updating resources in memory for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.InfoS("[DB Cache] Updating resources in memory for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		defer func() {
-			klog.V(3).InfoS("[DB Cache] Resources updated in memory for PackageRevision", context1.LogMetadataFrom(ctx)...)
+			klog.V(3).InfoS("[DB Cache] Resources updated in memory for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 		}()
 	}
 

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -31,7 +31,7 @@ import (
 	externalrepotypes "github.com/kptdev/porch/pkg/externalrepo/types"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -185,10 +185,10 @@ func (r *dbRepository) ListPackageRevisions(ctx context.Context, filter reposito
 	defer span.End()
 
 	klog.V(3).InfoS("[DB Cache] Retrieving PackageRevisions from database for repository",
-		context1.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
+		pctx.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
 	defer func() {
 		klog.V(3).InfoS("[DB Cache] Completed retrieving PackageRevisions from database for repository",
-			context1.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
+			pctx.LogMetadataFromWithExtras(ctx, "repository", r.Key())...)
 	}()
 
 	klog.V(5).Infof("ListPackageRevisions: listing package revisions in repository %+v with filter %+v", r.Key(), filter)
@@ -222,10 +222,10 @@ func (r *dbRepository) CreatePackageRevisionDraft(ctx context.Context, newPR *po
 	defer span.End()
 
 	klog.InfoS("[DB Cache] Creating database entry for draft object for PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[DB Cache] Database entry for draft object created for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	klog.V(5).Infof("dbRepository:CreatePackageRevisionDraft: creating draft for %+v on repo %+v", newPR, r.Key())
@@ -264,10 +264,10 @@ func (r *dbRepository) CreatePackageRevisionDraft(ctx context.Context, newPR *po
 	if r.pushDraftsToGit {
 		prName := repository.ComposePkgRevObjName(dbPkgRev.Key())
 		klog.InfoS("[DB Cache] Creating draft in Git for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] Draft created in Git for PackageRevision",
-				context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+				pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 		}()
 		gitPRDraft, err := r.externalRepo.CreatePackageRevisionDraft(ctx, newPR)
 		if err != nil {
@@ -292,17 +292,17 @@ func (r *dbRepository) DeletePackageRevision(ctx context.Context, pr2Delete repo
 	// TODO should be replaced with flag when option for db-cache push to git regardless PR comes in
 	if porchapi.LifecycleIsPublished(pr2Delete.Lifecycle(context.Background())) {
 		klog.InfoS("[DB Cache] Deleting PackageRevision from database and external repo for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] PackageRevision deleted from database and external repo for PackageRevision",
-				context1.LogMetadataFrom(ctx)...)
+				pctx.LogMetadataFrom(ctx)...)
 		}()
 	} else {
 		klog.InfoS("[DB Cache] Deleting PackageRevision from database for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] PackageRevision deleted from database for PackageRevision",
-				context1.LogMetadataFrom(ctx)...)
+				pctx.LogMetadataFrom(ctx)...)
 		}()
 	}
 
@@ -367,10 +367,10 @@ func (r *dbRepository) UpdatePackageRevision(ctx context.Context, updatePR repos
 	defer span.End()
 
 	klog.InfoS("[DB Cache] Loading draft from database for update for PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[DB Cache] Draft loaded from database and ready for modifications for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	klog.V(5).Infof("dbRepository:UpdatePackageRevision: updating package revision %+v on repo %+v", updatePR.Key(), r.Key())
@@ -393,10 +393,10 @@ func (r *dbRepository) UpdatePackageRevision(ctx context.Context, updatePR repos
 
 	if r.pushDraftsToGit && updatePkgRev.gitPRDraft == nil {
 		klog.InfoS("[DB Cache] Getting or creating Git draft for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(updatePkgRev.Key()))...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(updatePkgRev.Key()))...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] Git draft get or create completed for PackageRevision",
-				context1.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(updatePkgRev.Key()))...)
+				pctx.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(updatePkgRev.Key()))...)
 		}()
 		gitPRToUse := r.getCachedGitPR(updatePkgRev.Key().PkgKey, updatePkgRev.Key().WorkspaceName)
 
@@ -452,20 +452,20 @@ func (r *dbRepository) ClosePackageRevisionDraft(ctx context.Context, prd reposi
 	defer span.End()
 
 	klog.InfoS("[DB Cache] Saving PackageRevision to database for PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[DB Cache] PackageRevision saved to database for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	dbPrd := prd.(*dbPackageRevision)
 
 	if r.pushDraftsToGit && dbPrd.gitPRDraft != nil {
 		klog.InfoS("[DB Cache] Closing Git draft and pushing to Git for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(dbPrd.Key()))...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(dbPrd.Key()))...)
 		defer func() {
 			klog.V(3).InfoS("[DB Cache] Git draft closed and pushed for PackageRevision",
-				context1.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(dbPrd.Key()))...)
+				pctx.LogMetadataFromWithExtras(ctx, "packageRevision", repository.ComposePkgRevObjName(dbPrd.Key()))...)
 		}()
 		gitPR, err := r.externalRepo.ClosePackageRevisionDraft(ctx, dbPrd.gitPRDraft, version)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/task"
 	"github.com/kptdev/porch/pkg/util"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -144,10 +144,10 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 
 	pkgKey := repository.FromFullPathname(repo.Key(), newPr.Spec.PackageName)
 	klog.InfoS("[CaD Engine] Validating and preparing package creation for PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[CaD Engine] Package creation delegated to cache for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	if err := util.ValidPkgRevObjName(repositoryObj.Name, pkgKey.Path, pkgKey.Package, newPr.Spec.WorkspaceName); err != nil {
@@ -301,10 +301,10 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, version int, re
 	}
 
 	klog.InfoS("[CaD Engine] Processing lifecycle change and preparing update for PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[CaD Engine] Lifecycle change processed and delegated to cache for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	// Check if the PackageRevision is in the terminating state and
@@ -412,10 +412,10 @@ func (cad *cadEngine) DeletePackageRevision(ctx context.Context, repositoryObj *
 	defer span.End()
 
 	klog.InfoS("[CaD Engine] Preparing to delete PackageRevision",
-		context1.LogMetadataFrom(ctx)...)
+		pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[CaD Engine] PackageRevision deletion delegated to cache",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	repo, err := cad.cache.OpenRepository(ctx, repositoryObj)
@@ -460,10 +460,10 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 	ctx, span := tracer.Start(ctx, "cadEngine::UpdatePackageResources", trace.WithAttributes())
 	defer span.End()
 
-	klog.InfoS("[CaD Engine] Processing resource updates for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[CaD Engine] Processing resource updates for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
 		klog.V(3).InfoS("[CaD Engine] Resource updates processed and delegated to cache for PackageRevision",
-			context1.LogMetadataFrom(ctx)...)
+			pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	rev, err := pr2Update.GetPackageRevision(ctx)
@@ -533,7 +533,7 @@ func (cad *cadEngine) UpdatePackageResourcesWithoutRender(ctx context.Context, r
 	ctx, span := tracer.Start(ctx, "cadEngine::UpdatePackageResourcesWithoutRender", trace.WithAttributes())
 	defer span.End()
 
-	klog.InfoS("[CaD Engine] Writing resources without render for v1alpha2", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[CaD Engine] Writing resources without render for v1alpha2", pctx.LogMetadataFrom(ctx)...)
 
 	newRV := newRes.GetResourceVersion()
 	if len(newRV) == 0 {

--- a/pkg/engine/pushpr.go
+++ b/pkg/engine/pushpr.go
@@ -21,7 +21,7 @@ import (
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
@@ -34,14 +34,14 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 	prName := repository.ComposePkgRevObjName(pr.Key())
 	if pushDraftsToGit {
 		klog.InfoS("[Engine] Pushing PackageRevision to repository and to Git for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 	} else {
 		klog.InfoS("[Engine] Pushing PackageRevision to repository for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 	}
 	defer func() {
 		klog.V(3).InfoS("[Engine] Push PackageRevision to repository completed for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 	}()
 
 	prLifecycle := pr.Lifecycle(ctx)
@@ -65,7 +65,7 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 	if pushDraftsToGit {
 		if gitPR != nil {
 			klog.V(3).InfoS("[Engine] Updating existing Git draft for PackageRevision",
-				context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+				pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 			draft, err = repo.UpdatePackageRevision(ctx, gitPR)
 			if err != nil {
 				return kptfilev1.Locator{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update git PR:", pr.Key(), repo.Key())
@@ -73,7 +73,7 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 			foundExisting = true
 		} else {
 			klog.V(3).InfoS("[Engine] Listing existing Git revisions for PackageRevision",
-				context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+				pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 			existingPRs, err := repo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 				Key: repository.PackageRevisionKey{
 					PkgKey:        pr.Key().PkgKey,
@@ -83,7 +83,7 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 
 			if err == nil && len(existingPRs) > 0 {
 				klog.V(3).InfoS("[Engine] Updating existing Git package revision for PackageRevision",
-					context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+					pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 				draft, err = repo.UpdatePackageRevision(ctx, existingPRs[0])
 				if err != nil {
 					return kptfilev1.Locator{}, pkgerrors.Wrapf(err, "push of package revision %+v to repository %+v failed, could not update existing package revision:", pr.Key(), repo.Key())
@@ -131,10 +131,10 @@ func PushPackageRevision(ctx context.Context, repo repository.Repository, pr rep
 func GetOrCreateGitDraft(ctx context.Context, repo repository.Repository, pr repository.PackageRevision, gitPR repository.PackageRevision) (draft repository.PackageRevisionDraft, updatedGitPR repository.PackageRevision, err error) {
 	prName := repository.ComposePkgRevObjName(pr.Key())
 	klog.InfoS("[Engine] Getting or creating Git draft for PackageRevision",
-		context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+		pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 	defer func() {
 		klog.V(3).InfoS("[Engine] Get or create Git draft completed for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
+			pctx.LogMetadataFromWithExtras(ctx, "packageRevision", prName)...)
 	}()
 
 	if gitPR != nil {

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -41,7 +41,7 @@ import (
 	externalrepotypes "github.com/kptdev/porch/pkg/externalrepo/types"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -460,9 +460,9 @@ func (r *gitRepository) CreatePackageRevisionDraft(ctx context.Context, obj *por
 	if err := util.ValidPkgRevObjName(r.Key().Name, pkgKey.Path, pkgKey.Package, obj.Spec.WorkspaceName); err != nil {
 		return nil, fmt.Errorf("failed to create packagerevision: %w", err)
 	}
-	klog.InfoS("[Git] Creating in-memory draft object started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[Git] Creating in-memory draft object started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[Git] Creating in-memory draft object completed for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.V(3).InfoS("[Git] Creating in-memory draft object completed for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	var base plumbing.Hash
@@ -515,9 +515,9 @@ func (r *gitRepository) UpdatePackageRevision(ctx context.Context, old repositor
 		return nil, fmt.Errorf("cannot update non-git package %T", old)
 	}
 
-	klog.InfoS("[Git] Loading draft for update started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[Git] Loading draft for update started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[Git] Loading draft for update completed for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.V(3).InfoS("[Git] Loading draft for update completed for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	ref := oldGitPackage.ref
@@ -576,9 +576,9 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, pr2Delete rep
 			referenceName = ""
 		}
 	}
-	klog.InfoS("[Git] Deleting branch from Git repository started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[Git] Deleting branch from Git repository started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	defer func() {
-		klog.V(3).InfoS("[Git] Deleting branch from Git repository completed for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.V(3).InfoS("[Git] Deleting branch from Git repository completed for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}()
 
 	if referenceName == "" {
@@ -1406,10 +1406,10 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 	defer span.End()
 
 	klog.InfoS("[Git] Pushing changes to remote Git repository started",
-		context1.LogMetadataFromWithExtras(ctx, "repository", r.key.Name)...)
+		pctx.LogMetadataFromWithExtras(ctx, "repository", r.key.Name)...)
 	defer func() {
 		klog.V(3).InfoS("[Git] Pushing changes to remote Git repository completed",
-			context1.LogMetadataFromWithExtras(ctx, "repository", r.key.Name)...)
+			pctx.LogMetadataFromWithExtras(ctx, "repository", r.key.Name)...)
 	}()
 
 	maxRetries := r.repoOperationRetryAttempts
@@ -1719,10 +1719,10 @@ func (r *gitRepository) UpdateLifecycle(ctx context.Context, pkgRev *gitPackageR
 
 	oldLifecycle := pkgRev.Lifecycle(ctx)
 	klog.InfoS("[Git] Updating lifecycle started for PackageRevision",
-		context1.LogMetadataFromWithExtras(ctx, "old", oldLifecycle, "new", newLifecycle)...)
+		pctx.LogMetadataFromWithExtras(ctx, "old", oldLifecycle, "new", newLifecycle)...)
 	defer func() {
 		klog.V(3).InfoS("[Git] Updating lifecycle completed for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "old", oldLifecycle, "new", newLifecycle)...)
+			pctx.LogMetadataFromWithExtras(ctx, "old", oldLifecycle, "new", newLifecycle)...)
 	}()
 
 	r.mutex.Lock()
@@ -1834,10 +1834,10 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 
 	d := prd.(*gitPackageRevisionDraft)
 	klog.InfoS("[Git] Changing lifecycle and pushing to Git started for PackageRevision",
-		context1.LogMetadataFromWithExtras(ctx, "lifecycle", d.lifecycle)...)
+		pctx.LogMetadataFromWithExtras(ctx, "lifecycle", d.lifecycle)...)
 	defer func() {
 		klog.V(3).InfoS("[Git] Changing lifecycle and pushing to Git completed for PackageRevision",
-			context1.LogMetadataFromWithExtras(ctx, "lifecycle", d.lifecycle)...)
+			pctx.LogMetadataFromWithExtras(ctx, "lifecycle", d.lifecycle)...)
 	}()
 
 	refSpecs := newPushRefSpecBuilder()

--- a/pkg/registry/porch/packagecommon.go
+++ b/pkg/registry/porch/packagecommon.go
@@ -24,7 +24,7 @@ import (
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/engine"
 	"github.com/kptdev/porch/pkg/repository"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -269,7 +269,7 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 	defer span.End()
 
 	// TODO: Is this all boilerplate??
-	klog.V(3).InfoS("PackageRevision update validation started", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("PackageRevision update validation started", pctx.LogMetadataFrom(ctx)...)
 
 	namespace, namespaced := genericapirequest.NamespaceFrom(ctx)
 	if !namespaced {
@@ -337,13 +337,13 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("expected PackageRevision object, got %T", newRuntimeObj))
 	}
 
-	klog.V(3).InfoS("PackageRevision update validation completed", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("PackageRevision update validation completed", pctx.LogMetadataFrom(ctx)...)
 
 	if oldApiPkgRev != nil {
 		action := getLifecycleTransition(oldApiPkgRev.(*porchapi.PackageRevision), newApiPkgRev)
-		klog.InfoS("[API] Operation started for PackageRevision", context1.LogMetadataFromWithExtras(ctx, "action", action)...)
+		klog.InfoS("[API] Operation started for PackageRevision", pctx.LogMetadataFromWithExtras(ctx, "action", action)...)
 	} else {
-		klog.InfoS("[API] Update operation started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+		klog.InfoS("[API] Update operation started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 	}
 
 	prKey, err := repository.PkgRevK8sName2Key(namespace, name)
@@ -404,7 +404,7 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 	}
 
 	if action := getLifecycleTransition(oldApiPkgRev.(*porchapi.PackageRevision), newApiPkgRev); action != "" {
-		klog.InfoS("[API] Operation completed for PackageRevision", context1.LogMetadataFromWithExtras(ctx, "action", action)...)
+		klog.InfoS("[API] Operation completed for PackageRevision", pctx.LogMetadataFromWithExtras(ctx, "action", action)...)
 	}
 
 	return updated, false, nil

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -20,7 +20,7 @@ import (
 
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -74,9 +74,9 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::List", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestID(ctx)
+	ctx = pctx.WithNewRequestID(ctx)
 
-	klog.V(3).InfoS("[API] List operation started for PackageRevisions", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("[API] List operation started for PackageRevisions", pctx.LogMetadataFrom(ctx)...)
 
 	ns, _ := genericapirequest.NamespaceFrom(ctx)
 
@@ -106,7 +106,7 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 	}
 
 	klog.V(3).InfoS("[API] List operation completed for PackageRevisions",
-		context1.LogMetadataFromWithExtras(ctx, "found", len(result.Items))...)
+		pctx.LogMetadataFromWithExtras(ctx, "found", len(result.Items))...)
 
 	return result, nil
 }
@@ -116,9 +116,9 @@ func (r *packageRevisions) Get(ctx context.Context, name string, _ *metav1.GetOp
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Get", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
-	klog.V(3).InfoS("[API] Get operation started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("[API] Get operation started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 
 	repoPkgRev, err := r.getRepoPkgRev(ctx, name)
 	if err != nil {
@@ -130,7 +130,7 @@ func (r *packageRevisions) Get(ctx context.Context, name string, _ *metav1.GetOp
 		return nil, err
 	}
 
-	klog.V(3).InfoS("[API] Get operation completed for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("[API] Get operation completed for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 
 	return apiPkgRev, nil
 }
@@ -141,7 +141,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Create", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestID(ctx)
+	ctx = pctx.WithNewRequestID(ctx)
 
 	ns, namespaced := genericapirequest.NamespaceFrom(ctx)
 	if !namespaced {
@@ -172,7 +172,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		PkgKey:        pkgKeyStruct,
 		WorkspaceName: newApiPkgRev.Spec.WorkspaceName,
 	}.K8SName()
-	ctx = context1.WithPackageRevision(ctx, prName)
+	ctx = pctx.WithPackageRevision(ctx, prName)
 
 	repositoryObj, err := r.getRepositoryObj(ctx, types.NamespacedName{Name: repositoryName, Namespace: ns})
 	if err != nil {
@@ -189,7 +189,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 	}
 
 	klog.InfoS("[API] Operation started for PackageRevision",
-		context1.LogMetadataFromWithExtras(ctx, "action", action)...)
+		pctx.LogMetadataFromWithExtras(ctx, "action", action)...)
 
 	var parentPackage repository.PackageRevision
 	if newApiPkgRev.Spec.Parent != nil && newApiPkgRev.Spec.Parent.Name != "" {
@@ -225,7 +225,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 	}
 
 	klog.InfoS("[API] Operation completed for PackageRevision",
-		context1.LogMetadataFromWithExtras(ctx, "action", action)...)
+		pctx.LogMetadataFromWithExtras(ctx, "action", action)...)
 
 	return createdApiPkgRev, nil
 }
@@ -282,11 +282,11 @@ func (r *packageRevisions) Update(ctx context.Context, name string, objInfo rest
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Update", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	runTimeObj, ok, err := r.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate)
 	if err != nil {
-		klog.ErrorS(err, "[API] PackageRevision update operation failed", context1.LogMetadataFrom(ctx)...)
+		klog.ErrorS(err, "[API] PackageRevision update operation failed", pctx.LogMetadataFrom(ctx)...)
 	}
 	return runTimeObj, ok, err
 }
@@ -306,7 +306,7 @@ func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValida
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisions::Delete", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	ns, namespaced := genericapirequest.NamespaceFrom(ctx)
 	if !namespaced {
@@ -328,7 +328,7 @@ func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValida
 		return nil, false, err
 	}
 
-	klog.InfoS("[API] Delete operation started for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[API] Delete operation started for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 
 	if err := r.checkIfUpstreamIsReferenced(ctx, apiPkgRev); err != nil {
 		return nil, false, err
@@ -351,7 +351,7 @@ func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValida
 		return nil, false, apierrors.NewInternalError(err)
 	}
 
-	klog.InfoS("[API] Delete operation completed for PackageRevision", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[API] Delete operation completed for PackageRevision", pctx.LogMetadataFrom(ctx)...)
 
 	// TODO: Should we do an async delete?
 	return apiPkgRev, true, nil

--- a/pkg/registry/porch/packagerevision_approval.go
+++ b/pkg/registry/porch/packagerevision_approval.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +55,7 @@ func (a *packageRevisionApproval) Get(ctx context.Context, name string, _ *metav
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisionApproval::Get", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	pkg, err := a.getRepoPkgRev(ctx, name)
 	if err != nil {
@@ -72,12 +72,12 @@ func (a *packageRevisionApproval) Update(ctx context.Context, name string, objIn
 	ctx, span := tracer.Start(ctx, "[START]::packageRevisionApproval::Update", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	allowCreate := false // do not allow create on update
 	runTimeObj, ok, err := a.updatePackageRevision(ctx, name, objInfo, createValidation, updateValidation, allowCreate)
 	if err != nil {
-		klog.ErrorS(err, "[API] PackageRevision approval operation failed", context1.LogMetadataFrom(ctx)...)
+		klog.ErrorS(err, "[API] PackageRevision approval operation failed", pctx.LogMetadataFrom(ctx)...)
 	}
 	return runTimeObj, ok, err
 }

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -22,7 +22,7 @@ import (
 	porchv1alpha2 "github.com/kptdev/porch/api/porch/v1alpha2"
 	"github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
-	context1 "github.com/kptdev/porch/pkg/util/context"
+	pctx "github.com/kptdev/porch/pkg/util/context"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -71,9 +71,9 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 	ctx, span := tracer.Start(ctx, "[START]::PackageRevisionResources::List", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestID(ctx)
+	ctx = pctx.WithNewRequestID(ctx)
 
-	klog.V(3).InfoS("List PackageRevisionResources started", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("List PackageRevisionResources started", pctx.LogMetadataFrom(ctx)...)
 
 	result := &porchapi.PackageRevisionResourcesList{
 		TypeMeta: metav1.TypeMeta{
@@ -101,7 +101,7 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 	}
 
 	klog.V(3).InfoS("List PackageRevisionResources completed",
-		context1.LogMetadataFromWithExtras(ctx, "found", len(result.Items))...)
+		pctx.LogMetadataFromWithExtras(ctx, "found", len(result.Items))...)
 
 	return result, nil
 }
@@ -111,9 +111,9 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 	ctx, span := tracer.Start(ctx, "[START]::PackageRevisionResources::Get", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
-	klog.V(3).InfoS("Get PackageRevisionResources started", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("Get PackageRevisionResources started", pctx.LogMetadataFrom(ctx)...)
 
 	pkg, err := r.getRepoPkgRevForResources(ctx, name)
 	if err != nil {
@@ -125,7 +125,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 		return nil, err
 	}
 
-	klog.V(3).InfoS("Get PackageRevisionResources completed", context1.LogMetadataFrom(ctx)...)
+	klog.V(3).InfoS("Get PackageRevisionResources completed", pctx.LogMetadataFrom(ctx)...)
 
 	return apiPkgResources, nil
 }
@@ -138,7 +138,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 	ctx, span := tracer.Start(ctx, "[START]::PackageRevisionResources::Update", trace.WithAttributes())
 	defer span.End()
 
-	ctx = context1.WithNewRequestIDAndPackageRevision(ctx, name)
+	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
 	namespace, namespaced := genericapirequest.NamespaceFrom(ctx)
 	if !namespaced {
@@ -185,7 +185,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 			return nil, false, err
 		}
 	}
-	klog.InfoS("[API] Update operation started for PackageRevisionResources", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[API] Update operation started for PackageRevisionResources", pctx.LogMetadataFrom(ctx)...)
 
 	prKey, err := repository.PkgRevK8sName2Key(namespace, name)
 	if err != nil {
@@ -226,7 +226,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		created.Status.RenderStatus = *renderStatus
 	}
 
-	klog.InfoS("[API] Update operation completed for PackageRevisionResources", context1.LogMetadataFrom(ctx)...)
+	klog.InfoS("[API] Update operation completed for PackageRevisionResources", pctx.LogMetadataFrom(ctx)...)
 
 	return created, false, nil
 }


### PR DESCRIPTION
## Title
Rename all import aliases of `pkg/util/context` to `pctx`

---

## Description
- What changed: Renamed all import aliases of `pkg/util/context` to `pctx`.
- Why it’s needed: It looks like during some rebase or migration it got renamed to `context1` in a lot of places, which is not great. Also shortened from `porchcontext` for brevity.

---

## Related Issue(s)
None

---

## Type of Change
- [x] Other: Prettifying

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] ~~Tests added/updated~~
- [ ] ~~Documentation added/updated~~ 
- [ ] All tests and gating checks pass  

---

## AI Disclosure

**I have not used AI in the creation of this PR.**