### PR TITLE
Improve CI deploy reliability, move CR cache tests to nightly

### DIFF
--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -29,7 +29,6 @@ env:
   PORCH_SERVER_IMAGE: porch-server
   PORCH_CONTROLLERS_IMAGE: porch-controllers
 
-
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -172,7 +172,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Node Resources ==="
-          kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources"
+          kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources" || true
           echo ""
           echo "=== Pods (all namespaces) ==="
           kubectl get pods -A -o wide

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -29,6 +29,7 @@ env:
   PORCH_SERVER_IMAGE: porch-server
   PORCH_CONTROLLERS_IMAGE: porch-controllers
 
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -175,19 +175,19 @@ jobs:
           kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources" || true
           echo ""
           echo "=== Pods (all namespaces) ==="
-          kubectl get pods -A -o wide
+          kubectl get pods -A -o wide || true
           echo ""
           echo "=== Pod Resource Usage ==="
           kubectl top pods -A 2>/dev/null || true
           echo ""
           echo "=== Services (porch-system) ==="
-          kubectl get svc -n porch-system
+          kubectl get svc -n porch-system 2>/dev/null || true
           echo ""
           echo "=== PVCs (porch-system) ==="
-          kubectl get pvc -n porch-system
+          kubectl get pvc -n porch-system 2>/dev/null || true
           echo ""
           echo "=== ConfigMaps (porch-system) ==="
-          kubectl get configmaps -n porch-system
+          kubectl get configmaps -n porch-system 2>/dev/null || true
           echo ""
           echo "=== CRDs ==="
           kubectl get crds | grep -E "porch|kpt" || true
@@ -196,43 +196,39 @@ jobs:
           kubectl get apiservices | grep -E "porch|kpt" || true
           echo ""
           echo "=== Events (porch-system, last 60) ==="
-          kubectl get events -n porch-system --sort-by='.lastTimestamp' | tail -60
+          kubectl get events -n porch-system --sort-by='.lastTimestamp' 2>/dev/null | tail -60 || true
           echo ""
           echo "=== Events (kube-system, last 20) ==="
-          kubectl get events -n kube-system --sort-by='.lastTimestamp' | tail -20
+          kubectl get events -n kube-system --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
           echo ""
           echo "=== All pods details (porch-system) ==="
