### PR TITLE
Upgrade setup-go action to v6 and add cache-dependency-path input

### DIFF
--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Enable Go module caching"
     required: false
     default: "true"
+  cache-dependency-path:
+    description: "Relative path to go.sum file for Go module caching"
+    required: false
+    default: "go.sum"
 
 outputs:
   kpt-version:
@@ -42,10 +46,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.go-cache == 'true' }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Get kpt version from go.mod
       if: inputs.install-kpt == 'true'


### PR DESCRIPTION

  Upgrade setup-go action to v6 and add cache-dependency-path input

  ## Description
  - What changed: Bumped `actions/setup-go` from v5 to v6 in the `setup-go-kpt` composite action and added a new `cache-dependency-path` input parameter.
  - Why it's needed: `actions/setup-go@v6` requires explicit `cache-dependency-path` when caching is enabled. Repositories that consume this composite action with `go-version-file` pointing to a non-root location (e.g. `subdir/go.mod`) need to specify the corresponding `go.sum` path for caching to work correctly.
  - How it works: Adds a `cache-dependency-path` input (defaults to `go.sum`) and passes it through to the `actions/setup-go` step. Consuming repos can set it to match their `go-version-file` location.

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to review changes and draft PR description.