### PR TITLE
Cherry pick - Fix release workflow tag pattern to support multi-digit patch versions

### DIFF
--- a/.github/workflows/image-build-push-release.yaml
+++ b/.github/workflows/image-build-push-release.yaml
@@ -3,8 +3,8 @@ name: Release Image Build & Push
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]"
-      - "v[0-9]+.[0-9]+.[0-9]-pre[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+"
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/image-build-push-release.yaml
+++ b/.github/workflows/image-build-push-release.yaml
@@ -6,6 +6,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+"
 
+  workflow_dispatch:
+
 env:
   REGISTRY: docker.io
   ORG: nephio

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024,2026 The Nephio Authors
+# Copyright 2024, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@ name: porchctl Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]"
-      - "v[0-9]+.[0-9]+.[0-9]-pre[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Fix release workflow tag pattern to support multi-digit patch versions

### Description
  - **What changed**: Added + quantifier to the patch version segment in the tag filter pattern for `release.yaml` and `image-build-push-release.yaml`.
  - **Why it's needed**: The pattern `v[0-9]+.[0-9]+.[0-9]` only matches single-digit patch versions, so tags like v1.5.10 don't trigger the release workflow.
  - **How it works**: Changed `.[0-9]` to `.[0-9]+` for the patch segment, consistent with how major and minor segments are already defined.

### Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

 ### AI Disclosure

  - [x] I have used AI in the creation of this PR.
  If so, please describe how:
    - Kiro CLI to validate the fix and create PR description.