-          for pod in $(kubectl get pods -n porch-system -o jsonpath='{.items[*].metadata.name}'); do
+          for pod in $(kubectl get pods -n porch-system -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
             echo ""
             echo "--- Pod: porch-system/$pod ---"
-            kubectl describe pod -n porch-system $pod | grep -A 30 "Conditions:"
+            kubectl describe pod -n porch-system "$pod" 2>/dev/null | grep -A 30 "Conditions:" || true
             echo "--- Logs: porch-system/$pod (last 50 lines, all containers) ---"
-            kubectl logs -n porch-system $pod --all-containers --tail=50 2>/dev/null || true
+            kubectl logs -n porch-system "$pod" --all-containers --tail=50 2>/dev/null || true
           done
           echo ""
           echo "=== Non-running pods (other namespaces) ==="
-          for pod in $(kubectl get pods -A -o json | jq -r '.items[] | select(.metadata.namespace != "porch-system") | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\(.metadata.namespace)/\(.metadata.name)"'); do
+          for pod in $(kubectl get pods -A -o json 2>/dev/null | jq -r '.items[] | select(.metadata.namespace != "porch-system") | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\(.metadata.namespace)/\(.metadata.name)"'); do
             ns=$(echo $pod | cut -d/ -f1)
             name=$(echo $pod | cut -d/ -f2)
             echo "--- Describe $ns/$name ---"
-            kubectl describe pod -n $ns $name | tail -20
+            kubectl describe pod -n "$ns" "$name" 2>/dev/null | tail -20 || true
             echo "--- Logs $ns/$name ---"
-            kubectl logs -n $ns $name --all-containers --tail=30 2>/dev/null || true
+            kubectl logs -n "$ns" "$name" --all-containers --tail=30 2>/dev/null || true
           done
       - name: Run E2E tests
         run: ${{ matrix.test_env }} go test -v -timeout 20m ${{ matrix.test_path }}
       - name: Export porch server logs
         if: always()
         run: |
-          name=$(kubectl -n porch-system get pod -l app=porch-server -o custom-columns=NAME:.metadata.name --no-headers=true)
-          kubectl -n porch-system logs $name > ${{ matrix.log_prefix }}-server.log
+          kubectl -n porch-system logs -l app=porch-server --all-containers --tail=-1 > ${{ matrix.log_prefix }}-server.log 2>/dev/null || true
       - name: Export porch controllers logs
         if: always()
         run: |
-          name=$(kubectl -n porch-system get pod -l k8s-app=porch-controllers -o custom-columns=NAME:.metadata.name --no-headers=true 2>/dev/null || true)
-          if [ -n "$name" ]; then
-            kubectl -n porch-system logs $name > ${{ matrix.log_prefix }}-controllers.log 2>/dev/null || true
-          fi
+          kubectl -n porch-system logs -l k8s-app=porch-controllers --all-containers --tail=-1 > ${{ matrix.log_prefix }}-controllers.log 2>/dev/null || true
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v4  

--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -144,7 +144,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Node Resources ==="
-          kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources"
+          kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources" || true
           echo ""
           echo "=== Pods (all namespaces) ==="
           kubectl get pods -A -o wide

--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 The kpt Authors
+# Copyright 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: End-to-End Tests
+name: "E2E Tests (CR Cache - Nightly)"
 on:
-  pull_request:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch:
 
 concurrency:
@@ -30,24 +31,9 @@ env:
   PORCH_CONTROLLERS_IMAGE: porch-controllers
 
 jobs:
-  check-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - '!docs/**'
-
   build:
     name: Build Dev Images
     runs-on: ubuntu-latest
-    needs: check-changes
-    if: needs.check-changes.outputs.code == 'true'
     timeout-minutes: 15
     env:
       IMAGE_TAG: ${{ github.sha }}
@@ -83,14 +69,6 @@ jobs:
           IMAGE_NAME=${PORCH_CONTROLLERS_IMAGE} make -C controllers/ build-image &
           pid3=$!
           wait $pid1 && wait $pid2 && wait $pid3
-      - name: Verify images exist
-        run: |
-          export IMAGE_TAG=${IMAGE_TAG:0:8}
-          docker images
-          docker inspect ${IMAGE_REPO}/${PORCH_SERVER_IMAGE}:${IMAGE_TAG}
-          docker inspect ${IMAGE_REPO}/${PORCH_CONTROLLERS_IMAGE}:${IMAGE_TAG}
-          docker inspect ${IMAGE_REPO}/${PORCH_FUNCTION_RUNNER_IMAGE}:${IMAGE_TAG}
-          docker inspect ${IMAGE_REPO}/${PORCH_WRAPPER_SERVER_IMAGE}:${IMAGE_TAG}
       - name: Save all images
         run: |
           export IMAGE_TAG=${IMAGE_TAG:0:8}
@@ -112,29 +90,23 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [check-changes, build]
-    if: needs.check-changes.outputs.code == 'true'
+    needs: build
     env:
       IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: "Porch E2E Tests (DB Cache)"
-            make_target: "run-in-kind-db-cache-push-drafts"
+          - name: "Porch E2E Tests (CR Cache)"
+            make_target: "run-in-kind"
             test_path: "${GITHUB_WORKSPACE}/test/e2e/api"
-            test_env: "E2E=1 DB_CACHE=1"
-            log_prefix: "porch-e2e-dbcache"
-          - name: "Porch CLI E2E Tests (DB Cache)"
-            make_target: "run-in-kind-db-cache-push-drafts"
+            test_env: "E2E=1"
+            log_prefix: "porch-e2e-crcache"
+          - name: "Porch CLI E2E Tests (CR Cache)"
+            make_target: "run-in-kind"
             test_path: "${GITHUB_WORKSPACE}/test/e2e/cli"
             test_env: "E2E=1"
-            log_prefix: "porch-cli-e2e-dbcache"
-          - name: "Porch CRD E2E Tests (v1alpha2)"
-            make_target: "run-in-kind-v1alpha2"
-            test_path: "${GITHUB_WORKSPACE}/test/e2e/crd -ginkgo.v"
-            test_env: "E2E=1"
-            log_prefix: "porch-crd-e2e"
+            log_prefix: "porch-cli-e2e-crcache"
 
     steps:
       - name: Checkout Porch
@@ -186,9 +158,6 @@ jobs:
           echo "=== PVCs (porch-system) ==="
           kubectl get pvc -n porch-system
           echo ""
-          echo "=== ConfigMaps (porch-system) ==="
-          kubectl get configmaps -n porch-system
-          echo ""
           echo "=== CRDs ==="
           kubectl get crds | grep -E "porch|kpt" || true
           echo ""
@@ -198,9 +167,6 @@ jobs:
           echo "=== Events (porch-system, last 60) ==="
           kubectl get events -n porch-system --sort-by='.lastTimestamp' | tail -60
           echo ""
-          echo "=== Events (kube-system, last 20) ==="
-          kubectl get events -n kube-system --sort-by='.lastTimestamp' | tail -20
-          echo ""
           echo "=== All pods details (porch-system) ==="
           for pod in $(kubectl get pods -n porch-system -o jsonpath='{.items[*].metadata.name}'); do
             echo ""
@@ -208,16 +174,6 @@ jobs:
             kubectl describe pod -n porch-system $pod | grep -A 30 "Conditions:"
             echo "--- Logs: porch-system/$pod (last 50 lines, all containers) ---"
             kubectl logs -n porch-system $pod --all-containers --tail=50 2>/dev/null || true
-          done
-          echo ""
-          echo "=== Non-running pods (other namespaces) ==="
-          for pod in $(kubectl get pods -A -o json | jq -r '.items[] | select(.metadata.namespace != "porch-system") | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\(.metadata.namespace)/\(.metadata.name)"'); do
-            ns=$(echo $pod | cut -d/ -f1)
-            name=$(echo $pod | cut -d/ -f2)
-            echo "--- Describe $ns/$name ---"
-            kubectl describe pod -n $ns $name | tail -20
-            echo "--- Logs $ns/$name ---"
-            kubectl logs -n $ns $name --all-containers --tail=30 2>/dev/null || true
           done
       - name: Run E2E tests
         run: ${{ matrix.test_env }} go test -v -timeout 20m ${{ matrix.test_path }}
@@ -235,21 +191,9 @@ jobs:
           fi
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4  
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.log_prefix }}-logs
           path: "*.log"
           compression-level: 0
