### PR TITLE
Tiny docs fix: align Font Awesome font with Docsy theme

### DIFF
--- a/docs/assets/scss/_sidebar-left.scss
+++ b/docs/assets/scss/_sidebar-left.scss
@@ -52,7 +52,7 @@
 						&::after {
 							display: inline-flex;
 							content: '\f078';
-							font-family: 'Font Awesome 5 Free';
+  							font: var(--fa-font-solid);
 						}
 					}
 					&.active-path {


### PR DESCRIPTION
## Description
<!-- Describe what this PR does and why -->
- What changed:
  - use Docsy-provided variable in sidebar navigation SCSS to select Font Awesome font for expand/contract chevrons
    - instead of previous hard-coding to Font Awesome 5
- Why it’s needed:
  - recent Docsy upgrade brought in Font Awesome 6
    - hard-coding Font Awesome 5 resulted in breaking the chevrons
- How it works:
  - uses a CSS variable to refer to the font version specified by Docsy
---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
