### PR TITLE
Update dbpackagerevision.go to use pr.deployment - missed during cherrypick of #509

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -125,7 +125,7 @@ func (pr *dbPackageRevision) savePackageRevision(ctx context.Context, saveResour
 	_, span := tracer.Start(ctx, "dbPackageRevision::savePackageRevision", trace.WithAttributes())
 	defer span.End()
 
-	if saveResources && pr.repo.deployment {
+	if saveResources && pr.deployment {
 		pr.updated = time.Now()
 		pr.updatedBy = getCurrentUser()
 	}
@@ -215,18 +215,13 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 		return nil, fmt.Errorf("invalid package revision: nil object")
 	}
 
-	if pr.repo == nil {
-		klog.Warningf("package revision %+v has nil repository, skipping", pr.Key())
-		return nil, fmt.Errorf("package revision %s has no associated repository (may be deleted or not yet cached)", pr.KubeObjectName())
-	}
-
 	_, upstreamLock, _ := pr.GetUpstreamLock(ctx)
 	_, selfLock, _ := pr.GetLock(ctx)
 
 	status := porchapi.PackageRevisionStatus{
 		UpstreamLock:       repository.KptUpstreamLock2APIUpstreamLock(upstreamLock),
 		SelfLock:           repository.KptUpstreamLock2APIUpstreamLock(selfLock),
-		Deployment:         pr.repo.deployment,
+		Deployment:         pr.deployment,
 		Conditions:         pr.kptfileStatus.Conditions,
 		ResourcesSizeBytes: pr.resourcesSizeBytes,
 	}
@@ -343,6 +338,7 @@ func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) reposito
 		lifecycle:          pr.lifecycle,
 		extPRID:            pr.extPRID,
 		latest:             false,
+		deployment:         pr.deployment,
 		tasks:              pr.tasks,
 		resources:          pr.resources,
 		kptfileStatus:      pr.kptfileStatus,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Update GetPackageRevision to use pr.deployment - missed during cherrypick of #509

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  pr.repo nil checks are removed and pr.deployment is used instead of pr.repo.deployment.
- Why it’s needed:  It was missed during the cherry pick of  #509 
- How it works:  It repo is working or not, lists will return what's there in the DB. 

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

If so, please describe how:
  - E.g. Microsoft Copilot to analyse the code.
  - E.g. Claude code to generate the function someNewFunctionIAdded().
  - E.g. Kiro to generate unit tests.
