### PR TITLE
Harmonizing note titles

### DIFF
--- a/docs/content/en/docs/2_concepts/package.md
+++ b/docs/content/en/docs/2_concepts/package.md
@@ -6,7 +6,7 @@ description: |
   Understanding packages in Porch: the relationship between kpt packages and Porch's PackageRevision API.
 ---
 
-{{% alert title="Important!" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 
 A "Porch package" is a collection of **package revisions on the same kpt package**. Porch does not have the concept of a
 "Package" internally - whenever an API request is received on a package, Porch composes the response from the package revisions

--- a/docs/content/en/docs/2_concepts/repositories.md
+++ b/docs/content/en/docs/2_concepts/repositories.md
@@ -30,7 +30,7 @@ Git repositories are the primary and fully-supported storage backend for Porch. 
 
 OCI (Open Container Initiative) registries provide an alternative storage backend. Packages are stored as OCI artifacts (similar to container images). Support is experimental and may be unstable. This option is useful in environments that already use OCI registries.
 
-{{% alert title="Note" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 OCI repository support is **experimental** and **may be unstable**. Git repositories are recommended for production use.
 {{% /alert %}}
 
@@ -48,7 +48,7 @@ When a Repository resource is registered with Porch, Porch automatically conduct
 
 ## Immutability
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 The following fields are **immutable** after repository creation and cannot be modified:
 - `spec.type`
 - `spec.git.repo`

--- a/docs/content/en/docs/2_concepts/workspace.md
+++ b/docs/content/en/docs/2_concepts/workspace.md
@@ -6,7 +6,7 @@ description: |
   Understanding workspaces: how Porch isolates concurrent work on packages.
 ---
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 
 **Workspace is merely a unique ID for a package revision!**
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/deleting-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/deleting-packages.md
@@ -346,7 +346,7 @@ Error from server (Forbidden): cannot delete package revision, it is referenced 
 
 After deleting PackageRevisions, you may notice "main" branch-tracking PackageRevisions still exist. These are automatically created by Porch when packages are published and must be deleted separately.
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 Main branch-tracking PackageRevisions (with workspace name "main" and revision "-1") are managed automatically by Porch. Do not modify, propose, approve, or otherwise interact with them except for deletion after all regular PackageRevisions of that specific package have been removed.
 {{% /alert %}}
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
@@ -99,7 +99,7 @@ Key fields to inspect:
 - **spec.tasks**: History of operations performed on this PackageRevision
 - **status.publishTimestamp**: When the PackageRevision was published
 
-{{% alert title="Tip" color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 Use `jq` to extract specific fields: `porchctl rpkg get <name> -n default -o json | jq '.metadata'`
 {{% /alert %}}
 

--- a/docs/content/en/docs/6_configuration_and_deployments/configurations/cache.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/configurations/cache.md
@@ -69,7 +69,7 @@ args:
 - Database credentials and connection details
 - Database initialized with Porch schema (`api/sql/porch-db.sql`)
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 Before configuring database cache:
 1. Ensure PostgreSQL is running and accessible
 2. Initialize the database schema using `api/sql/porch-db.sql`

--- a/docs/content/en/docs/6_configuration_and_deployments/configurations/components/function-runner-config/private-registries-config.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/configurations/components/function-runner-config/private-registries-config.md
@@ -163,7 +163,7 @@ When TLS is enabled, Function Runner attempts connection in this order:
 3. Without TLS as fallback
 4. Returns error if all attempts fail
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 Ensure Kubernetes nodes are configured with the same TLS certificate information. The Function Runner can pull images, but KRM function pods need node-level certificate configuration to run successfully.
 {{% /alert %}}
 

--- a/docs/content/en/docs/6_configuration_and_deployments/configurations/components/porch-server-config/git-authentication.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/configurations/components/porch-server-config/git-authentication.md
@@ -93,8 +93,8 @@ For Git repositories with custom TLS certificates. The CA bundle secret must:
 
 #### Enable TLS Support
 
-{{% alert title="Pre-deployment Required" color="warning" %}}
-The `--use-git-cabundle=true` argument must be added to the Porch Server deployment **before** deployment. This cannot be configured post-deployment.
+{{% alert title="Warning" color="warning" %}}
+Pre-deployment requirement. The `--use-git-cabundle=true` argument must be added to the Porch Server deployment **before** deployment. This cannot be configured post-deployment.
 {{% /alert %}}
 
 Add the `--use-git-cabundle=true` argument to the Porch Server deployment.

--- a/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
@@ -18,7 +18,7 @@ Choose your cache backend based on deployment scale and requirements:
 - **CR Cache** (default): Development and small deployments (<100 repositories)
 - **DB Cache**: Production deployments requiring scale and reliability
 
-{{% alert title="Important" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 If using **DB Cache**, you must configure database settings for **both** Porch Server and Repository Controller before deployment. See [Cache Configuration]({{% relref "/docs/6_configuration_and_deployments/configurations/cache" %}}) for complete setup instructions including database initialization.
 {{% /alert %}}
 

--- a/docs/content/en/docs/9_troubleshooting_and_faq/disaster-recovery/_index.md
+++ b/docs/content/en/docs/9_troubleshooting_and_faq/disaster-recovery/_index.md
@@ -44,7 +44,7 @@ taking a snapshot of the cluster's etcd store. If Porch is itself being managed 
 or FluxCD, the GitOps platform is expected to have its own record of the custom resources, conducting its own reconciliation
 operations to save and restore custom resources.
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 
 `PackageRevisions` and `PackageRevisionResources` are not actual custom resources and **should not be backed up as such**.
 Their data and metadata are brought together by the Porch API server from separate sources in Git and the package revision
@@ -52,7 +52,7 @@ cache.
 
 {{% /alert %}}
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 
 In the absence of an overarching GitOps solution, the exact mechanism for backing up cluster resources may vary between
 Kubernetes distributions. Consult the documentation for your specific distribution!
@@ -67,14 +67,14 @@ server: `git push` to back up and `git clone` or `git pull` (depending on the ex
 repositories in larger numbers or containing many large Kpt packages may require more specialized approaches to back up
 the Git servers themselves
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 
 The exact mechanism for backing up Git servers may vary depending on your choice of Git software. Consult the documentation
 for your specific Git service!
 
 {{% /alert %}}
 
-{{% alert title="Caution!" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 
 The Git repository is the source of truth for package revision files. Even if a package revision's data is present in the
 cache, this is not enough for Porch to restore a package revision that is not already present in Git.
@@ -87,7 +87,7 @@ If the DB cache option is selected at install time, the package revision cache i
 backing up the entire contents of this database on a regular basis, as it contains all data for unpublished package revisions
 (in lifecycle stages "Draft", "Proposed", or "DeletionProposed")
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 
 The exact mechanism for backing up the database may vary depending on your choice of SQL software. Consult the documentation
 for your specific database!
@@ -104,7 +104,7 @@ number of Repository objects and package revisions to provide a representative w
 
 ### Test suite:
 
-{{% alert title="Caution!" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 
 The test suite was developed on a system with the following specifications:
 - CPU: 11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz
@@ -166,8 +166,8 @@ guide.
 This section gives details of tested scenarios with varying combinations of backup, wipe, and restore routines for different
 data stores.
 
-{{% alert title="In case of package revision cache corruption" color="warning" %}}
-
+{{% alert title="Warning" color="warning" %}}
+In case of package revision cache corruption:
 - If the CR cache is configured and becomes corrupted, it can be recreated from the Git repositories. Porch recommends
   restarting the `porch-server` microservice to trigger this process (which will entail a decrease in quality of service
   until all repositories are deemed Ready).
@@ -199,7 +199,7 @@ Kubernetes cluster is lost with all nodes; Git repositories are lost; DB cache d
 #### Restoration steps:
 1. Recreate Kubernetes cluster
 2. Reinstall Porch with DB cache pointed to empty database server
-   {{% alert title="Compatibility" color="warning" %}}
+   {{% alert title="Warning" color="warning" %}}
 
    To ensure data compatibility, backup must be restored into the DB cache of the same version of Porch.
 
@@ -224,7 +224,7 @@ Kubernetes cluster is lost with all nodes; Git repositories and DB cache databas
 #### Restoration steps:
 1. Recreate Kubernetes cluster
 2. Reinstall Porch with DB cache pointed to same (still-existing) PostgreSQL server
-   {{% alert title="Compatibility" color="warning" %}}
+   {{% alert title="Warning" color="warning" %}}
 
    To ensure data compatibility, backup must be restored into the DB cache of the same version of Porch.
 
@@ -264,7 +264,7 @@ with grace-period 0).
 In a representative testing environment, recovery takes **less than 5 minutes** for 115 Repository objects with a `4GiB`
 memory limit applied to the `porch-server` microservice
 
-{{% alert title="However:" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
 
 Recovery may take longer depending on:
 - CPU and memory resources allotted to the Porch pods
@@ -284,7 +284,7 @@ consistency. Given sufficiently low resource limits, it may enter a crash loop a
 
 Kubernetes cluster and Git repositories remain safe; DB cache database is lost.
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 Applicable only to Porch with DB cache configured.
 {{% /alert %}}
 
@@ -303,7 +303,7 @@ Applicable only to Porch with DB cache configured.
 
 Kubernetes cluster and Git repositories remain safe; DB cache database is lost without a valid backup.
 
-{{% alert title="N.B." color="primary" %}}
+{{% alert title="Note" color="primary" %}}
 Applicable only to Porch with DB cache configured.
 {{% /alert %}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
Harmonizing note titles

---

## Description
Right now we have all kinds of note titles (even for example "however" or "compatbility"). This should be harmonized throughout the documentation. Fixed so all basic notes (blue) are titledNote, and caution types (yellow) are titled Warning.

---

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [ ] Self-reviewed changes  
- [ ] Tests added/updated  
- [x] Documentation added/updated  
- [ ] All tests and gating checks pass  

---