-          retention-days: 2
-
-  e2e-summary:
-    name: E2E Tests Summary
-    if: always()
-    needs: [check-changes, build, tests]
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
-        if: |
-          needs.check-changes.outputs.code == 'true' &&
-          (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-      - run: echo "All tests passed or skipped"
+          retention-days: 5

--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -147,16 +147,16 @@ jobs:
           kubectl top nodes 2>/dev/null || kubectl describe nodes | grep -A 5 "Allocated resources" || true
           echo ""
           echo "=== Pods (all namespaces) ==="
-          kubectl get pods -A -o wide
+          kubectl get pods -A -o wide || true
           echo ""
           echo "=== Pod Resource Usage ==="
           kubectl top pods -A 2>/dev/null || true
           echo ""
           echo "=== Services (porch-system) ==="
-          kubectl get svc -n porch-system
+          kubectl get svc -n porch-system 2>/dev/null || true
           echo ""
           echo "=== PVCs (porch-system) ==="
-          kubectl get pvc -n porch-system
+          kubectl get pvc -n porch-system 2>/dev/null || true
           echo ""
           echo "=== CRDs ==="
           kubectl get crds | grep -E "porch|kpt" || true
@@ -165,30 +165,26 @@ jobs:
           kubectl get apiservices | grep -E "porch|kpt" || true
           echo ""
           echo "=== Events (porch-system, last 60) ==="
-          kubectl get events -n porch-system --sort-by='.lastTimestamp' | tail -60
+          kubectl get events -n porch-system --sort-by='.lastTimestamp' 2>/dev/null | tail -60 || true
           echo ""
           echo "=== All pods details (porch-system) ==="
-          for pod in $(kubectl get pods -n porch-system -o jsonpath='{.items[*].metadata.name}'); do
+          for pod in $(kubectl get pods -n porch-system -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
             echo ""
             echo "--- Pod: porch-system/$pod ---"
-            kubectl describe pod -n porch-system $pod | grep -A 30 "Conditions:"
+            kubectl describe pod -n porch-system "$pod" 2>/dev/null | grep -A 30 "Conditions:" || true
             echo "--- Logs: porch-system/$pod (last 50 lines, all containers) ---"
-            kubectl logs -n porch-system $pod --all-containers --tail=50 2>/dev/null || true
+            kubectl logs -n porch-system "$pod" --all-containers --tail=50 2>/dev/null || true
           done
       - name: Run E2E tests
         run: ${{ matrix.test_env }} go test -v -timeout 20m ${{ matrix.test_path }}
       - name: Export porch server logs
         if: always()
         run: |
-          name=$(kubectl -n porch-system get pod -l app=porch-server -o custom-columns=NAME:.metadata.name --no-headers=true)
-          kubectl -n porch-system logs $name > ${{ matrix.log_prefix }}-server.log
+          kubectl -n porch-system logs -l app=porch-server --all-containers --tail=-1 > ${{ matrix.log_prefix }}-server.log 2>/dev/null || true
       - name: Export porch controllers logs
         if: always()
         run: |
-          name=$(kubectl -n porch-system get pod -l k8s-app=porch-controllers -o custom-columns=NAME:.metadata.name --no-headers=true 2>/dev/null || true)
-          if [ -n "$name" ]; then
-            kubectl -n porch-system logs $name > ${{ matrix.log_prefix }}-controllers.log 2>/dev/null || true
-          fi
+          kubectl -n porch-system logs -l k8s-app=porch-controllers --all-containers --tail=-1 > ${{ matrix.log_prefix }}-controllers.log 2>/dev/null || true
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -126,7 +126,7 @@ load-images-to-kind:## Build porch images and load them into a kind cluster
 .PHONY: deploy-current-config
 deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYPORCHCONFIGDIR)
 	kpt live init $(DEPLOYPORCHCONFIGDIR) --name porch --namespace porch-system --inventory-id porch || true
-	timeout 300 kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
+	./scripts/run-with-timeout.sh 300 kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
 	kubectl rollout status deployment function-runner --namespace porch-system --timeout=180s
 ifeq ($(PORCH_CACHE_TYPE),DB)
 	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -126,10 +126,11 @@ load-images-to-kind:## Build porch images and load them into a kind cluster
 .PHONY: deploy-current-config
 deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYPORCHCONFIGDIR)
 	kpt live init $(DEPLOYPORCHCONFIGDIR) --name porch --namespace porch-system --inventory-id porch || true
