### PR TITLE
Remove status subresource from ServiceTemplate to fix intermittent kpt live apply timeout

### DIFF
--- a/api/porchconfig/v1alpha1/config.porch.kpt.dev_servicetemplates.yaml
+++ b/api/porchconfig/v1alpha1/config.porch.kpt.dev_servicetemplates.yaml
@@ -400,5 +400,3 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/api/porchconfig/v1alpha1/service_template_types.go
+++ b/api/porchconfig/v1alpha1/service_template_types.go
@@ -20,7 +20,6 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=servicetemplates,singular=servicetemplate
 type ServiceTemplate struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Remove status subresource from ServiceTemplate to fix intermittent kpt live apply timeout

## Description
- **What changed**: Removed `+kubebuilder:subresource:status` marker from `ServiceTemplate` type and regenerated the CRD.
- **Why it's needed**: 
   - `kpt live apply` intermittently times out (10 min) randomly waiting for ServiceTemplate to reconcile in E2E CI. 
   - The root cause is a race condition in cli-utils `ObjectStatusReporter` where the ServiceTemplate informer gets permanently killed due to a stale RESTMapper cache during CRD establishment. 
   - With the status subresource enabled, the API server sets `metadata.generation: 1`, causing kpt's generation check (`cachedGen < applyGen`) to require a live informer, which is dead.
- **How it works**: Without the status subresource, the API server doesn't set `metadata.generation`, so `applyGen = 0`. The generation check always passes, making the dead informer harmless. ServiceTemplate has no controller and no status field.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro CLI to analyse cli-utils source code and trace the informer lifecycle
  - Kiro CLI to compare success/failure CI logs and identify the race condition and draft the PR description 