### PR TITLE
Set latest-revision label on discovered PackageRevision CRs

### DIFF
--- a/api/porch/v1alpha2/packagerevision_types.go
+++ b/api/porch/v1alpha2/packagerevision_types.go
@@ -31,7 +31,7 @@ import (
 // +kubebuilder:printcolumn:name="Package",type=string,JSONPath=`.spec.packageName`
 // +kubebuilder:printcolumn:name="WorkspaceName",type=string,JSONPath=`.spec.workspaceName`
 // +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.revision`
-// +kubebuilder:printcolumn:name="Latest",type=string,JSONPath=".metadata.labels['porch.kpt.dev/latest-revision']"
+// +kubebuilder:printcolumn:name="Latest",type=string,JSONPath=`.metadata.labels['porch\.kpt\.dev/latest-revision']`
 // +kubebuilder:printcolumn:name="Lifecycle",type=string,JSONPath=`.spec.lifecycle`
 // +kubebuilder:printcolumn:name="Repository",type=string,JSONPath=`.spec.repository`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
+++ b/api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml
@@ -39,7 +39,7 @@ spec:
     - jsonPath: .status.revision
       name: Revision
       type: string
-    - jsonPath: .metadata.labels['porch.kpt.dev/latest-revision']
+    - jsonPath: .metadata.labels['porch\.kpt\.dev/latest-revision']
       name: Latest
       type: string
     - jsonPath: .spec.lifecycle

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
@@ -73,12 +73,14 @@ func (r *RepositoryReconciler) listExistingPackageRevisions(ctx context.Context,
 func (r *RepositoryReconciler) applyDesiredPackageRevisions(ctx context.Context, repo *configapi.Repository, pkgRevs []repository.PackageRevision, existingByName map[string]*porchv1alpha2.PackageRevision) map[string]bool {
 	log := log.FromContext(ctx)
 	desiredNames := make(map[string]bool, len(pkgRevs))
+	latestByPackage := computeLatestRevisions(ctx, pkgRevs)
 
 	for _, pkgRev := range pkgRevs {
 		name := pkgRev.KubeObjectName()
 		ex, isUpdate := existingByName[name]
 
-		desired, err := buildPackageRevision(ctx, repo, pkgRev)
+		isLatest := latestByPackage[name]
+		desired, err := buildPackageRevision(ctx, repo, pkgRev, isLatest)
 		if err != nil {
 			log.Error(err, "Failed to build PackageRevision", "key", pkgRev.Key())
 			continue
@@ -197,11 +199,21 @@ func (r *RepositoryReconciler) applySeedFields(ctx context.Context, repo *config
 // fields (package name, repo, workspace) and fields owned by other controllers
 // (lifecycle, conditions, publish metadata).
 func packageRevisionUpToDate(existing, desired *porchv1alpha2.PackageRevision) bool {
-	return equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+	return repoOwnedLabelsMatch(existing.Labels, desired.Labels) &&
 		existing.Status.Deployment == desired.Status.Deployment &&
 		resourcesSizeBytesUpToDate(existing.Status.ResourcesSizeBytes, desired.Status.ResourcesSizeBytes) &&
 		equality.Semantic.DeepEqual(existing.Status.UpstreamLock, desired.Status.UpstreamLock) &&
 		equality.Semantic.DeepEqual(existing.Status.SelfLock, desired.Status.SelfLock)
+}
+
+// repoOwnedLabelsMatch returns true if the labels the repo controller owns
+// (repository label and latest-revision) match between existing and desired.
+// Labels owned by other controllers or users are ignored.
+func repoOwnedLabelsMatch(existing, desired map[string]string) bool {
+	if existing[RepositoryLabel] != desired[RepositoryLabel] {
+		return false
+	}
+	return existing[porchv1alpha2.LatestPackageRevisionKey] == desired[porchv1alpha2.LatestPackageRevisionKey]
 }
 
 // resourcesSizeBytesUpToDate returns true if the size field doesn't need updating.
@@ -218,7 +230,7 @@ func resourcesSizeBytesUpToDate(existing, desired int64) bool {
 // repo-controller-owned fields: identity, labels, ownerRef, locks, deployment.
 // Seed fields (lifecycle, publish metadata, Kptfile-derived) are applied
 // separately via applySeedFields on create.
-func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRev repository.PackageRevision) (*porchv1alpha2.PackageRevision, error) {
+func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRev repository.PackageRevision, isLatest bool) (*porchv1alpha2.PackageRevision, error) {
 	key := pkgRev.Key()
 	_, upstreamLock, _ := pkgRev.GetUpstreamLock(ctx)
 	_, selfLock, _ := pkgRev.GetLock(ctx)
@@ -243,7 +255,7 @@ func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pkgRev.KubeObjectName(),
 			Namespace: pkgRev.KubeObjectNamespace(),
-			Labels:    packageRevisionLabelsForUpdate(repo.Name),
+			Labels:    packageRevisionLabelsWithLatest(repo.Name, isLatest),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: configapi.GroupVersion.Identifier(),
@@ -265,8 +277,58 @@ func buildPackageRevision(ctx context.Context, repo *configapi.Repository, pkgRe
 	return crd, nil
 }
 
+// computeLatestRevisions determines which revision is the latest (highest
+// revision number among Published packages) for each package, and returns
+// a map from CRD object name to whether it is the latest.
+func computeLatestRevisions(ctx context.Context, pkgRevs []repository.PackageRevision) map[string]bool {
+	type candidate struct {
+		name     string
+		revision int
+	}
+	// Group by package pathname and find highest revision per package.
+	latestPerPkg := make(map[string]candidate)
+	for _, pkgRev := range pkgRevs {
+		key := pkgRev.Key()
+		lifecycle := pkgRev.Lifecycle(ctx)
+		if !porchv1alpha2.LifecycleIsPublished(porchv1alpha2.PackageRevisionLifecycle(lifecycle)) {
+			continue
+		}
+		if key.Revision <= 0 {
+			continue
+		}
+		pkgPath := key.PkgKey.ToPkgPathname()
+		if c, exists := latestPerPkg[pkgPath]; !exists || key.Revision > c.revision {
+			latestPerPkg[pkgPath] = candidate{name: pkgRev.KubeObjectName(), revision: key.Revision}
+		}
+	}
+
+	result := make(map[string]bool, len(pkgRevs))
+	for _, c := range latestPerPkg {
+		result[c.name] = true
+	}
+	return result
+}
+
+// packageRevisionLabelsWithLatest returns the standard labels for a
+// PackageRevision, including the repository label and the latest-revision
+// indicator. The repo controller owns this label via SSA and keeps it
+// accurate across syncs. The PR controller may also update it on lifecycle
+// transitions via MergePatch (publish, delete).
+func packageRevisionLabelsWithLatest(repoName string, isLatest bool) map[string]string {
+	labels := map[string]string{
+		RepositoryLabel: repoName,
+	}
+	if isLatest {
+		labels[porchv1alpha2.LatestPackageRevisionKey] = porchv1alpha2.LatestPackageRevisionValue
+	} else {
+		labels[porchv1alpha2.LatestPackageRevisionKey] = "false"
+	}
+	return labels
+}
+
 // packageRevisionLabels returns the standard labels for a PackageRevision,
 // including the repository label and the latest-revision indicator.
+// Used in tests only.
 func packageRevisionLabels(repoName string, pkgRev repository.PackageRevision) map[string]string {
 	labels := map[string]string{
 		RepositoryLabel: repoName,
@@ -277,12 +339,4 @@ func packageRevisionLabels(repoName string, pkgRev repository.PackageRevision) m
 		labels[porchv1alpha2.LatestPackageRevisionKey] = "false"
 	}
 	return labels
-}
-
-// packageRevisionLabelsForUpdate returns labels for the update path.
-// Omits latest-revision — that's PR-controller-owned after initial creation.
-func packageRevisionLabelsForUpdate(repoName string) map[string]string {
-	return map[string]string{
-		RepositoryLabel: repoName,
-	}
 }

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync.go
@@ -73,13 +73,13 @@ func (r *RepositoryReconciler) listExistingPackageRevisions(ctx context.Context,
 func (r *RepositoryReconciler) applyDesiredPackageRevisions(ctx context.Context, repo *configapi.Repository, pkgRevs []repository.PackageRevision, existingByName map[string]*porchv1alpha2.PackageRevision) map[string]bool {
 	log := log.FromContext(ctx)
 	desiredNames := make(map[string]bool, len(pkgRevs))
-	latestByPackage := computeLatestRevisions(ctx, pkgRevs)
+	latestByName := computeLatestRevisions(ctx, pkgRevs)
 
 	for _, pkgRev := range pkgRevs {
 		name := pkgRev.KubeObjectName()
 		ex, isUpdate := existingByName[name]
 
-		isLatest := latestByPackage[name]
+		isLatest := latestByName[name]
 		desired, err := buildPackageRevision(ctx, repo, pkgRev, isLatest)
 		if err != nil {
 			log.Error(err, "Failed to build PackageRevision", "key", pkgRev.Key())

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -168,7 +168,7 @@ func TestBuildPackageRevision(t *testing.T) {
 			Git:  &kptfilev1.GitLock{Repo: "https://github.com/self.git", Ref: "main", Directory: "path/to/my-pkg", Commit: "def"},
 		}
 
-		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		crd, err := buildPackageRevision(ctx, repo, pkgRev, true)
 		assert.NoError(t, err)
 
 		// Metadata
@@ -205,7 +205,7 @@ func TestBuildPackageRevision(t *testing.T) {
 	t.Run("draft has no publish metadata", func(t *testing.T) {
 		pkgRev := newFakePkgRev("draft-pkg", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
 
-		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		crd, err := buildPackageRevision(ctx, repo, pkgRev, false)
 		assert.NoError(t, err)
 
 		// buildPackageRevision never includes seed fields
@@ -218,7 +218,7 @@ func TestBuildPackageRevision(t *testing.T) {
 	t.Run("empty kptfile yields nil optional fields", func(t *testing.T) {
 		pkgRev := newFakePkgRev("bare-pkg", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
 
-		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		crd, err := buildPackageRevision(ctx, repo, pkgRev, false)
 		assert.NoError(t, err)
 
 		assert.Nil(t, crd.Spec.ReadinessGates)
@@ -236,7 +236,7 @@ func TestBuildPackageRevision(t *testing.T) {
 			"ns.yaml": "ij",    // 2 bytes
 		}
 
-		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		crd, err := buildPackageRevision(ctx, repo, pkgRev, false)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(10), crd.Status.ResourcesSizeBytes)
 	})
@@ -244,7 +244,7 @@ func TestBuildPackageRevision(t *testing.T) {
 	t.Run("ResourcesSizeBytes zero when no resources", func(t *testing.T) {
 		pkgRev := newFakePkgRev("empty-pkg", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
 
-		crd, err := buildPackageRevision(ctx, repo, pkgRev)
+		crd, err := buildPackageRevision(ctx, repo, pkgRev, false)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(0), crd.Status.ResourcesSizeBytes)
 	})
@@ -255,7 +255,10 @@ func TestBuildPackageRevision(t *testing.T) {
 func TestPackageRevisionUpToDate(t *testing.T) {
 	base := &porchv1alpha2.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{RepositoryLabel: "repo1"},
+			Labels: map[string]string{
+				RepositoryLabel:                        "repo1",
+				porchv1alpha2.LatestPackageRevisionKey: "false",
+			},
 		},
 		Spec: porchv1alpha2.PackageRevisionSpec{
 			PackageName: "pkg1",
@@ -276,7 +279,7 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 		{name: "status changed (packageConditions — PR controller owned)", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Status.PackageConditions = []porchv1alpha2.PackageCondition{{Type: "new"}}
 		}, expected: true},
-		{name: "labels changed", modify: func(pr *porchv1alpha2.PackageRevision) {
+		{name: "latest-revision label changed", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Labels[porchv1alpha2.LatestPackageRevisionKey] = porchv1alpha2.LatestPackageRevisionValue
 		}, expected: false},
 		{name: "annotations differ - still up to date", modify: func(pr *porchv1alpha2.PackageRevision) {
@@ -284,6 +287,9 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 		}, expected: true},
 		{name: "ResourcesSizeBytes changed", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Status.ResourcesSizeBytes = 12345
+		}, expected: false},
+		{name: "repository label changed", modify: func(pr *porchv1alpha2.PackageRevision) {
+			pr.Labels[RepositoryLabel] = "different-repo"
 		}, expected: false},
 	}
 
@@ -344,6 +350,90 @@ func TestPackageRevisionLabels(t *testing.T) {
 	}
 }
 
+func TestPackageRevisionLabelsWithLatest(t *testing.T) {
+	t.Run("latest=true", func(t *testing.T) {
+		labels := packageRevisionLabelsWithLatest("my-repo", true)
+		assert.Equal(t, "my-repo", labels[RepositoryLabel])
+		assert.Equal(t, porchv1alpha2.LatestPackageRevisionValue, labels[porchv1alpha2.LatestPackageRevisionKey])
+	})
+
+	t.Run("latest=false", func(t *testing.T) {
+		labels := packageRevisionLabelsWithLatest("my-repo", false)
+		assert.Equal(t, "my-repo", labels[RepositoryLabel])
+		assert.Equal(t, "false", labels[porchv1alpha2.LatestPackageRevisionKey])
+	})
+}
+
+func TestComputeLatestRevisions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("single package with multiple revisions", func(t *testing.T) {
+		v1 := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v1.key.Revision = 1
+		v2 := newFakePkgRev("pkg1", "v2", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v2.key.Revision = 2
+		v3 := newFakePkgRev("pkg1", "v3", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v3.key.Revision = 3
+
+		result := computeLatestRevisions(ctx, []repository.PackageRevision{v1, v2, v3})
+		assert.True(t, result[v3.KubeObjectName()])
+		assert.False(t, result[v1.KubeObjectName()])
+		assert.False(t, result[v2.KubeObjectName()])
+	})
+
+	t.Run("draft packages are excluded", func(t *testing.T) {
+		v1 := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v1.key.Revision = 1
+		draft := newFakePkgRev("pkg1", "ws1", porchv1alpha2.PackageRevisionLifecycleDraft)
+		draft.key.Revision = 0
+
+		result := computeLatestRevisions(ctx, []repository.PackageRevision{v1, draft})
+		assert.True(t, result[v1.KubeObjectName()])
+		assert.False(t, result[draft.KubeObjectName()])
+	})
+
+	t.Run("main branch (revision 0) is excluded", func(t *testing.T) {
+		main := newFakePkgRev("pkg1", "main", porchv1alpha2.PackageRevisionLifecyclePublished)
+		main.key.Revision = 0
+		v1 := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v1.key.Revision = 1
+
+		result := computeLatestRevisions(ctx, []repository.PackageRevision{main, v1})
+		assert.True(t, result[v1.KubeObjectName()])
+		assert.False(t, result[main.KubeObjectName()])
+	})
+
+	t.Run("multiple packages each get their own latest", func(t *testing.T) {
+		pkg1v1 := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		pkg1v1.key.Revision = 1
+		pkg1v2 := newFakePkgRev("pkg1", "v2", porchv1alpha2.PackageRevisionLifecyclePublished)
+		pkg1v2.key.Revision = 2
+		pkg2v1 := newFakePkgRev("pkg2", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		pkg2v1.key.Revision = 1
+
+		result := computeLatestRevisions(ctx, []repository.PackageRevision{pkg1v1, pkg1v2, pkg2v1})
+		assert.True(t, result[pkg1v2.KubeObjectName()])
+		assert.True(t, result[pkg2v1.KubeObjectName()])
+		assert.False(t, result[pkg1v1.KubeObjectName()])
+	})
+
+	t.Run("DeletionProposed counts as published", func(t *testing.T) {
+		v1 := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
+		v1.key.Revision = 1
+		v2 := newFakePkgRev("pkg1", "v2", porchv1alpha2.PackageRevisionLifecycleDeletionProposed)
+		v2.key.Revision = 2
+
+		result := computeLatestRevisions(ctx, []repository.PackageRevision{v1, v2})
+		assert.True(t, result[v2.KubeObjectName()])
+		assert.False(t, result[v1.KubeObjectName()])
+	})
+
+	t.Run("empty list returns empty map", func(t *testing.T) {
+		result := computeLatestRevisions(ctx, nil)
+		assert.Empty(t, result)
+	})
+}
+
 // --- Tests: syncPackageRevisions ---
 
 func TestSyncPackageRevisions(t *testing.T) {
@@ -360,7 +450,7 @@ func TestSyncPackageRevisions(t *testing.T) {
 	}
 
 	// Pre-build the "up to date" resource for the skip test
-	upToDatePR, _ := buildPackageRevision(ctx, repo, draftPkgRev)
+	upToDatePR, _ := buildPackageRevision(ctx, repo, draftPkgRev, false)
 
 	tests := []struct {
 		name        string
@@ -538,7 +628,7 @@ func TestBuildPackageRevisionOmitsNonOwnedFields(t *testing.T) {
 		},
 	}
 
-	crd, err := buildPackageRevision(ctx, repo, pkgRev)
+	crd, err := buildPackageRevision(ctx, repo, pkgRev, false)
 	assert.NoError(t, err)
 
 	// Verify identity fields are present.
@@ -570,7 +660,7 @@ func TestResyncDoesNotStripNonOwnedStatusFields(t *testing.T) {
 	pkgRev.commitAuthor = "user@example.com"
 
 	// Build the resource as the repo controller would for the update path.
-	crd, err := buildPackageRevision(ctx, repo, pkgRev)
+	crd, err := buildPackageRevision(ctx, repo, pkgRev, true)
 	assert.NoError(t, err)
 
 	// The resource must NOT contain publish metadata — those are PR-controller-owned.
@@ -594,7 +684,7 @@ func TestSyncUpdatePathDoesNotCallSeedFields(t *testing.T) {
 	}
 
 	// Existing resource has an old selfLock so it's NOT up-to-date.
-	existingPR, _ := buildPackageRevision(ctx, repo, pkgRev)
+	existingPR, _ := buildPackageRevision(ctx, repo, pkgRev, true)
 	existingPR.Status.SelfLock = nil // different from desired → triggers update
 
 	mockClient := mockclient.NewMockClient(t)
@@ -636,10 +726,14 @@ func TestSeedFieldsNotCalledOnUpdate(t *testing.T) {
 
 	pkgRev := newFakePkgRev("pkg1", "v1", porchv1alpha2.PackageRevisionLifecyclePublished)
 	pkgRev.key.Revision = 1
+	pkgRev.selfLock = kptfilev1.Locator{
+		Type: kptfilev1.GitOrigin,
+		Git:  &kptfilev1.GitLock{Repo: "https://example.com/repo.git", Ref: "main", Directory: "pkg1", Commit: "new-commit"},
+	}
 
-	// Simulate existing resource with different labels to force an update.
-	existingPR, _ := buildPackageRevision(ctx, repo, pkgRev)
-	existingPR.Labels["extra"] = "label"
+	// Simulate existing resource with a different selfLock to force an update.
+	existingPR, _ := buildPackageRevision(ctx, repo, pkgRev, true)
+	existingPR.Status.SelfLock = nil // different from desired → triggers update
 
 	mockClient := mockclient.NewMockClient(t)
 	mockListReturning(mockClient, []porchv1alpha2.PackageRevision{*existingPR})

--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -285,6 +285,9 @@ func TestPackageRevisionUpToDate(t *testing.T) {
 		{name: "annotations differ - still up to date", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Annotations = map[string]string{"foo": "bar"}
 		}, expected: true},
+		{name: "non-repo-owned label differs - still up to date", modify: func(pr *porchv1alpha2.PackageRevision) {
+			pr.Labels["user.example.com/custom"] = "something"
+		}, expected: true},
 		{name: "ResourcesSizeBytes changed", modify: func(pr *porchv1alpha2.PackageRevision) {
 			pr.Status.ResourcesSizeBytes = 12345
 		}, expected: false},

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -68,6 +68,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 		subpackageDir1 = "level1/level2/my-subpackage-1"
 		subpackageDir2 = "level1/level2/my-subpackage-1/my-subpackage-2"
 		subpackageDir3 = "level1/level2/my-subpackage-1"
+		subpackageDir4 = "level1/level2/my-subpackage-1/"
 	)
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
@@ -92,15 +93,33 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
 
-	_, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir2)
-	if err == nil || !strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage") {
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir2)
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
 		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir2, err)
 	}
 
 	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir3)
-	if err == nil || !strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage") {
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
 		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
+	}
+
+	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir3)
+	if err == nil ||
+		!strings.Contains(err.Error(), "cannot clone subpackage into another subpackage, parent already has a subpackage at") &&
+			!strings.Contains(err.Error(), "cannot clone subpackage into parent, parent already has content at") {
+		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir3, err)
+	}
+
+	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir4)
+	if err == nil || !strings.Contains(err.Error(), "subpackageDir is invalid: subpackage directory \"level1/level2/my-subpackage-1/\" is invalid") {
+		t.Fatalf("Clone of subpackage %v in parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir4, err)
 	}
 
 	t.deletePR(parentPR)
@@ -547,7 +566,7 @@ func (t *PorchSuite) addPipelineToPR(pr *porchapi.PackageRevision) {
 	}
 	t.SaveKptfileF(&prResources, kptfile)
 
-	prResources.Spec.Resources["my-configmap.yaml"] = `
+	testConfigmapStr := `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -555,6 +574,10 @@ metadata:
 data:
   someKey: someValue
 `
+
+	prResources.Spec.Resources["my-configmap.yaml"] = strings.ReplaceAll(testConfigmapStr, "name: my-configmap", "name: my-"+pr.Name+"-configmap")
+	delete(prResources.Spec.Resources, "package-context.yaml")
+
 	t.UpdateF(&prResources)
 	t.GetF(client.ObjectKeyFromObject(pr), pr)
 }

--- a/test/e2e/cli-v1alpha2/testdata/rpkg-get/config.yaml
+++ b/test/e2e/cli-v1alpha2/testdata/rpkg-get/config.yaml
@@ -1,6 +1,3 @@
-# Skip: v1alpha2 CRD shows revision=-1 for main branches and LATEST label not consistently set.
-# Fix the controller to display <none> for unpublished revision and set the latest-revision label.
-skip: "v1alpha2 revision/latest display gaps - fix controller output before enabling"
 commands:
   - args:
       - porchctl
@@ -23,22 +20,22 @@ commands:
       - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.status.revision
     stdout: |
       NAME                                PKG            REPO              REV
-      test-blueprints.basens.main         basens         test-blueprints   <none>
+      test-blueprints.basens.main         basens         test-blueprints   -1
       test-blueprints.basens.v1           basens         test-blueprints   1
       test-blueprints.basens.v2           basens         test-blueprints   2
       test-blueprints.basens.v3           basens         test-blueprints   3
       test-blueprints.basens.v4           basens         test-blueprints   4
-      test-blueprints.bucket.main         bucket         test-blueprints   <none>
+      test-blueprints.bucket.main         bucket         test-blueprints   -1
       test-blueprints.bucket.v1           bucket         test-blueprints   1
-      test-blueprints.empty.main          empty          test-blueprints   <none>
+      test-blueprints.empty.main          empty          test-blueprints   -1
       test-blueprints.empty.v1            empty          test-blueprints   1
-      test-blueprints.nstest.main         nstest         test-blueprints   <none>
+      test-blueprints.nstest.main         nstest         test-blueprints   -1
       test-blueprints.nstest.v1           nstest         test-blueprints   1
-      test-blueprints.redis-bucket.main   redis-bucket   test-blueprints   <none>
+      test-blueprints.redis-bucket.main   redis-bucket   test-blueprints   -1
       test-blueprints.redis-bucket.v1     redis-bucket   test-blueprints   1
-      test-blueprints.unready.main        unready        test-blueprints   <none>
+      test-blueprints.unready.main        unready        test-blueprints   -1
       test-blueprints.unready.v1          unready        test-blueprints   1
-      test-blueprints.update.main         update         test-blueprints   <none>
+      test-blueprints.update.main         update         test-blueprints   -1
       test-blueprints.update.v1           update         test-blueprints   1
       test-blueprints.update.v2           update         test-blueprints   2
   - args:
@@ -48,8 +45,9 @@ commands:
       - --api-version=v1alpha2
       - --namespace=rpkg-get
       - test-blueprints.basens.v1
+      - "--output=custom-columns=NAME:.metadata.name,PACKAGE:.spec.packageName,WORKSPACENAME:.spec.workspaceName,REVISION:.status.revision,LATEST:.metadata.labels.porch\\.kpt\\.dev/latest-revision,LIFECYCLE:.spec.lifecycle,REPOSITORY:.spec.repository"
     stdout: |
-      NAME                        PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY        AGE
+      NAME                        PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
       test-blueprints.basens.v1   basens    v1              1          false    Published   test-blueprints
     ignoreWhitespace: true
   - args:
@@ -59,9 +57,10 @@ commands:
       - --api-version=v1alpha2
       - --namespace=rpkg-get
       - --name=basens
+      - "--output=custom-columns=NAME:.metadata.name,PACKAGE:.spec.packageName,WORKSPACENAME:.spec.workspaceName,REVISION:.status.revision,LATEST:.metadata.labels.porch\\.kpt\\.dev/latest-revision,LIFECYCLE:.spec.lifecycle,REPOSITORY:.spec.repository"
     stdout: |
-      NAME                          PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY        AGE
-      test-blueprints.basens.main   basens    main            <none>     <none>   Published   test-blueprints
+      NAME                          PACKAGE   WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
+      test-blueprints.basens.main   basens    main            -1         false    Published   test-blueprints
       test-blueprints.basens.v1     basens    v1              1          false    Published   test-blueprints
       test-blueprints.basens.v2     basens    v2              2          false    Published   test-blueprints
       test-blueprints.basens.v3     basens    v3              3          false    Published   test-blueprints

--- a/test/e2e/crd/repository_test.go
+++ b/test/e2e/crd/repository_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Repository", Ordered, Label("infra"), func() {
 			))
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 
-		By("verifying basens/main has no latest-revision label or is excluded")
+		By("verifying basens/main has latest-revision=false")
 		Eventually(func(g Gomega) {
 			pr := &porchv1alpha2.PackageRevision{}
 			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKey{

--- a/test/e2e/crd/repository_test.go
+++ b/test/e2e/crd/repository_test.go
@@ -415,4 +415,71 @@ var _ = Describe("Repository", Ordered, Label("infra"), func() {
 			Expect(pr.Namespace).To(Equal(ns2))
 		}
 	})
+
+	It("should set latest-revision label correctly on discovered packages", func() {
+		By("verifying the shared test-blueprints repo has discovered packages")
+		var allPRs porchv1alpha2.PackageRevisionList
+		Expect(k8sClient.List(env.Ctx, &allPRs,
+			client.InNamespace(env.Namespace),
+			client.MatchingLabels{"porch.kpt.dev/repository": testBlueprintsRepo},
+		)).To(Succeed())
+		Expect(allPRs.Items).NotTo(BeEmpty())
+
+		By("verifying basens/v4 is the latest (highest revision)")
+		// test-blueprints has basens v1-v4 tagged; v4 should be latest.
+		Eventually(func(g Gomega) {
+			pr := &porchv1alpha2.PackageRevision{}
+			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKey{
+				Namespace: env.Namespace,
+				Name:      crdName(testBlueprintsRepo, "basens", "v4"),
+			}, pr)).To(Succeed())
+			g.Expect(pr.Labels).To(HaveKeyWithValue(
+				porchv1alpha2.LatestPackageRevisionKey, porchv1alpha2.LatestPackageRevisionValue,
+			))
+		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
+
+		By("verifying basens/v1 is not latest")
+		Eventually(func(g Gomega) {
+			pr := &porchv1alpha2.PackageRevision{}
+			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKey{
+				Namespace: env.Namespace,
+				Name:      crdName(testBlueprintsRepo, "basens", "v1"),
+			}, pr)).To(Succeed())
+			g.Expect(pr.Labels).To(HaveKeyWithValue(
+				porchv1alpha2.LatestPackageRevisionKey, "false",
+			))
+		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
+
+		By("verifying basens/main has no latest-revision label or is excluded")
+		Eventually(func(g Gomega) {
+			pr := &porchv1alpha2.PackageRevision{}
+			g.Expect(k8sClient.Get(env.Ctx, client.ObjectKey{
+				Namespace: env.Namespace,
+				Name:      crdName(testBlueprintsRepo, "basens", "main"),
+			}, pr)).To(Succeed())
+			// main branch has latest=false (consistent with v1alpha1 behavior)
+			g.Expect(pr.Labels).To(HaveKeyWithValue(
+				porchv1alpha2.LatestPackageRevisionKey, "false",
+			))
+		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
+
+		By("verifying label selector returns exactly one latest per package")
+		var latestPRs porchv1alpha2.PackageRevisionList
+		Expect(k8sClient.List(env.Ctx, &latestPRs,
+			client.InNamespace(env.Namespace),
+			client.MatchingLabels{
+				"porch.kpt.dev/repository":             testBlueprintsRepo,
+				porchv1alpha2.LatestPackageRevisionKey: porchv1alpha2.LatestPackageRevisionValue,
+			},
+		)).To(Succeed())
+		// Each package in test-blueprints should have exactly one latest.
+		// Verify no duplicates per package.
+		latestByPkg := map[string]string{}
+		for _, pr := range latestPRs.Items {
+			pkg := pr.Spec.PackageName
+			Expect(latestByPkg).NotTo(HaveKey(pkg), "duplicate latest for package %s", pkg)
+			latestByPkg[pkg] = pr.Name
+		}
+		Expect(latestByPkg).NotTo(BeEmpty())
+	})
 })


### PR DESCRIPTION
## Title

Set latest-revision label on discovered PackageRevision CRDs

---

## Description

- What changed: The repo controller now computes which revision is the latest (highest revision among Published packages) per package during git discovery sync, and sets the `porch.kpt.dev/latest-revision` label via SSA. Also fixes the CRD print column JSONPath (dots in label key need escaping).
- Why it's needed: Discovered packages never had the latest-revision label set, making `kubectl get rpkg` show an empty LATEST column and breaking label-selector-based filtering (#922). The CRD print column JSONPath was also broken due to unescaped dots in the label key.
- How it works: `computeLatestRevisions()` groups discovered packages by name, finds the highest revision among Published packages, and passes `isLatest` to `buildPackageRevision` which includes the label in the SSA apply. The PR controller continues to own label updates on lifecycle transitions (publish, delete).

---

## Related Issue(s)

- Fixes #922

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other

---

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions

1. `make reload-controllers` to deploy the new controller
2. `kubectl apply -f api/porch/v1alpha2/porch.kpt.dev_packagerevisions.yaml` to update the CRD
3. Register a v1alpha2 repo and verify: `kubectl get rpkg -n <ns>` shows LATEST column populated
4. `E2E=1 go test ./test/e2e/cli-v1alpha2/ -run TestPorchCLIV1Alpha2/rpkg-get -count=1 -v`
5. `E2E=1 go test ./test/e2e/crd/ -run "should set latest-revision label" -count=1 -v`

---

## Additional Notes

- v1alpha2 behavior now matches v1alpha1: main branches show `LATEST=false`, highest versioned published package shows `LATEST=true`
- The `packageRevisionUpToDate` check was refined to only compare repo-controller-owned labels, avoiding patch churn from user or PR-controller-set labels

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to analyse the codebase, implement the fix, write unit tests, and debug the CRD JSONPath escaping issue.
  - The author has fully verified all code.