-	kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
-	@kubectl rollout status deployment function-runner --namespace porch-system 2>/dev/null || true
-	@kubectl rollout status deployment porch-controllers --namespace porch-system 2>/dev/null || true
-	@kubectl rollout status deployment porch-server --namespace porch-system 2>/dev/null || true
+	timeout 300 kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
+	kubectl rollout status deployment function-runner --namespace porch-system --timeout=180s
+	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s 2>/dev/null || true
+	kubectl rollout status deployment porch-server --namespace porch-system --timeout=180s
+	kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s
 	@echo "Done."
 
 .PHONY: reload-function-runner

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -128,7 +128,9 @@ deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYP
 	kpt live init $(DEPLOYPORCHCONFIGDIR) --name porch --namespace porch-system --inventory-id porch || true
 	timeout 300 kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
 	kubectl rollout status deployment function-runner --namespace porch-system --timeout=180s
-	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s 2>/dev/null || true
+ifeq ($(PORCH_CACHE_TYPE),DB)
+	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s
+endif
 	kubectl rollout status deployment porch-server --namespace porch-system --timeout=180s
 	kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s
 	@echo "Done."

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -131,8 +131,12 @@ deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYP
 ifeq ($(PORCH_CACHE_TYPE),DB)
 	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s
 endif
