### PR TITLE
Skip TestPackageSizeMetric, TestPackageSizeMetricValues when running against CR cache

### DIFF
--- a/test/e2e/api/metrics_test.go
+++ b/test/e2e/api/metrics_test.go
@@ -88,6 +88,10 @@ data:
 }
 
 func (t *PorchSuite) TestPackageSizeMetric() {
+	if !t.UsingDBCache {
+		t.T().Skip("Package size metrics are only supported when using the DB cache. If you already installed Porch with the DB cache activated, set DB_CACHE and re-run this test.")
+	}
+
 	expectedMetrics := []string{
 		`porch_package_size_bytes_bucket`,
 		`porch_package_size_bytes_count`,

--- a/test/e2e/api/metrics_test.go
+++ b/test/e2e/api/metrics_test.go
@@ -89,7 +89,7 @@ data:
 
 func (t *PorchSuite) TestPackageSizeMetric() {
 	if !t.UsingDBCache {
-		t.T().Skip("Package size metrics are only supported when using the DB cache. If you already installed Porch with the DB cache activated, set DB_CACHE and re-run this test.")
+		t.T().Skip("Package size metrics are only supported in DB cache deployments. If you already deployed Porch with the DB cache activated, set the DB_CACHE environment variable and re-run this test.")
 	}
 
 	expectedMetrics := []string{
@@ -118,6 +118,10 @@ func (t *PorchSuite) TestPackageSizeMetric() {
 }
 
 func (t *PorchSuite) TestPackageSizeMetricValues() {
+	if !t.UsingDBCache {
+		t.T().Skip("Package size metrics are only supported in DB cache deployments. If you already deployed Porch with the DB cache activated, set the DB_CACHE environment variable and re-run this test.")
+	}
+
 	// Create a new package via init, no task specified
 	const (
 		repository  = "metrics-values"

--- a/test/e2e/api/metrics_test.go
+++ b/test/e2e/api/metrics_test.go
@@ -87,9 +87,11 @@ data:
 	}
 }
 
+const dbCacheSkipMessage = "Package size metrics are only supported in DB cache deployments. If you already deployed Porch with the DB cache activated, set the DB_CACHE environment variable and re-run this test."
+
 func (t *PorchSuite) TestPackageSizeMetric() {
 	if !t.UsingDBCache {
-		t.T().Skip("Package size metrics are only supported in DB cache deployments. If you already deployed Porch with the DB cache activated, set the DB_CACHE environment variable and re-run this test.")
+		t.T().Skip(dbCacheSkipMessage)
 	}
 
 	expectedMetrics := []string{
@@ -119,7 +121,7 @@ func (t *PorchSuite) TestPackageSizeMetric() {
 
 func (t *PorchSuite) TestPackageSizeMetricValues() {
 	if !t.UsingDBCache {
-		t.T().Skip("Package size metrics are only supported in DB cache deployments. If you already deployed Porch with the DB cache activated, set the DB_CACHE environment variable and re-run this test.")
+		t.T().Skip(dbCacheSkipMessage)
 	}
 
 	// Create a new package via init, no task specified


### PR DESCRIPTION
## Description
<!-- Describe what this PR does and why -->
- What changed:
  - TestPackageSizeMetric E2E test is now skipped if the suite is running against the CR cache
  - TestPackageSizeMetricValues E2E test is now skipped if the suite is running against the CR cache
- Why it’s needed:
  - Package size metrics are not supported in CR cache deployments
    - therefore, when Porch does a package revision operation with the CR cache, package sizes are not recorded
    - therefore, when TestPackageSizeMetric scrapes metrics, the package size metrics are not included and the test fails
  - TestPackageSizeMetricValues already asserts only if running against DB cache - added skip to cut down on needless PackageRevision operations
- How it works:
  - added skip directives in relevant E2E tests

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- failure in nightly CR cache E2E run: https://github.com/kptdev/porch/actions/runs/27594348302/job/81582058728
  - different exact failure here, but that seems to be an intermittent thing
    - reproduced locally with no-metrics-found failure described here

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [n/a] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**