### PR TITLE
Fix CRCACHE nightly ci runs

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -128,15 +128,15 @@ deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYP
 	kpt live init $(DEPLOYPORCHCONFIGDIR) --name porch --namespace porch-system --inventory-id porch || true
 	./scripts/run-with-timeout.sh 300 kpt live apply --inventory-policy=adopt --server-side --force-conflicts $(DEPLOYPORCHCONFIGDIR)
 	kubectl rollout status deployment function-runner --namespace porch-system --timeout=180s
-ifeq ($(PORCH_CACHE_TYPE),DB)
-	kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s
-endif
-ifneq ($(SKIP_PORCHSERVER_BUILD),true)
-	kubectl rollout status deployment porch-server --namespace porch-system --timeout=180s
-endif
-ifneq ($(SKIP_CONTROLLER_BUILD),true)
-	kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s
-endif
+	@if [ "$(PORCH_CACHE_TYPE)" = "DB" ]; then \
+		kubectl rollout status statefulset porch-postgresql --namespace porch-system --timeout=180s; \
+	fi
+	@if [ "$(SKIP_PORCHSERVER_BUILD)" != "true" ]; then \
+		kubectl rollout status deployment porch-server --namespace porch-system --timeout=180s; \
+	fi
+	@if [ "$(SKIP_CONTROLLER_BUILD)" != "true" ]; then \
+		kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s; \
+	fi
 	@echo "Done."
 
 .PHONY: reload-function-runner


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Fix CRCACHE nightly ci runs

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Improve cache type parsing
- Why it’s needed:  Cache type parsing is failing in make cmds
- How it works:  See change

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [X] Tests
- [ ] Other: ________

---

## Checklist
- [X] Code follows project style guidelines  
- [X] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [X] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

If so, please describe how:
  - E.g. Microsoft Copilot to analyse the code.
  - E.g. Claude code to generate the function someNewFunctionIAdded().
  - E.g. Kiro to generate unit tests.
