### PR TITLE
Evict pod based on GRPC response instead of force check on every call

### DIFF
--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -44,7 +44,7 @@ type podEvictionRequest struct {
 
 // podCacheManager manages the cache of the pods and the corresponding GRPC clients.
 // It also does the garbage collection after pods' TTL.
-// It has 2 receive-only channels: connectionRequestCh and podReadyCh.
+// It has 3 receive-only channels: connectionRequestCh, podReadyCh, and evictionCh.
 // It listens to the connectionRequestCh channel and receives clientConnRequest from the
 // GRPC request handlers and add them in the waitlists.
 // It also listens to the podReadyCh channel. If a pod is ready, it notifies the

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -207,11 +207,25 @@ func (pcm *podCacheManager) podCacheManager(ctx context.Context) {
 		case evict := <-pcm.evictionCh:
 			fn, ok := pcm.functions[evict.image]
 			if !ok {
-				close(evict.doneCh)
+				if evict.doneCh != nil {
+					close(evict.doneCh)
+				}
 				continue
 			}
-			pcm.removeUnhealthyPods(fn, false)
-			close(evict.doneCh)
+			idx := slices.IndexFunc(fn.pods, func(pod functionPodInfo) bool {
+				return pod.podData != nil && pod.podKey != nil && *pod.podKey == evict.podKey
+			})
+			if idx != -1 {
+				klog.Infof("Evicting dead pod %s from cache for image %s (Unavailable)", evict.podKey.Name, evict.image)
+				pcm.DeletePodWithServiceInBackgroundByObjectKey(*fn.pods[idx].podData)
+				fn.pods = slices.Delete(fn.pods, idx, idx+1)
+			} else {
+				// Best-effort cleanup of any other stale entries for this image.
+				pcm.removeUnhealthyPods(fn, false)
+			}
+			if evict.doneCh != nil {
+				close(evict.doneCh)
+			}
 
 		case <-tick:
 			pcm.garbageCollector()

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -33,15 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// podEvictionRequest is sent after an Unavailable gRPC error to remove a dead pod from cache.
-type podEvictionRequest struct {
-	image  string
-	podKey client.ObjectKey
-	// doneCh is closed by the cache manager once the pod has been removed from cache,
-	// allowing the caller to wait for eviction completion before retrying.
-	doneCh chan struct{}
-}
-
 // podCacheManager manages the cache of the pods and the corresponding GRPC clients.
 // It also does the garbage collection after pods' TTL.
 // It has 3 receive-only channels: connectionRequestCh, podReadyCh, and evictionCh.
@@ -68,6 +59,15 @@ type podCacheManager struct {
 	maxWaitlistLength          int
 	maxParallelPodsPerFunction int
 	functionConfigMap          *fnconf.FunctionConfigStore
+}
+
+// podEvictionRequest is sent after an Unavailable gRPC error to remove a dead pod from cache.
+type podEvictionRequest struct {
+	image  string
+	podKey client.ObjectKey
+	// doneCh is closed by the cache manager once the pod has been removed from cache,
+	// allowing the caller to wait for eviction completion before retrying.
+	doneCh chan struct{}
 }
 
 // functionInfo holds the list of all pod instances for the same KRM function image.

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -33,6 +33,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// podEvictionRequest is sent after an Unavailable gRPC error to remove a dead pod from cache.
+type podEvictionRequest struct {
+	image  string
+	podKey client.ObjectKey
+}
+
 // podCacheManager manages the cache of the pods and the corresponding GRPC clients.
 // It also does the garbage collection after pods' TTL.
 // It has 2 receive-only channels: connectionRequestCh and podReadyCh.
@@ -48,6 +54,8 @@ type podCacheManager struct {
 	connectionRequestCh <-chan *connectionRequest
 	// podReadyCh is a channel to receive the information when a pod is ready.
 	podReadyCh <-chan *podReadyResponse
+	// evictionCh receives requests to remove specific dead pods from cache
+	evictionCh <-chan *podEvictionRequest
 
 	// functions maps KRM function image names to its pods and waitlist information.
 	functions map[string]*functionInfo
@@ -114,7 +122,6 @@ func (pcm *podCacheManager) podCacheManager(ctx context.Context) {
 			fn := pcm.FunctionInfo(req.image)
 
 			shouldScaleUp := false
-			pcm.removeUnhealthyPods(fn, false)
 			bestPodIndex, bestWaitlistLen := pcm.findBestPod(fn)
 			_, maxWaitlist, maxPods := pcm.getParamsForImage(req.image)
 			if bestPodIndex == -1 {
@@ -193,6 +200,22 @@ func (pcm *podCacheManager) podCacheManager(ctx context.Context) {
 				pod.SendResponse(ch, nil)
 			}
 			pod.waitlist = nil
+
+		case evict := <-pcm.evictionCh:
+			fn, ok := pcm.functions[evict.image]
+			if !ok {
+				continue
+			}
+			fn.pods = slices.DeleteFunc(fn.pods, func(pod functionPodInfo) bool {
+				if pod.podData != nil && *pod.podKey == evict.podKey {
+					klog.Infof("Evicting dead pod %s from cache for image %s (Unavailable)", evict.podKey.Name, evict.image)
+					if pod.grpcConnection != nil {
+						pod.grpcConnection.Close()
+					}
+					return true
+				}
+				return false
+			})
 
 		case <-tick:
 			pcm.garbageCollector()

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -37,6 +37,9 @@ import (
 type podEvictionRequest struct {
 	image  string
 	podKey client.ObjectKey
+	// doneCh is closed by the cache manager once the pod has been removed from cache,
+	// allowing the caller to wait for eviction completion before retrying.
+	doneCh chan struct{}
 }
 
 // podCacheManager manages the cache of the pods and the corresponding GRPC clients.
@@ -204,19 +207,11 @@ func (pcm *podCacheManager) podCacheManager(ctx context.Context) {
 		case evict := <-pcm.evictionCh:
 			fn, ok := pcm.functions[evict.image]
 			if !ok {
+				close(evict.doneCh)
 				continue
 			}
-			fn.pods = slices.DeleteFunc(fn.pods, func(pod functionPodInfo) bool {
-				if pod.podData != nil && *pod.podKey == evict.podKey {
-					klog.Infof("Evicting dead pod %s from cache for image %s (Unavailable)", evict.podKey.Name, evict.image)
-					if pod.grpcConnection != nil {
-						pod.grpcConnection.Close()
-					}
-					pcm.DeletePodWithServiceInBackgroundByObjectKey(*pod.podData)
-					return true
-				}
-				return false
-			})
+			pcm.removeUnhealthyPods(fn, false)
+			close(evict.doneCh)
 
 		case <-tick:
 			pcm.garbageCollector()

--- a/func/internal/podcachemanager.go
+++ b/func/internal/podcachemanager.go
@@ -212,6 +212,7 @@ func (pcm *podCacheManager) podCacheManager(ctx context.Context) {
 					if pod.grpcConnection != nil {
 						pod.grpcConnection.Close()
 					}
+					pcm.DeletePodWithServiceInBackgroundByObjectKey(*pod.podData)
 					return true
 				}
 				return false

--- a/func/internal/podcachemanager_eventloop_test.go
+++ b/func/internal/podcachemanager_eventloop_test.go
@@ -38,14 +38,16 @@ import (
 // newTestEventLoopPCM creates a podCacheManager with unbuffered channels suitable
 // for deterministic event loop testing. The podManager's podReadyCh is the same as
 // the pcm's podReadyCh so that getFuncEvalPodClient sends results to the event loop.
-func newTestEventLoopPCM(kubeClient client.Client) (*podCacheManager, chan *connectionRequest, chan *podReadyResponse) {
+func newTestEventLoopPCM(kubeClient client.Client) (*podCacheManager, chan *connectionRequest, chan *podReadyResponse, chan *podEvictionRequest) {
 	reqCh := make(chan *connectionRequest)
 	readyCh := make(chan *podReadyResponse)
+	evictCh := make(chan *podEvictionRequest)
 	pcm := &podCacheManager{
 		gcScanInterval:             5 * time.Minute,
 		podTTL:                     10 * time.Minute,
 		connectionRequestCh:        reqCh,
 		podReadyCh:                 readyCh,
+		evictionCh:                 evictCh,
 		functions:                  map[string]*functionInfo{},
 		maxWaitlistLength:          2,
 		maxParallelPodsPerFunction: 1,
@@ -60,14 +62,14 @@ func newTestEventLoopPCM(kubeClient client.Client) (*podCacheManager, chan *conn
 			managerNamespace:   defaultNamespace,
 		},
 	}
-	return pcm, reqCh, readyCh
+	return pcm, reqCh, readyCh, evictCh
 }
 
 // ---------- Event Loop Tests ----------
 
 func TestEventLoop_PodReadyEmptyImage(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
-	pcm, _, readyCh := newTestEventLoopPCM(kubeClient)
+	pcm, _, readyCh, _ := newTestEventLoopPCM(kubeClient)
 
 	// Pre-populate a pending pod for "test-image" BEFORE starting the event loop
 	waitCh := make(chan *connectionResponse, 1)
@@ -104,7 +106,7 @@ func TestEventLoop_PodReadyEmptyImage(t *testing.T) {
 
 func TestEventLoop_PodReadyUnknownFunction(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
-	pcm, _, readyCh := newTestEventLoopPCM(kubeClient)
+	pcm, _, readyCh, _ := newTestEventLoopPCM(kubeClient)
 
 	// Pre-populate a pending pod for "known-image" BEFORE starting the event loop
 	waitCh := make(chan *connectionResponse, 1)
@@ -163,7 +165,7 @@ func TestEventLoop_PodReadyNoPendingPod(t *testing.T) {
 	}
 
 	kubeClient := fake.NewClientBuilder().WithObjects(k8sPod, k8sSvc).Build()
-	pcm, reqCh, readyCh := newTestEventLoopPCM(kubeClient)
+	pcm, reqCh, readyCh, _ := newTestEventLoopPCM(kubeClient)
 
 	readyPod := makeReadyPodInfo("test-image", podKey, serviceKey, conn, 0)
 	pcm.functions["test-image"] = &functionInfo{
@@ -196,7 +198,7 @@ func TestEventLoop_PodReadyNoPendingPod(t *testing.T) {
 
 func TestEventLoop_QueueOnPendingPod(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().Build()
-	pcm, reqCh, readyCh := newTestEventLoopPCM(kubeClient)
+	pcm, reqCh, readyCh, _ := newTestEventLoopPCM(kubeClient)
 
 	// Pre-populate with pending pod that has one initial waiter
 	initialCh := make(chan *connectionResponse, 1)
@@ -251,7 +253,7 @@ func TestEventLoop_PodFailedNoRedistribution(t *testing.T) {
 			},
 		}).Build()
 
-	pcm, reqCh, _ := newTestEventLoopPCM(kubeClient)
+	pcm, reqCh, _, _ := newTestEventLoopPCM(kubeClient)
 
 	// Pre-populate imageMetadataCache so imageDigestAndEntrypoint returns instantly
 	pcm.podManager.imageMetadataCache.Store("ghcr.io/kptdev/krm-functions-catalog/test-fn:latest", &digestAndEntrypoint{
@@ -317,4 +319,121 @@ func TestRetrieveFunctionPods_EmptyPodList(t *testing.T) {
 	err := pcm.retrieveFunctionPods(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, pcm.functions)
+}
+
+func TestEventLoop_EvictionRemovesPodByKey(t *testing.T) {
+	podKey := client.ObjectKey{Name: "evict-pod", Namespace: defaultNamespace}
+	serviceKey := client.ObjectKey{Name: "evict-svc", Namespace: defaultNamespace}
+	serviceUrl := serviceKey.Name + "." + serviceKey.Namespace + serviceDnsNameSuffix
+	address := net.JoinHostPort(serviceUrl, defaultWrapperServerPort)
+	conn, _ := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	k8sPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "evict-pod", Namespace: defaultNamespace},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	k8sSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "evict-svc", Namespace: defaultNamespace},
+	}
+
+	kubeClient := fake.NewClientBuilder().WithObjects(k8sPod, k8sSvc).Build()
+	pcm, _, _, evictCh := newTestEventLoopPCM(kubeClient)
+
+	readyPod := makeReadyPodInfo("test-image", podKey, serviceKey, conn, 0)
+	pcm.functions["test-image"] = &functionInfo{
+		pods: []functionPodInfo{readyPod},
+	}
+
+	go pcm.podCacheManager(t.Context())
+
+	// Send eviction for the specific pod
+	doneCh := make(chan struct{})
+	evictCh <- &podEvictionRequest{
+		image:  "test-image",
+		podKey: podKey,
+		doneCh: doneCh,
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("eviction did not complete")
+	}
+
+	// Verify pod was removed from cache
+	fn := pcm.functions["test-image"]
+	assert.Empty(t, fn.pods, "evicted pod should be removed from cache")
+
+	// Verify k8s pod was deleted
+	time.Sleep(200 * time.Millisecond) // background delete
+	var pod corev1.Pod
+	err := kubeClient.Get(t.Context(), podKey, &pod)
+	assert.True(t, apierrors.IsNotFound(err), "k8s pod should be deleted")
+}
+
+func TestEventLoop_EvictionUnknownImage(t *testing.T) {
+	kubeClient := fake.NewClientBuilder().Build()
+	pcm, _, _, evictCh := newTestEventLoopPCM(kubeClient)
+
+	go pcm.podCacheManager(t.Context())
+
+	// Send eviction for an image not in the cache
+	doneCh := make(chan struct{})
+	evictCh <- &podEvictionRequest{
+		image:  "unknown-image",
+		podKey: client.ObjectKey{Name: "no-pod", Namespace: defaultNamespace},
+		doneCh: doneCh,
+	}
+
+	select {
+	case <-doneCh:
+		// doneCh closed even for unknown image — no hang
+	case <-time.After(5 * time.Second):
+		t.Fatal("eviction for unknown image should still close doneCh")
+	}
+}
+
+func TestEventLoop_EvictionPodKeyNotFound(t *testing.T) {
+	// Pod in cache has a different key than the eviction request
+	podKey := client.ObjectKey{Name: "real-pod", Namespace: defaultNamespace}
+	serviceKey := client.ObjectKey{Name: "real-svc", Namespace: defaultNamespace}
+	serviceUrl := serviceKey.Name + "." + serviceKey.Namespace + serviceDnsNameSuffix
+	address := net.JoinHostPort(serviceUrl, defaultWrapperServerPort)
+	conn, _ := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	k8sPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "real-pod", Namespace: defaultNamespace},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	k8sSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "real-svc", Namespace: defaultNamespace},
+	}
+
+	kubeClient := fake.NewClientBuilder().WithObjects(k8sPod, k8sSvc).Build()
+	pcm, _, _, evictCh := newTestEventLoopPCM(kubeClient)
+
+	readyPod := makeReadyPodInfo("test-image", podKey, serviceKey, conn, 0)
+	pcm.functions["test-image"] = &functionInfo{
+		pods: []functionPodInfo{readyPod},
+	}
+
+	go pcm.podCacheManager(t.Context())
+
+	// Send eviction with a non-matching podKey → falls back to removeUnhealthyPods
+	doneCh := make(chan struct{})
+	evictCh <- &podEvictionRequest{
+		image:  "test-image",
+		podKey: client.ObjectKey{Name: "wrong-pod", Namespace: defaultNamespace},
+		doneCh: doneCh,
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("eviction with non-matching podKey should still close doneCh")
+	}
+
+	// Pod should still be in cache (it's healthy, removeUnhealthyPods won't remove it)
+	fn := pcm.functions["test-image"]
+	assert.Len(t, fn.pods, 1, "healthy pod should remain in cache when podKey doesn't match")
 }

--- a/func/internal/podcachemanager_eventloop_test.go
+++ b/func/internal/podcachemanager_eventloop_test.go
@@ -364,11 +364,20 @@ func TestEventLoop_EvictionRemovesPodByKey(t *testing.T) {
 	fn := pcm.functions["test-image"]
 	assert.Empty(t, fn.pods, "evicted pod should be removed from cache")
 
-	// Verify k8s pod was deleted
-	time.Sleep(200 * time.Millisecond) // background delete
-	var pod corev1.Pod
-	err := kubeClient.Get(t.Context(), podKey, &pod)
-	assert.True(t, apierrors.IsNotFound(err), "k8s pod should be deleted")
+	// Verify k8s pod was deleted (background delete)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var pod corev1.Pod
+		err := kubeClient.Get(t.Context(), podKey, &pod)
+		if apierrors.IsNotFound(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			assert.True(t, apierrors.IsNotFound(err), "k8s pod should be deleted")
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func TestEventLoop_EvictionUnknownImage(t *testing.T) {

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -259,6 +259,9 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 					// Wait for the cache manager to confirm eviction before retrying,
 					// preventing re-allocation of the same dead pod.
 					doneCh := make(chan struct{})
+					if pod.podKey == nil {
+						return nil, fmt.Errorf("unable to evict dead pod for %v: missing pod key", req.Image)
+					}
 					evictReq := &podEvictionRequest{image: pod.image, podKey: *pod.podKey, doneCh: doneCh}
 					select {
 					case pe.evictionCh <- evictReq:

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -246,7 +246,12 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 					// Wait for the cache manager to confirm eviction before retrying,
 					// preventing re-allocation of the same dead pod.
 					doneCh := make(chan struct{})
-					pe.evictionCh <- &podEvictionRequest{image: pod.image, podKey: *pod.podKey, doneCh: doneCh}
+					evictReq := &podEvictionRequest{image: pod.image, podKey: *pod.podKey, doneCh: doneCh}
+					select {
+					case pe.evictionCh <- evictReq:
+					case <-ctx.Done():
+						return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
+					}
 					select {
 					case <-doneCh:
 					case <-ctx.Done():

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -216,7 +216,12 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 				return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: nil pod response", req.Image)
 			}
 
-			defer pod.concurrentEvaluations.Add(-1)
+			decremented := false
+			defer func() {
+				if !decremented {
+					pod.concurrentEvaluations.Add(-1)
+				}
+			}()
 
 			// First attempt: fail fast if pod is dead (no WaitForReady).
 			// Retries: use WaitForReady since eviction triggered a new pod that may still be starting.
@@ -233,6 +238,10 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 				// function errors that should not be retried.
 				if status.Code(err) == codes.Unavailable && ctx.Err() == nil {
 					lastErr = err
+					// Decrement immediately so the evicted pod's counter reflects reality
+					// while we wait for the next attempt.
+					pod.concurrentEvaluations.Add(-1)
+					decremented = true
 					pe.evictionCh <- &podEvictionRequest{image: req.Image, podKey: *pod.podKey}
 					continue
 				}

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -224,7 +224,8 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 			}()
 
 			// First attempt: fail fast if pod is dead (no WaitForReady).
-			// Retries: use WaitForReady since eviction triggered a new pod that may still be starting.
+			// Retries: use WaitForReady since eviction cleaned stale pods and
+			// the retry may get a newly-created pod that is still starting.
 			var callOpts []grpc.CallOption
 			if attempt > 0 {
 				callOpts = append(callOpts, grpc.WaitForReady(true))
@@ -242,7 +243,15 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 					// while we wait for the next attempt.
 					pod.concurrentEvaluations.Add(-1)
 					decremented = true
-					pe.evictionCh <- &podEvictionRequest{image: pod.image, podKey: *pod.podKey}
+					// Wait for the cache manager to confirm eviction before retrying,
+					// preventing re-allocation of the same dead pod.
+					doneCh := make(chan struct{})
+					pe.evictionCh <- &podEvictionRequest{image: pod.image, podKey: *pod.podKey, doneCh: doneCh}
+					select {
+					case <-doneCh:
+					case <-ctx.Done():
+						return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
+					}
 					continue
 				}
 				klog.V(4).Infof("Resource List: %s", req.ResourceList)

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -26,6 +26,8 @@ import (
 	"github.com/kptdev/porch/func/evaluator"
 	"github.com/kptdev/porch/pkg/util"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,7 +49,8 @@ const (
 )
 
 type podEvaluator struct {
-	requestCh chan<- *connectionRequest
+	requestCh  chan<- *connectionRequest
+	evictionCh chan<- *podEvictionRequest
 
 	podCacheManager *podCacheManager
 }
@@ -106,7 +109,7 @@ type podReadyResponse struct {
 func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Client, functionConfigStore *fnconf.FunctionConfigStore) (Evaluator, error) {
 	maxWaitlist := o.MaxWaitlistLength
 	if maxWaitlist <= 0 {
-		maxWaitlist = 2
+		maxWaitlist = 1
 	}
 	maxPods := o.MaxParallelPodsPerFunction
 	if maxPods <= 0 {
@@ -122,14 +125,17 @@ func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Clien
 
 	reqCh := make(chan *connectionRequest, channelBufferSize)
 	readyCh := make(chan *podReadyResponse, channelBufferSize)
+	evictCh := make(chan *podEvictionRequest, channelBufferSize)
 
 	pe := &podEvaluator{
-		requestCh: reqCh,
+		requestCh:  reqCh,
+		evictionCh: evictCh,
 		podCacheManager: &podCacheManager{
 			gcScanInterval:             o.GcScanInterval,
 			podTTL:                     o.PodTTL,
 			connectionRequestCh:        reqCh,
 			podReadyCh:                 readyCh,
+			evictionCh:                 evictCh,
 			functions:                  map[string]*functionInfo{},
 			maxWaitlistLength:          maxWaitlist,
 			maxParallelPodsPerFunction: maxPods,
@@ -187,34 +193,66 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 	}
 	req.Image = image
 
-	// make a buffer for the channel to prevent unnecessary blocking when the pod cache manager sends it to multiple waiting goroutine in batch.
-	responseChannel := make(chan *connectionResponse, 1)
-	// Send a request to request a grpc client.
-	pe.requestCh <- &connectionRequest{
-		image:      req.Image,
-		responseCh: responseChannel,
+	const maxRetries = 2
+	retryBackoff := []time.Duration{5 * time.Second, 10 * time.Second}
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			klog.Warningf("Retrying function evaluation for %v (attempt %d/%d) after Unavailable error, backing off %v", req.Image, attempt+1, maxRetries+1, retryBackoff[attempt-1])
+			select {
+			case <-time.After(retryBackoff[attempt-1]):
+			case <-ctx.Done():
+				return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
+			}
+		}
+
+		responseChannel := make(chan *connectionResponse, 1)
+		pe.requestCh <- &connectionRequest{
+			image:      req.Image,
+			responseCh: responseChannel,
+		}
+
+		select {
+		case pod := <-responseChannel:
+			if pod == nil || pod.grpcConnection == nil || pod.err != nil {
+				if pod != nil {
+					return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
+				}
+				return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: nil pod response", req.Image)
+			}
+
+			defer pod.concurrentEvaluations.Add(-1)
+
+			// First attempt: fail fast if pod is dead (no WaitForReady).
+			// Retries: use WaitForReady since eviction triggered a new pod that may still be starting.
+			var callOpts []grpc.CallOption
+			if attempt > 0 {
+				callOpts = append(callOpts, grpc.WaitForReady(true))
+			}
+			resp, err := evaluator.NewFunctionEvaluatorClient(pod.grpcConnection).EvaluateFunction(ctx, req, callOpts...)
+			if err != nil {
+				// Retry only on Unavailable — indicates the pod is dead/unreachable:
+				// connection refused (pod deleted), connection reset (pod crashed),
+				// DNS failure (service deleted), TCP timeout (pod IP unreachable).
+				// Other codes (Internal, InvalidArgument, DeadlineExceeded) are real
+				// function errors that should not be retried.
+				if status.Code(err) == codes.Unavailable && ctx.Err() == nil {
+					lastErr = err
+					pe.evictionCh <- &podEvictionRequest{image: req.Image, podKey: *pod.podKey}
+					continue
+				}
+				klog.V(4).Infof("Resource List: %s", req.ResourceList)
+				return nil, fmt.Errorf("unable to evaluate %v with pod evaluator: %w", req.Image, err)
+			}
+			if len(resp.Log) > 0 {
+				klog.Warningf("evaluating %q succeeded, but stderr is: %v", req.Image, string(resp.Log))
+			}
+			return resp, nil
+		case <-ctx.Done():
+			return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
+		}
 	}
 
-	// Waiting for the client from the channel. This step is blocking.
-	select {
-	case pod := <-responseChannel:
-		if pod == nil || pod.grpcConnection == nil || pod.err != nil {
-			return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
-		}
-
-		defer pod.concurrentEvaluations.Add(-1)
-
-		resp, err := evaluator.NewFunctionEvaluatorClient(pod.grpcConnection).EvaluateFunction(ctx, req)
-		if err != nil {
-			klog.V(4).Infof("Resource List: %s", req.ResourceList)
-			return nil, fmt.Errorf("unable to evaluate %q with pod evaluator: %w", req.Image, err)
-		}
-		// Log stderr when the function succeeded. If the function fails, stderr will be surfaced to the users.
-		if len(resp.Log) > 0 {
-			klog.Warningf("evaluating %q succeeded, but stderr is: %v", req.Image, string(resp.Log))
-		}
-		return resp, nil
-	case <-ctx.Done():
-		return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
-	}
+	return nil, fmt.Errorf("unable to evaluate %v with pod evaluator after retries: %w", req.Image, lastErr)
 }

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -209,11 +209,14 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 
 		select {
 		case pod := <-responseChannel:
-			if pod == nil || pod.grpcConnection == nil || pod.err != nil {
-				if pod != nil {
-					return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
-				}
+			if pod == nil {
 				return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: nil pod response", req.Image)
+			}
+			if pod.err != nil {
+				return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, pod.err)
+			}
+			if pod.grpcConnection == nil {
+				return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: missing grpc connection", req.Image)
 			}
 
 			decremented := false

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -109,7 +109,7 @@ type podReadyResponse struct {
 func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Client, functionConfigStore *fnconf.FunctionConfigStore) (Evaluator, error) {
 	maxWaitlist := o.MaxWaitlistLength
 	if maxWaitlist <= 0 {
-		maxWaitlist = 1
+		maxWaitlist = 2
 	}
 	maxPods := o.MaxParallelPodsPerFunction
 	if maxPods <= 0 {

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -194,17 +194,11 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 	req.Image = image
 
 	const maxRetries = 2
-	retryBackoff := []time.Duration{5 * time.Second, 10 * time.Second}
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			klog.Warningf("Retrying function evaluation for %v (attempt %d/%d) after Unavailable error, backing off %v", req.Image, attempt+1, maxRetries+1, retryBackoff[attempt-1])
-			select {
-			case <-time.After(retryBackoff[attempt-1]):
-			case <-ctx.Done():
-				return nil, fmt.Errorf("function evaluation timed out for %v: %w", req.Image, ctx.Err())
-			}
+			klog.Warningf("Retrying function evaluation for %v (attempt %d/%d) after Unavailable error", req.Image, attempt+1, maxRetries+1)
 		}
 
 		responseChannel := make(chan *connectionResponse, 1)

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -33,19 +33,22 @@ import (
 )
 
 const (
-	defaultWrapperServerPort  = "9446"
-	volumeName                = "wrapper-server-tools"
-	volumeMountPath           = "/wrapper-server-tools"
-	wrapperServerBin          = "wrapper-server"
-	gRPCProbeBin              = "grpc-health-probe"
-	krmFunctionImageLabel     = "fn.kpt.dev/image"
-	templateVersionAnnotation = "fn.kpt.dev/template-version"
-	fieldManagerName          = "krm-function-runner"
-	functionContainerName     = "function"
-	defaultManagerNamespace   = "porch-system"
-	defaultRegistry           = "ghcr.io/kptdev/krm-functions-catalog/"
-	serviceDnsNameSuffix      = ".svc.cluster.local"
-	channelBufferSize         = 128
+	defaultWrapperServerPort          = "9446"
+	volumeName                        = "wrapper-server-tools"
+	volumeMountPath                   = "/wrapper-server-tools"
+	wrapperServerBin                  = "wrapper-server"
+	gRPCProbeBin                      = "grpc-health-probe"
+	krmFunctionImageLabel             = "fn.kpt.dev/image"
+	templateVersionAnnotation         = "fn.kpt.dev/template-version"
+	fieldManagerName                  = "krm-function-runner"
+	functionContainerName             = "function"
+	defaultManagerNamespace           = "porch-system"
+	defaultRegistry                   = "ghcr.io/kptdev/krm-functions-catalog/"
+	serviceDnsNameSuffix              = ".svc.cluster.local"
+	channelBufferSize                 = 128
+	defaultMaxWaitlistLength          = 2
+	defaultMaxParallelPodsPerFunction = 1
+	defaultMaxGrpcRetries             = 2
 )
 
 type podEvaluator struct {
@@ -111,15 +114,15 @@ type podReadyResponse struct {
 func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Client, functionConfigStore *fnconf.FunctionConfigStore) (Evaluator, error) {
 	maxWaitlist := o.MaxWaitlistLength
 	if maxWaitlist <= 0 {
-		maxWaitlist = 2
+		maxWaitlist = defaultMaxWaitlistLength
 	}
 	maxPods := o.MaxParallelPodsPerFunction
 	if maxPods <= 0 {
-		maxPods = 1
+		maxPods = defaultMaxParallelPodsPerFunction
 	}
 	maxRetries := o.MaxGrpcRetries
 	if maxRetries <= 0 {
-		maxRetries = 2
+		maxRetries = defaultMaxGrpcRetries
 	}
 
 	managerNs, err := util.GetInClusterNamespace()

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -242,7 +242,7 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 					// while we wait for the next attempt.
 					pod.concurrentEvaluations.Add(-1)
 					decremented = true
-					pe.evictionCh <- &podEvictionRequest{image: req.Image, podKey: *pod.podKey}
+					pe.evictionCh <- &podEvictionRequest{image: pod.image, podKey: *pod.podKey}
 					continue
 				}
 				klog.V(4).Infof("Resource List: %s", req.ResourceList)

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -53,6 +53,7 @@ type podEvaluator struct {
 	evictionCh chan<- *podEvictionRequest
 
 	podCacheManager *podCacheManager
+	maxGrpcRetries  int
 }
 
 type PodEvaluatorOptions struct {
@@ -70,6 +71,7 @@ type PodEvaluatorOptions struct {
 	DefaultImagePrefix         string        // Default image prefix to use when no prefix is given for an image
 	MaxWaitlistLength          int           // Maximum waitlist length per pod
 	MaxParallelPodsPerFunction int           // Maximum parallel pods per function
+	MaxGrpcRetries             int           // Maximum number of retries on gRPC Unavailable errors
 }
 
 var _ Evaluator = &podEvaluator{}
@@ -115,6 +117,10 @@ func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Clien
 	if maxPods <= 0 {
 		maxPods = 1
 	}
+	maxRetries := o.MaxGrpcRetries
+	if maxRetries <= 0 {
+		maxRetries = 2
+	}
 
 	managerNs, err := util.GetInClusterNamespace()
 	if err != nil {
@@ -128,8 +134,9 @@ func NewPodEvaluator(ctx context.Context, o PodEvaluatorOptions, cl client.Clien
 	evictCh := make(chan *podEvictionRequest, channelBufferSize)
 
 	pe := &podEvaluator{
-		requestCh:  reqCh,
-		evictionCh: evictCh,
+		requestCh:      reqCh,
+		evictionCh:     evictCh,
+		maxGrpcRetries: maxRetries,
 		podCacheManager: &podCacheManager{
 			gcScanInterval:             o.GcScanInterval,
 			podTTL:                     o.PodTTL,
@@ -193,7 +200,7 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 	}
 	req.Image = image
 
-	const maxRetries = 2
+	maxRetries := pe.maxGrpcRetries
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {

--- a/func/internal/podevaluator_podcachemanager_test.go
+++ b/func/internal/podevaluator_podcachemanager_test.go
@@ -306,7 +306,7 @@ func TestPodCacheManager(t *testing.T) {
 				WithScheme(scheme).
 				WithInterceptorFuncs(interceptor.Funcs{Create: fakeClientCreateFixInterceptor}).
 				Build(),
-			expectedLog: "Removing deleted pod from cache for image apply-replacements",
+			expectedLog: "Queuing request for apply-replacements on pod instance #0",
 		},
 		{
 			name:       "Pod does not Exists but Service Exists and not in Cache",

--- a/func/internal/podevaluator_unit_test.go
+++ b/func/internal/podevaluator_unit_test.go
@@ -296,13 +296,18 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 	healthyCounter := &atomic.Int32{}
 	healthyCounter.Store(1)
 
-	// Serve two requests: first returns dead pod, second returns healthy pod
+	// Serve two requests: first returns dead pod, second returns healthy pod.
+	// Between them, drain the eviction and ack it so the retry proceeds.
+	var capturedEviction *podEvictionRequest
 	go func() {
 		req1 := <-reqCh
 		req1.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: unavailableConn, podKey: &deadPodKey, serviceKey: &deadPodKey},
 			concurrentEvaluations: deadCounter,
 		}
+		eviction := <-evictCh
+		capturedEviction = eviction
+		close(eviction.doneCh)
 		req2 := <-reqCh
 		req2.responseCh <- &connectionResponse{
 			podData:               podData{image: "test-image", grpcConnection: healthyConn, podKey: &healthyPodKey, serviceKey: &healthyPodKey},
@@ -322,11 +327,7 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 	assert.Equal(t, []byte("success"), resp.ResourceList)
 
 	// Verify eviction was sent for the dead pod
-	select {
-	case eviction := <-evictCh:
-		assert.Equal(t, "test-image", eviction.image)
-		assert.Equal(t, deadPodKey, eviction.podKey)
-	default:
-		t.Fatal("expected eviction request but none was sent")
-	}
+	require.NotNil(t, capturedEviction, "expected eviction request but none was sent")
+	assert.Equal(t, "test-image", capturedEviction.image)
+	assert.Equal(t, deadPodKey, capturedEviction.podKey)
 }

--- a/func/internal/podevaluator_unit_test.go
+++ b/func/internal/podevaluator_unit_test.go
@@ -298,7 +298,7 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 
 	// Serve two requests: first returns dead pod, second returns healthy pod.
 	// Between them, drain the eviction and ack it so the retry proceeds.
-	var capturedEviction *podEvictionRequest
+	capturedEvictionCh := make(chan *podEvictionRequest, 1)
 	go func() {
 		req1 := <-reqCh
 		req1.responseCh <- &connectionResponse{
@@ -306,7 +306,7 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 			concurrentEvaluations: deadCounter,
 		}
 		eviction := <-evictCh
-		capturedEviction = eviction
+		capturedEvictionCh <- eviction
 		close(eviction.doneCh)
 		req2 := <-reqCh
 		req2.responseCh <- &connectionResponse{
@@ -325,7 +325,11 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 	// Should succeed on retry
 	require.NoError(t, err)
 	assert.Equal(t, []byte("success"), resp.ResourceList)
-
+	var capturedEviction *podEvictionRequest
+	select {
+	case capturedEviction = <-capturedEvictionCh:
+	case <-ctx.Done():
+	}
 	// Verify eviction was sent for the dead pod
 	require.NotNil(t, capturedEviction, "expected eviction request but none was sent")
 	assert.Equal(t, "test-image", capturedEviction.image)

--- a/func/internal/podevaluator_unit_test.go
+++ b/func/internal/podevaluator_unit_test.go
@@ -282,8 +282,9 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 	evictCh := make(chan *podEvictionRequest, 1)
 
 	pe := &podEvaluator{
-		requestCh:  reqCh,
-		evictionCh: evictCh,
+		requestCh:      reqCh,
+		evictionCh:     evictCh,
+		maxGrpcRetries: 2,
 		podCacheManager: &podCacheManager{
 			podManager: &podManager{
 				tagResolver: runtime.TagResolver{},
@@ -334,4 +335,73 @@ func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
 	require.NotNil(t, capturedEviction, "expected eviction request but none was sent")
 	assert.Equal(t, "test-image", capturedEviction.image)
 	assert.Equal(t, deadPodKey, capturedEviction.podKey)
+}
+
+func TestEvaluateFunction_ExhaustsRetries(t *testing.T) {
+	// With maxGrpcRetries=1, the function should fail after 2 attempts (initial + 1 retry)
+	// when all pods return Unavailable.
+
+	// Server that always returns Unavailable
+	unavailableAddr, unavailableCleanup := startFakeEvalServer(t, func(_ context.Context, _ *pb.EvaluateFunctionRequest) (*pb.EvaluateFunctionResponse, error) {
+		return nil, status.Error(codes.Unavailable, "connection refused")
+	})
+	defer unavailableCleanup()
+
+	unavailableConn, err := grpc.NewClient(unavailableAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer unavailableConn.Close()
+
+	deadPodKey1 := client.ObjectKey{Namespace: "fn-ns", Name: "dead-pod-1"}
+	deadPodKey2 := client.ObjectKey{Namespace: "fn-ns", Name: "dead-pod-2"}
+
+	reqCh := make(chan *connectionRequest, 2)
+	evictCh := make(chan *podEvictionRequest, 2)
+
+	pe := &podEvaluator{
+		requestCh:      reqCh,
+		evictionCh:     evictCh,
+		maxGrpcRetries: 1, // only 1 retry allowed
+		podCacheManager: &podCacheManager{
+			podManager: &podManager{
+				tagResolver: runtime.TagResolver{},
+			},
+		},
+	}
+
+	counter1 := &atomic.Int32{}
+	counter1.Store(1)
+	counter2 := &atomic.Int32{}
+	counter2.Store(1)
+
+	// Serve exactly 2 requests (initial + 1 retry), both return dead pods.
+	// Drain evictions and ack them.
+	go func() {
+		req1 := <-reqCh
+		req1.responseCh <- &connectionResponse{
+			podData:               podData{image: "test-image", grpcConnection: unavailableConn, podKey: &deadPodKey1, serviceKey: &deadPodKey1},
+			concurrentEvaluations: counter1,
+		}
+		eviction1 := <-evictCh
+		close(eviction1.doneCh)
+
+		req2 := <-reqCh
+		req2.responseCh <- &connectionResponse{
+			podData:               podData{image: "test-image", grpcConnection: unavailableConn, podKey: &deadPodKey2, serviceKey: &deadPodKey2},
+			concurrentEvaluations: counter2,
+		}
+		eviction2 := <-evictCh
+		close(eviction2.doneCh)
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	resp, err := pe.EvaluateFunction(ctx, &pb.EvaluateFunctionRequest{
+		Image: "test-image",
+	})
+
+	// Should fail after exhausting retries
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "after retries")
 }

--- a/func/internal/podevaluator_unit_test.go
+++ b/func/internal/podevaluator_unit_test.go
@@ -20,13 +20,17 @@ import (
 	"net"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kptdev/kpt/pkg/fn/runtime"
 	pb "github.com/kptdev/porch/func/evaluator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // startFakeEvalServer starts a gRPC function evaluator server on a dynamic port.
@@ -248,4 +252,81 @@ func TestEvaluateFunction_CounterDecrement(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), counter.Load(), "concurrentEvaluations should be decremented back to 0")
+}
+
+func TestEvaluateFunction_Unavailable_EvictsAndRetries(t *testing.T) {
+	// First server returns Unavailable (simulates dead pod)
+	unavailableAddr, unavailableCleanup := startFakeEvalServer(t, func(_ context.Context, _ *pb.EvaluateFunctionRequest) (*pb.EvaluateFunctionResponse, error) {
+		return nil, status.Error(codes.Unavailable, "connection refused")
+	})
+	defer unavailableCleanup()
+
+	unavailableConn, err := grpc.NewClient(unavailableAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer unavailableConn.Close()
+
+	// Second server returns success (healthy pod)
+	healthyAddr, healthyCleanup := startFakeEvalServer(t, func(_ context.Context, _ *pb.EvaluateFunctionRequest) (*pb.EvaluateFunctionResponse, error) {
+		return &pb.EvaluateFunctionResponse{ResourceList: []byte("success")}, nil
+	})
+	defer healthyCleanup()
+
+	healthyConn, err := grpc.NewClient(healthyAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer healthyConn.Close()
+
+	deadPodKey := client.ObjectKey{Namespace: "fn-ns", Name: "dead-pod"}
+	healthyPodKey := client.ObjectKey{Namespace: "fn-ns", Name: "healthy-pod"}
+
+	reqCh := make(chan *connectionRequest, 2)
+	evictCh := make(chan *podEvictionRequest, 1)
+
+	pe := &podEvaluator{
+		requestCh:  reqCh,
+		evictionCh: evictCh,
+		podCacheManager: &podCacheManager{
+			podManager: &podManager{
+				tagResolver: runtime.TagResolver{},
+			},
+		},
+	}
+
+	deadCounter := &atomic.Int32{}
+	deadCounter.Store(1)
+	healthyCounter := &atomic.Int32{}
+	healthyCounter.Store(1)
+
+	// Serve two requests: first returns dead pod, second returns healthy pod
+	go func() {
+		req1 := <-reqCh
+		req1.responseCh <- &connectionResponse{
+			podData:               podData{image: "test-image", grpcConnection: unavailableConn, podKey: &deadPodKey, serviceKey: &deadPodKey},
+			concurrentEvaluations: deadCounter,
+		}
+		req2 := <-reqCh
+		req2.responseCh <- &connectionResponse{
+			podData:               podData{image: "test-image", grpcConnection: healthyConn, podKey: &healthyPodKey, serviceKey: &healthyPodKey},
+			concurrentEvaluations: healthyCounter,
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	resp, err := pe.EvaluateFunction(ctx, &pb.EvaluateFunctionRequest{
+		Image: "test-image",
+	})
+
+	// Should succeed on retry
+	require.NoError(t, err)
+	assert.Equal(t, []byte("success"), resp.ResourceList)
+
+	// Verify eviction was sent for the dead pod
+	select {
+	case eviction := <-evictCh:
+		assert.Equal(t, "test-image", eviction.image)
+		assert.Equal(t, deadPodKey, eviction.podKey)
+	default:
+		t.Fatal("expected eviction request but none was sent")
+	}
 }

--- a/func/internal/podmanager.go
+++ b/func/internal/podmanager.go
@@ -247,7 +247,6 @@ func (pm *podManager) createPodData(ctx context.Context, serviceKey client.Objec
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(pm.maxGrpcMessageSize),
 			grpc.MaxCallSendMsgSize(pm.maxGrpcMessageSize),
-			grpc.WaitForReady(true),
 		),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	)

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -92,6 +92,7 @@ func main() {
 	flag.IntVar(&o.pod.MaxGrpcMessageSize, "max-request-body-size", 6*1024*1024, "Maximum size of grpc messages in bytes. Keep this in sync with porch-server's corresponding argument.")
 	flag.IntVar(&o.pod.MaxWaitlistLength, "max-waitlist-length", 2, "Maximum waitlist length per pod")
 	flag.IntVar(&o.pod.MaxParallelPodsPerFunction, "max-parallel-pods-per-function", 1, "Maximum parallel pods per function")
+	flag.IntVar(&o.pod.MaxGrpcRetries, "max-grpc-retries", 2, "Maximum number of retries on gRPC Unavailable errors")
 
 	flag.Parse()
 

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -83,7 +83,7 @@ func main() {
 	flag.BoolVar(&o.pod.WarmUpPodCacheOnStartup, "warm-up-pod-cache", true, "if true, pod-cache-config image pods will be deployed at startup")
 	flag.StringVar(&o.pod.PodNamespace, "pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
 	flag.DurationVar(&o.pod.PodTTL, "pod-ttl", 30*time.Minute, "TTL for pods before GC.")
-	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", 20*time.Second, "The interval of GC between scans.")
+	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", time.Minute, "The interval of GC between scans.")
 	flag.BoolVar(&o.pod.EnablePrivateRegistries, "enable-private-registries", false, "if true enables the use of private registries and their authentication")
 	flag.StringVar(&o.pod.RegistryAuthSecretPath, "registry-auth-secret-path", "/var/tmp/config-secret/.dockerconfigjson", "The path of the secret used for authenticating to custom registries")
 	flag.StringVar(&o.pod.RegistryAuthSecretName, "registry-auth-secret-name", "auth-secret", "The name of the secret used for authenticating to custom registries")

--- a/func/server/server.go
+++ b/func/server/server.go
@@ -83,7 +83,7 @@ func main() {
 	flag.BoolVar(&o.pod.WarmUpPodCacheOnStartup, "warm-up-pod-cache", true, "if true, pod-cache-config image pods will be deployed at startup")
 	flag.StringVar(&o.pod.PodNamespace, "pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
 	flag.DurationVar(&o.pod.PodTTL, "pod-ttl", 30*time.Minute, "TTL for pods before GC.")
-	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", time.Minute, "The interval of GC between scans.")
+	flag.DurationVar(&o.pod.GcScanInterval, "scan-interval", 20*time.Second, "The interval of GC between scans.")
 	flag.BoolVar(&o.pod.EnablePrivateRegistries, "enable-private-registries", false, "if true enables the use of private registries and their authentication")
 	flag.StringVar(&o.pod.RegistryAuthSecretPath, "registry-auth-secret-path", "/var/tmp/config-secret/.dockerconfigjson", "The path of the secret used for authenticating to custom registries")
 	flag.StringVar(&o.pod.RegistryAuthSecretName, "registry-auth-secret-name", "auth-secret", "The name of the secret used for authenticating to custom registries")

--- a/test/e2e/api/fn_runner_test.go
+++ b/test/e2e/api/fn_runner_test.go
@@ -347,15 +347,23 @@ func (t *PorchSuite) TestPodEvaluatorParallelExecution() {
 	}
 
 	const (
-		repoName               = "git-fn-parallel-sleep"
-		parallelRequestCount   = 4
-		maxWaitList            = 2 // this should be kept in sync with the max-wait-list argument of the function-runner
-		expectedPodCount       = (parallelRequestCount + maxWaitList - 1) / maxWaitList
-		sleepDuration          = 3 * time.Second
-		singleFunctionTime     = sleepDuration
-		expectedSequentialTime = parallelRequestCount * sleepDuration * 5 / 2 // add some buffer to account for overhead and slow ci
-		pollTimeout            = expectedSequentialTime * 5 / 4               // +0.25 headroom
+		repoName             = "git-fn-parallel-sleep"
+		parallelRequestCount = 4
+		sleepDuration        = 3 * time.Second
+		singleFunctionTime   = sleepDuration
+
+		// Defaults from func/server/server.go flag definitions
+		defaultMaxWaitlistLength          = 2
+		defaultMaxParallelPodsPerFunction = 1
 	)
+
+	// Read the actual function-runner args to determine scaling parameters
+	maxWaitList, maxParallelPods := t.getFunctionRunnerScalingParams(defaultMaxWaitlistLength, defaultMaxParallelPodsPerFunction)
+	expectedPodCount := min((parallelRequestCount+maxWaitList-1)/maxWaitList, maxParallelPods)
+	expectedSequentialTime := parallelRequestCount * sleepDuration * 5 / 2 // add some buffer to account for overhead and slow ci
+	pollTimeout := expectedSequentialTime * 5 / 4                          // +0.25 headroom
+
+	t.Logf("Function-runner scaling params: maxWaitList=%d, maxParallelPods=%d, expectedPodCount=%d", maxWaitList, maxParallelPods, expectedPodCount)
 
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repoName, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
@@ -384,7 +392,7 @@ func (t *PorchSuite) TestPodEvaluatorParallelExecution() {
 		}(i)
 	}
 
-	t.Logf("Waiting to observe %d parallel sleep function evaluator pods: %s", parallelRequestCount, t.KrmFunctionsRegistry+"/"+sleepImage)
+	t.Logf("Waiting to observe %d parallel sleep function evaluator pods: %s", expectedPodCount, t.KrmFunctionsRegistry+"/"+sleepImage)
 	err := wait.PollUntilContextTimeout(t.GetContext(), 1*time.Second, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		select {
 		case err := <-errChan:
@@ -432,6 +440,43 @@ func (t *PorchSuite) TestPodEvaluatorParallelExecution() {
 	assert.Greater(t, totalDuration, singleFunctionTime, "Total duration was too fast, suggesting the sleep function did not wait long enough.")
 
 	t.Log("All parallel evaluations completed, and duration check passed.")
+}
+
+// getFunctionRunnerScalingParams reads the deployed function-runner container args
+// and returns the max-waitlist-length and max-parallel-pods-per-function values.
+// Falls back to the provided defaults if the args are not found.
+func (t *PorchSuite) getFunctionRunnerScalingParams(defaultMaxWaitlist, defaultMaxParallelPods int) (int, int) {
+	porchSvcKey := t.PorchServerServiceKey()
+	container := t.FindFirstContainerByImageName(porchSvcKey.Namespace, "porch-function-runner", "porch-fnrunner")
+	if container == nil {
+		t.Logf("Could not find function-runner container, using defaults: maxWaitlist=%d, maxParallelPods=%d", defaultMaxWaitlist, defaultMaxParallelPods)
+		return defaultMaxWaitlist, defaultMaxParallelPods
+	}
+
+	maxWaitlist := defaultMaxWaitlist
+	maxParallelPods := defaultMaxParallelPods
+
+	allArgs := append(container.Command, container.Args...)
+	for _, arg := range allArgs {
+		if strings.Contains(arg, "max-waitlist-length") {
+			parts := strings.Split(arg, "=")
+			if len(parts) == 2 {
+				if v, err := strconv.Atoi(parts[1]); err == nil {
+					maxWaitlist = v
+				}
+			}
+		}
+		if strings.Contains(arg, "max-parallel-pods-per-function") {
+			parts := strings.Split(arg, "=")
+			if len(parts) == 2 {
+				if v, err := strconv.Atoi(parts[1]); err == nil {
+					maxParallelPods = v
+				}
+			}
+		}
+	}
+
+	return maxWaitlist, maxParallelPods
 }
 
 func (t *PorchSuite) skipIfLocalPodEvaluator() {

--- a/test/e2e/api/fn_runner_test.go
+++ b/test/e2e/api/fn_runner_test.go
@@ -476,6 +476,14 @@ func (t *PorchSuite) getFunctionRunnerScalingParams(defaultMaxWaitlist, defaultM
 		}
 	}
 
+	// Clamp to same semantics as NewPodEvaluator (<=0 means use default)
+	if maxWaitlist <= 0 {
+		maxWaitlist = defaultMaxWaitlist
+	}
+	if maxParallelPods <= 0 {
+		maxParallelPods = defaultMaxParallelPods
+	}
+
 	return maxWaitlist, maxParallelPods
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Evict pod based on GRPC response instead of force check on every call

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Removed removeUnhealthyPods from the pod cache manager event loop request path. Added an eviction channel so dead pods are removed from cache reactively when grpc  calls fail with status.Code(err) == codes.Unavailable. 
EvaluateFunction now loops — evicting dead pods and with a configurable retry mechanism.

- Why it’s needed:  removeUnhealthyPods made 3 Kubernetes API calls per cached pod on every incoming request, blocking the single-goroutine event loop for ~700ms with 11 pods. This serialized all function evaluations and caused increased latency per render.

- How it works:  The event loop dispatches instantly (no health checks). When grpc  reports with status.Code(err) == codes.Unavailable, the caller sends a podEvictionRequest to the event loop which removes that pod from cache and clears it from the cluster, then requests a new pod and retries. Real function errors return immediately. The periodic GC still catches any remaining stale pods.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
Microsoft Copilot to analyse the code.
Kiro to generate eviction channel code.
