### PR TITLE
Defining node version for the documentation

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,6 +11,7 @@
   GO_VERSION = "1.26.3"
   HUGO_VERSION = "0.161.1"
   HUGO_ENV = "production"
+  NODE_VERSION = "24"
 
 [context.production.environment]
   HUGO_ENV = "production"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -11,7 +11,7 @@
   GO_VERSION = "1.26.3"
   HUGO_VERSION = "0.161.1"
   HUGO_ENV = "production"
-  NODE_VERSION = "24"
+  NODE_VERSION = "24.15.0"
 
 [context.production.environment]
   HUGO_ENV = "production"


### PR DESCRIPTION
Netlify PR preview stated to fail due to an [unsupported Node version problem](https://app.netlify.com/projects/kpt-porch/deploys/6a339674203c3a0008c49169). For some reason Netlify is looking for Node version 20 what seem to be not supported anymore. 
We have a Node version defined in package.json to 24.15.0 , so I'm defining the major Node version to 24 for Netlify. 