### PR TITLE
Add go-version-file input to setup-go-kpt action

### DIFF
--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -23,7 +23,11 @@ inputs:
   kpt-fallback-version:
     description: "Fallback kpt version if extraction from go.mod fails"
     required: false
-    default: "v1.0.0-beta.62.1"
+    default: "v1.0.0-beta.64"
+  go-version-file:
+    description: "Path to go.mod file for Go version setup"
+    required: false
+    default: "go.mod"
   go-cache:
     description: "Enable Go module caching"
     required: false
@@ -40,7 +44,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.go-cache == 'true' }}
 
     - name: Get kpt version from go.mod

--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -51,11 +51,15 @@ runs:
       if: inputs.install-kpt == 'true'
       id: kpt-version
       shell: bash
+      env:
+        GO_VERSION_FILE: ${{ inputs.go-version-file }}
+        KPT_FALLBACK: ${{ inputs.kpt-fallback-version }}
       run: |
-        KPT_VERSION=$(go list -m -f '{{.Version}}' github.com/kptdev/kpt 2>/dev/null)
+        GO_MOD_DIR=$(dirname -- "$GO_VERSION_FILE")
+        KPT_VERSION=$(cd "$GO_MOD_DIR" && go list -m -f '{{.Version}}' github.com/kptdev/kpt 2>/dev/null)
         if [ -z "$KPT_VERSION" ]; then
           echo "Warning: Could not resolve kpt version from go.mod, using fallback"
-          KPT_VERSION="${{ inputs.kpt-fallback-version }}"
+          KPT_VERSION="$KPT_FALLBACK"
         fi
         echo "version=${KPT_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -58,7 +58,7 @@ runs:
         GO_MOD_DIR=$(dirname -- "$GO_VERSION_FILE")
         KPT_VERSION=$(cd "$GO_MOD_DIR" && go list -m -f '{{.Version}}' github.com/kptdev/kpt 2>/dev/null)
         if [ -z "$KPT_VERSION" ]; then
-          echo "Warning: Could not resolve kpt version from go.mod, using fallback"
+          echo "Warning: Could not resolve kpt version from ${GO_VERSION_FILE}, using fallback."
           KPT_VERSION="$KPT_FALLBACK"
         fi
         echo "version=${KPT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -185,14 +185,6 @@ jobs:
           kubectl get pods -A
           echo "=== Events (porch-system) ==="
           kubectl get events -n porch-system --sort-by='.lastTimestamp' | tail -40
-          echo "=== Porch server logs (last 50 lines) ==="
-          kubectl logs -n porch-system -l app=porch-server --tail=50 2>/dev/null || true
-          echo "=== Porch controllers logs (last 50 lines) ==="
-          kubectl logs -n porch-system -l k8s-app=porch-controllers --tail=50 2>/dev/null || true
-          echo "=== FunctionConfig CR status ==="
-          kubectl get functionconfigs.config.porch.kpt.dev -n porch-system -o yaml 2>/dev/null | grep -A 5 "status:" || echo "No status found"
-          echo "=== ServiceTemplate CR status ==="
-          kubectl get servicetemplates.config.porch.kpt.dev -n porch-system -o yaml 2>/dev/null | grep -A 5 "status:" || echo "No status found"
           echo "=== Non-running pods details ==="
           kubectl get pods -A -o json | jq -r '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\n--- \(.metadata.namespace)/\(.metadata.name) (\(.status.phase)) ---"' 
           for pod in $(kubectl get pods -A -o json | jq -r '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\(.metadata.namespace)/\(.metadata.name)"'); do

--- a/.github/workflows/porch-e2e-ci-jobs.yaml
+++ b/.github/workflows/porch-e2e-ci-jobs.yaml
@@ -185,6 +185,14 @@ jobs:
           kubectl get pods -A
           echo "=== Events (porch-system) ==="
           kubectl get events -n porch-system --sort-by='.lastTimestamp' | tail -40
+          echo "=== Porch server logs (last 50 lines) ==="
+          kubectl logs -n porch-system -l app=porch-server --tail=50 2>/dev/null || true
+          echo "=== Porch controllers logs (last 50 lines) ==="
+          kubectl logs -n porch-system -l k8s-app=porch-controllers --tail=50 2>/dev/null || true
+          echo "=== FunctionConfig CR status ==="
+          kubectl get functionconfigs.config.porch.kpt.dev -n porch-system -o yaml 2>/dev/null | grep -A 5 "status:" || echo "No status found"
+          echo "=== ServiceTemplate CR status ==="
+          kubectl get servicetemplates.config.porch.kpt.dev -n porch-system -o yaml 2>/dev/null | grep -A 5 "status:" || echo "No status found"
           echo "=== Non-running pods details ==="
           kubectl get pods -A -o json | jq -r '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\n--- \(.metadata.namespace)/\(.metadata.name) (\(.status.phase)) ---"' 
           for pod in $(kubectl get pods -A -o json | jq -r '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | "\(.metadata.namespace)/\(.metadata.name)"'); do


### PR DESCRIPTION
Add go-version-file input to setup-go-kpt composite action and upgrades default kpt  version

## Description
  - What changed: Added a `go-version-file` input to the setup-go-kpt composite action, defaulting to `go.mod`.
  - Why it's needed: Cross-repo consumers (e.g. krm-functions-catalog) don't have a root `go.mod` and need to specify a custom path like `documentation/go.mod`.
  - How it works: The new input is passed to `actions/setup-go`'s `go-version-file` parameter. Existing users are unaffected since the default remains `go.mod`.

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**
  - Kiro to implement the portion of change and draft the PR description.