### PR TITLE
Fix intermittent failures on subpackage e2e tests

### DIFF
--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -547,7 +547,7 @@ func (t *PorchSuite) addPipelineToPR(pr *porchapi.PackageRevision) {
 	}
 	t.SaveKptfileF(&prResources, kptfile)
 
-	prResources.Spec.Resources["my-configmap.yaml"] = `
+	testConfigmapStr := `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -555,6 +555,10 @@ metadata:
 data:
   someKey: someValue
 `
+
+	prResources.Spec.Resources["my-configmap.yaml"] = strings.ReplaceAll(testConfigmapStr, "name: my-configmap", "name: my-"+pr.Name+"-configmap")
+	delete(prResources.Spec.Resources, "package-context.yaml")
+
 	t.UpdateF(&prResources)
 	t.GetF(client.ObjectKeyFromObject(pr), pr)
 }

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -68,6 +68,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 		subpackageDir1 = "level1/level2/my-subpackage-1"
 		subpackageDir2 = "level1/level2/my-subpackage-1/my-subpackage-2"
 		subpackageDir3 = "level1/level2/my-subpackage-1"
+		subpackageDir4 = "level1/level2/my-subpackage-1/"
 	)
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
@@ -92,15 +93,33 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
 
-	_, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir2)
-	if err == nil || !strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage") {
-		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir2, err)
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir2)
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
+		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
 	}
 
 	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir3)
-	if err == nil || !strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage") {
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
 		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
+	}
+
+	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir3)
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
+		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
+	}
+
+	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir4)
+	if err == nil || !strings.Contains(err.Error(), "subpackageDir is invalid: subpackage directory \"level1/level2/my-subpackage-1/\" is invalid") {
+		t.Fatalf("Upgrade of subpackage %v to %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, cloneePRV1, parentPR, subpackageDir2, err)
 	}
 
 	t.deletePR(parentPR)

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -97,7 +97,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 	if err == nil ||
 		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
 			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
-		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
+		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir2, err)
 	}
 
 	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
@@ -119,7 +119,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir4)
 	if err == nil || !strings.Contains(err.Error(), "subpackageDir is invalid: subpackage directory \"level1/level2/my-subpackage-1/\" is invalid") {
-		t.Fatalf("Upgrade of subpackage %v to %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, cloneePRV1, parentPR, subpackageDir2, err)
+		t.Fatalf("Clone of subpackage %v to %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, cloneePRV1, parentPR, subpackageDir4, err)
 	}
 
 	t.deletePR(parentPR)

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -119,7 +119,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir4)
 	if err == nil || !strings.Contains(err.Error(), "subpackageDir is invalid: subpackage directory \"level1/level2/my-subpackage-1/\" is invalid") {
-		t.Fatalf("Clone of subpackage %v to %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, cloneePRV1, parentPR, subpackageDir4, err)
+		t.Fatalf("Clone of subpackage %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir4, err)
 	}
 
 	t.deletePR(parentPR)


### PR DESCRIPTION
## Fix intermittent failures and subpackage e2e tests
---

## Description
- What changed:  This PR fixes intermittent failures on subpackage e2e tests
- Why it’s needed:  Depending on the order that resources are returned to Porch for existing resources on a PR, the check for existing subpackages failed, it always assumed that the first resource to be returned on an existing subpackage was the Kptfile and this is not always the case. In additin, the test data generated by the e2e tests created multiple versions of the same ConfigMap KRM resource, this sometimes caused the `set-labels` krm function to fail if it found the same ConfigMa in pultiple kpt packages. The name of each ConfigMap is now unique in each test.
- How it works:  The test was fixed to check for Kptfiles or other existing resources where the subpackage is to be placed.

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

AI was not used.