+ifneq ($(SKIP_PORCHSERVER_BUILD),true)
 	kubectl rollout status deployment porch-server --namespace porch-system --timeout=180s
+endif
+ifneq ($(SKIP_CONTROLLER_BUILD),true)
 	kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s
+endif
 	@echo "Done."
 
 .PHONY: reload-function-runner

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright 2026 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portable timeout wrapper that works on both Linux (GNU coreutils) and macOS.
+# Usage: run-with-timeout.sh <seconds> <command> [args...]
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <timeout_seconds> <command> [args...]" >&2
+  exit 1
+fi
+
+TIMEOUT_SECS="$1"
+shift
+
+if command -v timeout &>/dev/null; then
+  # GNU coreutils timeout (Linux, or macOS with coreutils installed)
+  timeout "${TIMEOUT_SECS}" "$@"
+else
+  # POSIX fallback using background process + wait
+  "$@" &
+  pid=$!
+
+  (sleep "${TIMEOUT_SECS}" && kill "$pid" 2>/dev/null && echo "ERROR: command timed out after ${TIMEOUT_SECS}s" >&2) &
+  watchdog=$!
+
+  if wait "$pid"; then
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+    exit 0
+  else
+    status=$?
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+    exit $status
+  fi
+fi

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2026 The kpt and Nephio Authors
+# Copyright 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,14 +28,19 @@ shift
 
 if command -v timeout &>/dev/null; then
   # GNU coreutils timeout (Linux, or macOS with coreutils installed)
-  timeout "${TIMEOUT_SECS}" "$@"
+  timeout --kill-after=10 "${TIMEOUT_SECS}" "$@"
 else
-  # POSIX fallback using background process + wait
+  # POSIX fallback using process group for reliable subprocess cleanup.
+  # Run the command in its own process group so we can kill the entire tree on timeout.
+  set -m
   "$@" &
   pid=$!
 
-  (sleep "${TIMEOUT_SECS}" && kill "$pid" 2>/dev/null && echo "ERROR: command timed out after ${TIMEOUT_SECS}s" >&2) &
+  (sleep "${TIMEOUT_SECS}" && kill -- -"$pid" 2>/dev/null && echo "ERROR: command timed out after ${TIMEOUT_SECS}s" >&2) &
   watchdog=$!
+
+  # Forward SIGINT/SIGTERM to the process group and clean up the watchdog.
+  trap 'kill -- -"$pid" 2>/dev/null; kill "$watchdog" 2>/dev/null; exit 143' INT TERM
 
   if wait "$pid"; then
     kill "$watchdog" 2>/dev/null || true
@@ -43,6 +48,7 @@ else
     exit 0
   else
     status=$?
+    kill -- -"$pid" 2>/dev/null || true
     kill "$watchdog" 2>/dev/null || true
     wait "$watchdog" 2>/dev/null || true
     exit $status


### PR DESCRIPTION
## Description
- What changed: Added timeout to `kpt live apply`, explicit `--timeout` on rollout status waits, moved CR cache e2e suites to a nightly workflow, expanded cluster dump on failure.
- Why it's needed: CI flakiness from `kpt live apply` hanging silently and rollout failures being swallowed by `|| true`. CR cache tests add load to every PR run without being the primary code path.
- How it works:
  - `timeout 300 kpt live apply ...` kills the process after 5 min if it hangs
  - `kubectl rollout status --timeout=180s` fails the step explicitly if pods don't come up
  - CR cache tests (`run-in-kind`) moved to `porch-e2e-nightly.yaml` (daily 03:00 UTC + manual dispatch)
  - DB cache + v1alpha2 CRD tests remain on every PR
  - Cluster dump now includes: node resources, pod resource usage, services, PVCs, CRDs, APIServices, full porch-system pod details with conditions

---

## Related Issue(s)
- N/A (CI flakiness investigation)

---

## Type of Change
- [x] Enhancement

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. Trigger the PR workflow — should only run DB cache + v1alpha2 CRD tests
2. Manually trigger the nightly workflow to verify CR cache tests run
3. Simulate a deploy failure to verify expanded cluster dump output

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to analyse CI workflow structure and generate the split + timeout changes.
  - The author has fully verified all code.