### PR TITLE
Cherrypick: Make subpackage name unique in independent subpackage Kptfiles

### DIFF
--- a/api/porch/v1alpha1/util.go
+++ b/api/porch/v1alpha1/util.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// Valid relative paths should not start with '/', should not contain '..' components,
-// and should only contain valid path characters
+// validRelativePathRegex validates the basic shape of a relative path (slash-separated segments made of allowed characters).
+// Additional constraints (e.g. no leading/trailing '/', no '.', and DNS1123-compliant name composition) are enforced in IsValidSubpackageDir.
 var validRelativePathRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)*)?$`)
 
 func (pr *PackageRevision) IsPublished() bool {

--- a/api/porch/v1alpha1/util.go
+++ b/api/porch/v1alpha1/util.go
@@ -124,13 +124,6 @@ func IsValidSubpackageDir(subpackageDir string) error {
 		return pkgerrors.Errorf("subpackage directory %q is invalid, it cannot contain '.' or start with '/' or end with '/'", subpackageDir)
 	}
 
-	// Reject any path segment equal to "." (for example ".", "./subpkg", or "subpkg/./nested").
-	for _, segment := range strings.Split(subpackageDir, "/") {
-		if segment == "." {
-			return pkgerrors.Errorf("subpackage directory %q is invalid, it cannot contain '.'", subpackageDir)
-		}
-	}
-
 	if !validRelativePathRegex.MatchString(subpackageDir) {
 		return pkgerrors.Errorf("subpackage directory %q is invalid, it must match regular expression %q", subpackageDir, validRelativePathRegex.String())
 	}

--- a/api/porch/v1alpha1/util.go
+++ b/api/porch/v1alpha1/util.go
@@ -19,14 +19,14 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	pkgerrors "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // Valid relative paths should not start with '/', should not contain '..' components,
 // and should only contain valid path characters
 var validRelativePathRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)*)?$`)
-
-// Check that there are no '..' components in a path
-var noDoubleDots = regexp.MustCompile(`(^|/)\.\.(/|$)`)
 
 func (pr *PackageRevision) IsPublished() bool {
 	return LifecycleIsPublished(pr.Spec.Lifecycle)
@@ -105,10 +105,56 @@ func GetSubpackageDir(pkgRev *PackageRevision) (string, error) {
 	}
 
 	subpackageDir := getSubpackageDir(pkgRev.Spec.Tasks[1])
-	if IsValidSubpackageDir(subpackageDir) {
+	if err := IsValidSubpackageDir(subpackageDir); err == nil {
 		return subpackageDir, nil
 	} else {
-		return "", fmt.Errorf("subpackage directory %q is invalid", subpackageDir)
+		return "", err
+	}
+}
+
+// IsValidSubpackageDir returns an error if subpackageDir is invalid.
+func IsValidSubpackageDir(subpackageDir string) error {
+	// Empty string is invalid, a subpackage directory must be a relative path.
+	if subpackageDir == "" {
+		return pkgerrors.Errorf("subpackage directory %q is invalid", subpackageDir)
+	}
+
+	// Check basic format and ensure it doesn't start with '/', doesn't end with '/', and doesn't contain '.'
+	if subpackageDir[0] == '/' || strings.HasSuffix(subpackageDir, "/") || strings.Contains(subpackageDir, ".") {
+		return pkgerrors.Errorf("subpackage directory %q is invalid, it cannot contain '.' or start with '/' or end with '/'", subpackageDir)
+	}
+
+	// Reject any path segment equal to "." (for example ".", "./subpkg", or "subpkg/./nested").
+	for _, segment := range strings.Split(subpackageDir, "/") {
+		if segment == "." {
+			return pkgerrors.Errorf("subpackage directory %q is invalid, it cannot contain '.'", subpackageDir)
+		}
+	}
+
+	if !validRelativePathRegex.MatchString(subpackageDir) {
+		return pkgerrors.Errorf("subpackage directory %q is invalid, it must match regular expression %q", subpackageDir, validRelativePathRegex.String())
+	}
+
+	if _, err := ComposeSubpkgObjName(subpackageDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ComposeSubpkgObjName(subpackageDir string) (string, error) {
+	if subpackageDir == "" {
+		return "", pkgerrors.Errorf("subpackage directory %q is invalid", subpackageDir)
+	}
+
+	subpackageName := strings.ReplaceAll(subpackageDir, "/", ".")
+
+	objNameErrs := validation.IsDNS1123Subdomain(subpackageName)
+
+	if len(objNameErrs) == 0 {
+		return subpackageName, nil
+	} else {
+		return "", pkgerrors.Errorf("subpackage resource name %q invalid: %s", subpackageName, strings.Join(objNameErrs, ","))
 	}
 }
 
@@ -128,28 +174,6 @@ func getSubpackageDir(task Task) string {
 	default:
 		return ""
 	}
-}
-
-// IsValidSubpackageDir returns true if subpackageDir is valid, false otherwise.
-func IsValidSubpackageDir(subpackageDir string) bool {
-	// Empty string is invalid, a subpackage directory must be a relative path.
-	if subpackageDir == "" {
-		return false
-	}
-
-	// Check basic format and ensure it doesn't contain '..' or start with '/' or end with '/'
-	if subpackageDir[0] == '/' || strings.HasSuffix(subpackageDir, "/") || noDoubleDots.MatchString(subpackageDir) {
-		return false
-	}
-
-	// Reject any path segment equal to "." (for example ".", "./subpkg", or "subpkg/./nested").
-	for _, segment := range strings.Split(subpackageDir, "/") {
-		if segment == "." {
-			return false
-		}
-	}
-
-	return validRelativePathRegex.MatchString(subpackageDir)
 }
 
 func (pr *PackageRevision) IsPushOnRenderFailure() bool {

--- a/api/porch/v1alpha1/util_test.go
+++ b/api/porch/v1alpha1/util_test.go
@@ -23,45 +23,52 @@ import (
 
 func TestIsValidSubpackageDir(t *testing.T) {
 	tests := []struct {
-		name     string
-		dir      string
-		expected bool
+		name        string
+		dir         string
+		expectValid bool
 	}{
 		// Invalid cases
-		{name: "empty string", dir: "", expected: false},
-		{name: "leading slash", dir: "/subpkg", expected: false},
-		{name: "trailing slash", dir: "subpkg/", expected: false},
-		{name: "double dots at start", dir: "../subpkg", expected: false},
-		{name: "double dots in middle", dir: "sub/../pkg", expected: false},
-		{name: "double dots at end", dir: "subpkg/..", expected: false},
-		{name: "only double dots", dir: "..", expected: false},
-		{name: "dot segment at start", dir: "./subpkg", expected: false},
-		{name: "dot segment in middle", dir: "sub/./pkg", expected: false},
-		{name: "only dot", dir: ".", expected: false},
-		{name: "leading and trailing slash", dir: "/subpkg/", expected: false},
-		{name: "spaces in path", dir: "sub pkg", expected: false},
-		{name: "special characters", dir: "sub@pkg", expected: false},
-		{name: "backslash", dir: "sub\\pkg", expected: false},
-		{name: "colon in path", dir: "sub:pkg", expected: false},
-		{name: "empty segment (double slash)", dir: "sub//pkg", expected: false},
+		{name: "empty string", dir: "", expectValid: false},
+		{name: "leading slash", dir: "/subpkg", expectValid: false},
+		{name: "trailing slash", dir: "subpkg/", expectValid: false},
+		{name: "double dots at start", dir: "../subpkg", expectValid: false},
+		{name: "double dots in middle", dir: "sub/../pkg", expectValid: false},
+		{name: "double dots at end", dir: "subpkg/..", expectValid: false},
+		{name: "only double dots", dir: "..", expectValid: false},
+		{name: "dot segment at start", dir: "./subpkg", expectValid: false},
+		{name: "dot segment in middle", dir: "sub/./pkg", expectValid: false},
+		{name: "only dot", dir: ".", expectValid: false},
+		{name: "leading and trailing slash", dir: "/subpkg/", expectValid: false},
+		{name: "spaces in path", dir: "sub pkg", expectValid: false},
+		{name: "special characters", dir: "sub@pkg", expectValid: false},
+		{name: "backslash", dir: "sub\\pkg", expectValid: false},
+		{name: "colon in path", dir: "sub:pkg", expectValid: false},
+		{name: "empty segment (double slash)", dir: "sub//pkg", expectValid: false},
+		{name: "with underscores (invalid DNS)", dir: "my_subpkg", expectValid: false},
+		{name: "mixed with underscores (invalid DNS)", dir: "my-sub_pkg.v1/nested-dir", expectValid: false},
+		{name: "with dots in name", dir: "my.subpkg", expectValid: false},
 
 		// Valid cases
-		{name: "simple directory", dir: "subpkg", expected: true},
-		{name: "nested directory", dir: "path/to/subpkg", expected: true},
-		{name: "two levels", dir: "sub/pkg", expected: true},
-		{name: "with hyphens", dir: "my-subpkg", expected: true},
-		{name: "with underscores", dir: "my_subpkg", expected: true},
-		{name: "with dots in name", dir: "my.subpkg", expected: true},
-		{name: "numeric name", dir: "123", expected: true},
-		{name: "mixed valid chars", dir: "my-sub_pkg.v1/nested-dir", expected: true},
-		{name: "deeply nested", dir: "a/b/c/d/e", expected: true},
-		{name: "single char segments", dir: "a/b/c", expected: true},
+		{name: "simple directory", dir: "subpkg", expectValid: true},
+		{name: "nested directory", dir: "path/to/subpkg", expectValid: true},
+		{name: "two levels", dir: "sub/pkg", expectValid: true},
+		{name: "with hyphens", dir: "my-subpkg", expectValid: true},
+		{name: "numeric name", dir: "123", expectValid: true},
+		{name: "deeply nested", dir: "a/b/c/d/e", expectValid: true},
+		{name: "single char segments", dir: "a/b/c", expectValid: true},
+		{name: "starts with digit", dir: "1subpackage", expectValid: true},
+		{name: "ends with digit", dir: "subpackage1", expectValid: true},
+		{name: "contains digits", dir: "1subpckage2/3subpackage4/5subpackage6", expectValid: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsValidSubpackageDir(tt.dir)
-			assert.Equal(t, tt.expected, result)
+			err := IsValidSubpackageDir(tt.dir)
+			if tt.expectValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }

--- a/docs/content/en/docs/2_concepts/subpackages.md
+++ b/docs/content/en/docs/2_concepts/subpackages.md
@@ -98,7 +98,7 @@ one after another before it is proposed and approved.
 When Porch clones or upgrades a subpackage it names the subpackage (sets `metadata.name`) based on the `--subpackage-dir` parameter value (`subpackageDir` on the API).
 It creates a Kubernetes-compliant DNS subdomain name and inserts it in the `metadata.name` field of the Kptfile.
 
-Porch converts any “/“ characters in the `--subpackage-dir` or `subpackageDir` value into ‘.’ characters to create a
+Porch converts any “/“ characters in the `--subpackage-dir` (or `subpackageDir` on the API) value into ‘.’ characters to create a
 [valid Kubernetes DNS Subdomain name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). This creates a
 unique name for the subpackage in the package. This means that `--subpackage-dir` and `subpackageDir` values are restricted to the rules for subdomain
 names in `--subpackage-dir` and `subpackageDir` values.

--- a/docs/content/en/docs/2_concepts/subpackages.md
+++ b/docs/content/en/docs/2_concepts/subpackages.md
@@ -21,12 +21,15 @@ and dependent subpackages that are managed as a single unit, independent subpack
 ## What is a Dependent Subpackage?
 
 A **dependent subpackage** does not maintain its own upstream source and cannot be independently upgraded.  The subpackage contents
-is managed as a single unit with the regular package contents.
+are managed as a single unit with the regular package contents.
 
 ## Why Use Independent Subpackages?
 
 Independent subpackages enable **composition** of packages from multiple upstream sources. A single parent package can
-contain multiple independently-versioned components, each tracking a different upstream package. This is useful when a deployment package must combine resources from several blueprint packages,different components within a package need to be upgraded on different schedules or you want to assemble a complex package from reusable building blocks without creating separate package revisions for each component.
+contain multiple independently-versioned components, each tracking a different upstream package. This is useful when a deployment
+package must combine resources from several blueprint packages, different components within a package need to be upgraded on
+different schedules or you want to assemble a complex package from reusable building blocks without creating separate package
+revisions for each component.
 
 ## How Subpackages Work
 
@@ -54,7 +57,8 @@ When a new version of the upstream package is published, the independent subpack
 the parent package. The upgrade operation:
 
 1. Reads the subpackage's `Kptfile` to determine its current upstream source
-2. Merges the new upstream version into the subpackage directory using the specified strategy using the same mechanism as is used in the upgrade of a regular PR
+2. Merges the new upstream version into the subpackage directory employing the specified strategy, using the same mechanism
+as a regular package revision upgrade
 3. Updates the origin information of the subpackage in the `Kptfile` of the cloned subpackage
 
 ```bash
@@ -66,7 +70,7 @@ If the `revision` parameter is omitted, the subpackage is upgraded to the latest
 source.
 
 Subpackage operations may be performed on a freshly created draft before any other modifications are pushed to it or on
-a draft to which other modifications have already been pushed. Muitiple subpackages may be cloned and upgraded on a draft
+a draft to which other modifications have already been pushed. Multiple subpackages may be cloned and upgraded on a draft
 one after another before it is proposed and approved.
 
 

--- a/docs/content/en/docs/2_concepts/subpackages.md
+++ b/docs/content/en/docs/2_concepts/subpackages.md
@@ -10,7 +10,7 @@ description: |
 
 A **subpackage** is a kpt package nested within a parent package at a specific subdirectory. Subpackages have a `Kptfile` that can
 be used to apply specific mutations or validations to the contents of the subpackage. See
-[the kpt package documentation](https://kpt.dev/book/03-packages) for a full description of dependent and independent subpackages.
+[the kpt package documentation](https://kpt.dev/book/03-packages) for a description of dependent and independent subpackages.
 
 ## What is an Independent Subpackage?
 
@@ -40,7 +40,8 @@ parent package revision. The clone operation:
 
 1. Copies the upstream package contents into the specified subdirectory
 2. Preserves the upstream's `Kptfile`
-3. Adds the origin information of the subpackage to the `Kptfile` of the cloned subpackage
+3. Updates the `metadata.name` of the subpackage
+4. Adds the origin information of the subpackage to the `Kptfile` of the cloned subpackage
 
 ```bash
 porchctl rpkg clone upstream-repo.blueprint.v1 deployment.my-app.v2 \
@@ -59,7 +60,8 @@ the parent package. The upgrade operation:
 1. Reads the subpackage's `Kptfile` to determine its current upstream source
 2. Merges the new upstream version into the subpackage directory employing the specified strategy, using the same mechanism
 as a regular package revision upgrade
-3. Updates the origin information of the subpackage in the `Kptfile` of the cloned subpackage
+3. Updates the `metadata.name` of the subpackage
+4. Updates the origin information of the subpackage in the `Kptfile` of the cloned subpackage
 
 ```bash
 porchctl rpkg upgrade deployment.my-app.v2 \
@@ -77,7 +79,7 @@ one after another before it is proposed and approved.
 ## Constraints
 
 - The parent package revision must be in **Draft** state for both clone and upgrade operations
-- The `--subpackage-dir` path must be a valid relative path (no leading `/`, `./`, or `..` segments)
+- The `--subpackage-dir` path must be a valid relative path (no leading `/`, `./`, `.`, or `..` segments) and comply with the subpackage directory naming rules described in the [subpackage naming](#subpackage-naming) section below.
 - For clone: the subdirectory must **not already exist** in the package
 - For upgrade: the subdirectory **must already exist** and contain a valid `Kptfile` with upstream information
 - `--workspace` and `--repository` must not be specified when using `--subpackage-dir`
@@ -90,6 +92,36 @@ one after another before it is proposed and approved.
 | Target | New package in a repository | Subdirectory within a parent package |
 | Upgrade | Creates a new package revision | Modifies the parent package revision in-place |
 | Tracking | PackageRevision tracks upstream | Subpackage's Kptfile tracks upstream |
+
+## Subpackage Naming
+
+When Porch clones or upgrades a subpackage it names the subpackage (sets `metadata.name`) based on the `--subpackage-dir` parameter value (`subpackageDir` on the API).
+It creates a Kubernetes-compliant DNS subdomain name and inserts it in the `metadata.name` field of the Kptfile.
+
+Porch converts any “/“ characters in the `--subpackage-dir` or `subpackageDir` value into ‘.’ characters to create a
+[valid Kubernetes DNS Subdomain name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). This creates a
+unique name for the subpackage in the package. This means that `--subpackage-dir` and `subpackageDir` values are restricted to the rules for subdomain
+names in `--subpackage-dir` and `subpackageDir` values.
+
+- No more than 253 characters (after replacing "/" with ".")
+- Only lowercase alphanumeric characters, "-", "/" ("/" is converted to ".")
+- Must start and end with an alphanumeric character (letter or digit)
+
+This [Kubernetes validation IsDNS1123Subdomain() function](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go)
+is used to check the value once "/" characters are replaced with "." characters.
+
+So the following `subpackageDir` values result in the following `metadata.name` values in the Kptfile:
+
+| subpackageDir                            | metadata.name                            |
+|------------------------------------------|------------------------------------------|
+| subpackage                               | subpackage                               |
+| ran/subpackage                           | ran.subpackage                           |
+| ran/south/southeast/region-1a/subpackage | ran.south.southeast.region-1a.subpackage |
+| 1subpackage                              | 1subpackage                              |
+| 1subpckage2/3subpackage4/5subpackage6    | 1subpckage2.3subpackage4.5subpackage6    |
+| Subpackage                               | error (Uppercase character)              |
+| sub_package                              | error ("_" illegal)                      |
+| ran\subpackage                           | error ("\\" illegal)                     |
 
 ## Key Points
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
@@ -24,6 +24,9 @@ Unlike a regular clone (which creates a new package revision), a subpackage clon
 Draft package revision. Similarly, a subpackage upgrade modifies the parent package revision in-place rather than
 creating a new one.
 
+Note that **Subpackage directory** paths must follow the
+[rules described on the subpackage page]({{% relref "/docs/2_concepts/subpackages/#subpackage-naming" %}}).
+
 ## Prerequisites
 
 Before following this guide, ensure you have:

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
@@ -16,7 +16,7 @@ For detailed command reference, see the [porchctl CLI guide]({{% relref "/docs/7
 
 - **Independent subpackage**: A kpt package nested in a subdirectory of a parent package that maintains its own
   upstream tracking via its `Kptfile`. See [the kpt package documentation](https://kpt.dev/book/03-packages) for
-  a full description of independent subpackages 
+  a full description of independent subpackages
 - **Parent package revision**: The Draft package revision into which subpackages are cloned or upgraded.
 - **Subpackage directory**: The relative path within the parent package where the subpackage resides.
 
@@ -38,7 +38,7 @@ Subpackage operations require the parent package revision to be in **Draft** sta
 {{% /alert %}}
 
  Subpackage operations may be performed on a freshly created draft before any other modifications are pushed to it or on
- a draft to which other modifications have already been pushed. Muitiple subpackages may be cloned and upgraded on a draft
+ a draft to which other modifications have already been pushed. Multiple subpackages may be cloned and upgraded on a draft
  one after another.
 
 ## End-to-End Example
@@ -184,7 +184,7 @@ When `--subpackage-dir` is specified:
 |-------------|--------|
 | Parent must be in Draft state | Subpackage clone modifies an existing package revision |
 | Subdirectory must not exist | Prevents overwriting existing content |
-| Path must be relative (no `/`, `./`, `..`) | Ensures subpackage stays within the parent package tree |
+| Path must be relative (no leading or trailing `/`, no `./` or `..`) | Ensures subpackage stays within the parent package tree |
 
 ## Subpackage Upgrade in Detail
 

--- a/docs/content/en/docs/7_cli_api/porchctl.md
+++ b/docs/content/en/docs/7_cli_api/porchctl.md
@@ -327,7 +327,7 @@ porchctl rpkg clone SOURCE_PACKAGE NAME [flags]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--repository string` | Downstream repository for cloned package | (required unless `--subpackage-dir` is set) |
-| `--workspace string` | Workspace name for new package | `v1` (ignored when `--subpackage-dir` is set; must not be explicitly specified) |
+| `--workspace string` | Workspace name for new package | `v1` (must not be explicitly specified with `--subpackage-dir`) |
 | `--directory string` | Directory within upstream repository (Git only) | |
 | `--ref string` | Branch, tag, or SHA in upstream repository (Git only) | |
 | `--strategy string` | Update strategy: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge` | `resource-merge` |

--- a/docs/content/en/docs/7_cli_api/porchctl.md
+++ b/docs/content/en/docs/7_cli_api/porchctl.md
@@ -327,7 +327,7 @@ porchctl rpkg clone SOURCE_PACKAGE NAME [flags]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--repository string` | Downstream repository for cloned package | (required unless `--subpackage-dir` is set) |
-| `--workspace string` | Workspace name for new package | `v1` (must not be explicitly specified with `--subpackage-dir`) |
+| `--workspace string` | Workspace name for new package | `v1` (must not be explicitly specified together with `--subpackage-dir`) |
 | `--directory string` | Directory within upstream repository (Git only) | |
 | `--ref string` | Branch, tag, or SHA in upstream repository (Git only) | |
 | `--strategy string` | Update strategy: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge` | `resource-merge` |

--- a/docs/content/en/docs/7_cli_api/porchctl.md
+++ b/docs/content/en/docs/7_cli_api/porchctl.md
@@ -320,7 +320,7 @@ porchctl rpkg clone SOURCE_PACKAGE NAME [flags]
 - `SOURCE_PACKAGE` - Source package to clone. Can be:
   - Git: `https://git-repository.git/package-name`
   - Package: `example-repo.example-package-name.example-workspace`
-- `NAME` - Name of the new package or the parent package if `--subpackage-dir` is set.
+- `NAME` - Name of the new package, or the parent package revision if `--subpackage-dir` is set.
 
 **Flags:**
 
@@ -333,6 +333,10 @@ porchctl rpkg clone SOURCE_PACKAGE NAME [flags]
 | `--strategy string` | Update strategy: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge` | `resource-merge` |
 | `--secret-ref string` | Secret name for basic auth (Git only) | |
 | `--subpackage-dir string` | Directory path into which the upstream package will be cloned as an independent subpackage. When set, `NAME` refers to the parent package revision (which must be in Draft state), and `--repository`/`--workspace` must not be specified. | |
+
+Note that **--subpackage-dir** paths must follow the
+[rules described on the subpackage page]({{% relref "/docs/2_concepts/subpackages/#subpackage-naming" %}}).
+
 
 **Examples:**
 
@@ -585,7 +589,7 @@ porchctl rpkg upgrade SOURCE_PACKAGE_REVISION [flags]
 
 **Arguments:**
 
-- `SOURCE_PACKAGE_REVISION` - Target downstream package revision to upgrade. Must be published and have an upstream package.
+- `SOURCE_PACKAGE_REVISION` - Target downstream package revision to upgrade. Must be published and have an upstream package unless `--subpackage-dir` is also specified, in which case `SOURCE_PACKAGE_REVISION` refers to the parent Draft package revision.
 
 **Flags:**
 
@@ -595,7 +599,11 @@ porchctl rpkg upgrade SOURCE_PACKAGE_REVISION [flags]
 | `--workspace string` | Workspace name for new package revision | (required unless `--subpackage-dir` is set) |
 | `--strategy string` | Update strategy: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge` | `resource-merge` |
 | `--discover string` | Discover available updates instead of upgrading. Options: `upstream`, `downstream` | |
-| `--subpackage-dir string` | Directory path of an independent subpackage to upgrade within the parent package. When set, the parent package must be in Draft state and `--workspace` must not be specified. | |
+| `--subpackage-dir string` | Directory path of an independent subpackage to upgrade within the parent package. When set, `SOURCE_PACKAGE_REVISION` refers to the parent Draft package revision, and `--workspace` must not be specified. | |
+
+
+Note that **--subpackage-dir** paths must follow the
+[rules described on the subpackage page]({{% relref "/docs/2_concepts/subpackages/#subpackage-naming" %}}).
 
 **Examples:**
 

--- a/docs/content/en/docs/7_cli_api/porchctl.md
+++ b/docs/content/en/docs/7_cli_api/porchctl.md
@@ -320,14 +320,14 @@ porchctl rpkg clone SOURCE_PACKAGE NAME [flags]
 - `SOURCE_PACKAGE` - Source package to clone. Can be:
   - Git: `https://git-repository.git/package-name`
   - Package: `example-repo.example-package-name.example-workspace`
-- `NAME` - Name of the new package.
+- `NAME` - Name of the new package or the parent package if `--subpackage-dir` is set.
 
 **Flags:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--repository string` | Downstream repository for cloned package | (required unless `--subpackage-dir` is set) |
-| `--workspace string` | Workspace name for new package | `v1` (must not be set with `--subpackage-dir`) |
+| `--workspace string` | Workspace name for new package | `v1` (ignored when `--subpackage-dir` is set; must not be explicitly specified) |
 | `--directory string` | Directory within upstream repository (Git only) | |
 | `--ref string` | Branch, tag, or SHA in upstream repository (Git only) | |
 | `--strategy string` | Update strategy: `resource-merge`, `fast-forward`, `force-delete-replace`, `copy-merge` | `resource-merge` |

--- a/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
+++ b/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
@@ -58,11 +58,15 @@ into your Starlark script, which will cause an error and trigger the output:
 You can use the Porch Kubernetes API directly (via `kubectl` or `curl`) to clone an upstream package as an independent
 subpackage into an existing Draft package revision, and to upgrade that subpackage later.
 
+Note that **subpackageDir** paths must follow the
+[rules described on the subpackage page]({{% relref "/docs/2_concepts/subpackages/#subpackage-naming" %}}).
+
 ### Cloning a subpackage via the API
 
-To clone an upstream package into a subdirectory of an existing Draft package revision, send a PUT (update) request on
-the parent `PackageRevision` with a second task of type `clone` that includes `subpackageDir`. The parent must already
-exist in Draft state with exactly one task.
+To clone an upstream package into a subdirectory of an existing Draft package revision, update the parent `PackageRevision` by appending
+an additional task of type `clone` that includes `subpackageDir` (for example via `kubectl apply` / server-side apply, or
+a PATCH request). The parent must already exist in Draft state with exactly one task.
+
 
 ```json
 {
@@ -71,8 +75,7 @@ exist in Draft state with exactly one task.
   "metadata": {
     "name": "porch-test.package-with-sub.first-draft",
     "namespace": "porch-demo",
-    "resourceVersion": "WHATEVER_THE_RESOURCE_VERSION_IS",
-    "uid": "WHATEVER_THE_UID_IS"
+    "resourceVersion": "WHATEVER_THE_RESOURCE_VERSION_IS"
   },
   "spec": {
     "tasks": [
@@ -108,8 +111,9 @@ Key points:
 
 ### Upgrading a subpackage via the API
 
-To upgrade an existing independent subpackage, send a PUT (update) request on the parent `PackageRevision` with a
-second task of type `upgrade` that includes `subpackageDir`. The parent must be in Draft state with exactly one task.
+To upgrade an existing independent subpackage, update the parent `PackageRevision` by appending
+an additional task of type `upgrade` that includes `subpackageDir` (for example via `kubectl apply` / server-side apply,
+or a PATCH request). The parent must be in Draft state with exactly one task.
 
 ```json
 {
@@ -118,8 +122,7 @@ second task of type `upgrade` that includes `subpackageDir`. The parent must be 
   "metadata": {
     "name": "porch-test.package-with-sub.second-draft",
     "namespace": "porch-demo",
-    "resourceVersion": "WHATEVER_THE_RESOURCE_VERSION_IS",
-    "uid": "WHATEVER_THE_UID_IS"
+    "resourceVersion": "WHATEVER_THE_RESOURCE_VERSION_IS"
   },
   "spec": {
     "tasks": [

--- a/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
+++ b/docs/content/en/docs/9_troubleshooting_and_faq/lazy-dog/_index.md
@@ -103,7 +103,7 @@ Key points:
 - The first task is the parent's original task (e.g., `init` or `clone`)
 - The second task is the new `clone` task with `subpackageDir` set to the target subdirectory
 - `upstreamRef.upstreamRef.name` identifies the published upstream package revision to clone from
-- `resourceVersion` and `uid` must match the current parent package revision (fetch them with `kubectl get packagerevision <name> -o json`)
+- `resourceVersion` must match the current parent package revision (fetch it with `kubectl get packagerevision <name> -o json`)
 - The `"clone"` task is removed from the `PackageRevision` resource once the clone operation has been executed.
 
 ### Upgrading a subpackage via the API
@@ -139,7 +139,7 @@ second task of type `upgrade` that includes `subpackageDir`. The parent must be 
             "name": "porch-test.upstream-function.beta"
           },
           "localPackageRevisionRef": {
-            "name": "porch-test.nf-with-sub.second-draft"
+            "name": "porch-test.package-with-sub.second-draft"
           },
           "strategy": "force-delete-replace",
           "subpackageDir": "subpackages/subpackage1"
@@ -152,18 +152,17 @@ second task of type `upgrade` that includes `subpackageDir`. The parent must be 
 
 Key points:
 
-- `oldUpstreamRef.name` is the package revision the subpackage was originally cloned from
-- `newUpstreamRef.name` is the new upstream package revision to upgrade to
-- `localPackageRevisionRef.name` is the published parent package revision that contains the current subpackage contents (used as the local side of the 3-way merge)
+- `oldUpstreamRef.name` is the published package revision the subpackage was originally cloned from
+- `newUpstreamRef.name` is the new upstream published package revision to upgrade to
+- `localPackageRevisionRef.name` is the parent draft package revision that contains the current subpackage contents (used as the local side of the 3-way merge)
 - `strategy` controls the merge behaviour (e.g., `resource-merge`, `force-delete-replace`)
 - `subpackageDir` identifies which subdirectory contains the independent subpackage to upgrade
-- The `"upgrade"` task is removed from the `PackageRevision` resource once the clone operation has been executed.
-
+- The `"upgrade"` task is removed from the `PackageRevision` resource once the upgrade operation has been executed.
 
 ### Typical workflow
 
 1. Create or copy a parent package revision (it will be in Draft state with one task)
-2. `kubectl get packagerevision <name> -n <namespace> -o json` to fetch the current `resourceVersion` and `uid`
+2. `kubectl get packagerevision <name> -n <namespace> -o json` to fetch the current `resourceVersion`
 3. Append the clone or upgrade task to the `spec.tasks` array
 4. `kubectl apply -f <file>.json` to trigger the operation
 5. Verify with `porchctl rpkg pull <name> ./dir --namespace=<namespace>` to inspect the subpackage contents

--- a/pkg/cli/commands/rpkg/clone/command.go
+++ b/pkg/cli/commands/rpkg/clone/command.go
@@ -24,6 +24,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	cliutils "github.com/kptdev/porch/internal/cliutils"
 	"github.com/kptdev/porch/pkg/cli/commands/rpkg/docs"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -105,23 +106,21 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 		}
 
 	} else {
-		if !porchapi.IsValidSubpackageDir(r.subpackageDir) {
-			return errors.E(op, fmt.Errorf("invalid --subpackage-dir %q", r.subpackageDir))
+		if err = porchapi.IsValidSubpackageDir(r.subpackageDir); err != nil {
+			return errors.E(op, pkgerrors.Wrapf(err, "invalid --subpackage-dir %q", r.subpackageDir))
 		}
 
 		r.clone.SubpackageDir = r.subpackageDir
 
-		if r.repository != "" {
+		if r.Command.Flags().Changed("repository") {
 			return errors.E(op, fmt.Errorf("--repository may not be specified on subpackage clones"))
 		}
 
-		if !r.Command.Flags().Changed("workspace") {
-			r.workspace = ""
-		}
-
-		if r.workspace != "" {
+		if r.Command.Flags().Changed("workspace") {
 			return errors.E(op, fmt.Errorf("--workspace may not be specified on subpackage clones"))
 		}
+
+		r.workspace = ""
 	}
 
 	source := args[0]

--- a/pkg/cli/commands/rpkg/clone/command_test.go
+++ b/pkg/cli/commands/rpkg/clone/command_test.go
@@ -295,9 +295,12 @@ func TestPreRunE(t *testing.T) {
 				subpackageDir: test.flags["subpackage-dir"],
 			}
 
-			// Mark workspace flag as changed if explicitly set in test
-			if ws, ok := test.flags["workspace"]; ok && ws != "" {
+			// Mark flags as changed if explicitly set in test
+			if ws, ok := test.flags["workspace"]; ok {
 				_ = cmd.Flags().Set("workspace", ws)
+			}
+			if repo, ok := test.flags["repository"]; ok {
+				_ = cmd.Flags().Set("repository", repo)
 			}
 
 			err := r.preRunE(cmd, test.args)

--- a/pkg/cli/commands/rpkg/docs/docs.go
+++ b/pkg/cli/commands/rpkg/docs/docs.go
@@ -83,7 +83,7 @@ Flags:
 
   --subpackage-dir string
     Directory path into which the upstream package will be cloned as an independent subpackage. When set, NAME refers
-    to the parent package revision (which must be in Draft state),and --repository/--workspace must not be specified. 	
+    to the parent package revision (which must be in Draft state), and --repository/--workspace must not be specified.
 `
 
 var CloneExamples = `
@@ -96,7 +96,7 @@ var CloneExamples = `
   $ porchctl rpkg clone https://github.com/repo/blueprint.git example-downstream-package --repository=blueprint --ref=base/v0 --namespace=default --directory=base
 
   # Clone as an independent subpackage into a draft parent package
-  # porchctl rpkg clone upstream-repo.blueprint.v1 deployment.parent-package.v2 --subpackage-dir=path/to/subpkg --namespace=default
+  $ porchctl rpkg clone upstream-repo.blueprint.v1 deployment.parent-package.v2 --subpackage-dir=path/to/subpkg --namespace=default
 `
 
 var CopyShort = `Create a new package revision from an existing one.`
@@ -245,7 +245,7 @@ var PullLong = `
 Args:
 
   K8S_PACKAGE_REV_NAME:
-    The kubernetes name of a an existing package revision in a repository.
+    The kubernetes name of an existing package revision in a repository.
 
   DIR:
     A local directory where the package manifests will be written.
@@ -263,7 +263,7 @@ var PushLong = `
 Args:
 
   K8S_PACKAGE_REV_NAME:
-    The kubernetes name of a an existing package revision in a repository.
+    The kubernetes name of an existing package revision in a repository.
 
   DIR:
     A local directory with the new manifest. If the manifests have be read from stdin, use '-' in place of DIR.
@@ -342,5 +342,5 @@ var UpgradeExamples = `
   $ porchctl rpkg upgrade deployment.some-package.v1 --revision=3 --workspace=v2 --strategy=copy-merge
 
   # Upgrade an independent subpackage within a draft parent package
-  porchctl rpkg upgrade deployment.parent-package.v2 --subpackage-dir=path/to/subpkg --revision=3
+  $ porchctl rpkg upgrade deployment.parent-package.v2 --subpackage-dir=path/to/subpkg --revision=3
 `

--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -118,11 +118,11 @@ func (r *runner) preRunE(_ *cobra.Command, args []string) error {
 				return errors.E(op, fmt.Errorf("workspace is required"))
 			}
 		} else {
-			if !porchapi.IsValidSubpackageDir(r.subpackageDir) {
-				return errors.E(op, fmt.Errorf("invalid --subpackage-dir %q", r.subpackageDir))
+			if err = porchapi.IsValidSubpackageDir(r.subpackageDir); err != nil {
+				return errors.E(op, pkgerrors.Wrapf(err, "invalid --subpackage-dir %q", r.subpackageDir))
 			}
 
-			if r.workspace != "" {
+			if r.Command.Flags().Changed("workspace") {
 				return errors.E(op, fmt.Errorf("--workspace may not be specified on subpackage upgrades"))
 			}
 		}

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -194,15 +194,17 @@ func TestPreRunSubpackageDir(t *testing.T) {
 	const ns = "ns"
 
 	t.Run("Subpackage upgrade with workspace flag returns error", func(t *testing.T) {
+		cmd := NewCommand(context.Background(), &genericclioptions.ConfigFlags{Namespace: func() *string { s := ns; return &s }()})
+		assert.NoError(t, cmd.Flags().Set("workspace", "ws"))
 		r := &runner{
 			ctx:           context.Background(),
 			cfg:           &genericclioptions.ConfigFlags{Namespace: func() *string { s := ns; return &s }()},
-			Command:       NewCommand(context.Background(), &genericclioptions.ConfigFlags{Namespace: func() *string { s := ns; return &s }()}),
+			Command:       cmd,
 			revision:      2,
 			subpackageDir: "my-subpkg",
 			workspace:     "ws",
 		}
-		err := r.preRunE(r.Command, []string{"some-pr"})
+		err := r.preRunE(cmd, []string{"some-pr"})
 		assert.ErrorContains(t, err, "--workspace may not be specified on subpackage upgrades")
 	})
 
@@ -217,6 +219,20 @@ func TestPreRunSubpackageDir(t *testing.T) {
 		}
 		err := r.preRunE(r.Command, []string{"some-pr"})
 		assert.NoError(t, err)
+	})
+
+	t.Run("Subpackage upgrade with invalid subpackage-dir returns error", func(t *testing.T) {
+		r := &runner{
+			ctx:           context.Background(),
+			cfg:           &genericclioptions.ConfigFlags{Namespace: func() *string { s := ns; return &s }()},
+			Command:       NewCommand(context.Background(), &genericclioptions.ConfigFlags{Namespace: func() *string { s := ns; return &s }()}),
+			revision:      2,
+			subpackageDir: "../invalid",
+			strategy:      "resource-merge",
+		}
+		err := r.preRunE(r.Command, []string{"some-pr"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid --subpackage-dir "../invalid"`)
 	})
 }
 

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -277,12 +277,13 @@ func (th *genericTaskHandler) applySubpackageTask(
 		return err
 	}
 
-	if err := kptFile.SetName(path.Base(subpackageDir)); err != nil {
-		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", path.Base(subpackageDir))
+	subpackageName, _ := porchapi.ComposeSubpkgObjName(subpackageDir)
+	if err := kptFile.SetName(subpackageName); err != nil {
+		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
 	}
 
 	if err := kptFile.WriteToPackage(subpackageResources.Contents); err != nil {
-		return pkgerrors.Wrap(err, "failed to write to subpackage Kptfile")
+		return pkgerrors.Wrapf(err, "failed to write to subpackage Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
 	}
 
 	// Remove the subpackage task to prevent re-execution of the task

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -1157,8 +1157,8 @@ func TestApplySubpackageTask_SuccessfulUpgrade(t *testing.T) {
 		Resources: &porchapi.PackageRevisionResources{
 			Spec: porchapi.PackageRevisionResourcesSpec{
 				Resources: map[string]string{
-					"Kptfile":              "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: parent\n",
-					"my-subpkg/Kptfile":    kptfileContent,
+					"Kptfile":                 "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: parent\n",
+					"my-subpkg/Kptfile":       kptfileContent,
 					"my-subpkg/resource.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: original\n",
 				},
 			},
@@ -1172,8 +1172,8 @@ func TestApplySubpackageTask_SuccessfulUpgrade(t *testing.T) {
 	// Parent resources with existing subpackage content at "my-subpkg/"
 	parentResources := repository.PackageResources{
 		Contents: map[string]string{
-			"Kptfile":              "parent-kptfile",
-			"my-subpkg/Kptfile":    kptfileContent,
+			"Kptfile":                 "parent-kptfile",
+			"my-subpkg/Kptfile":       kptfileContent,
 			"my-subpkg/resource.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: original\n",
 		},
 	}
@@ -1337,6 +1337,93 @@ func TestApplySubpackageTask_ClearsTasksAfterExecution(t *testing.T) {
 	// Verify tasks were trimmed to only the first task
 	assert.Len(t, obj.Spec.Tasks, 1)
 	assert.Equal(t, porchapi.TaskTypeClone, obj.Spec.Tasks[0].Type)
+}
+
+func TestApplySubpackageTask_InvalidSubpackageName(t *testing.T) {
+	// SubpackageDir that produces an invalid k8s name (uppercase letters)
+	upstreamPrKey := repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			RepoKey: repository.RepositoryKey{
+				Namespace: "default",
+				Name:      "upstream-repo",
+			},
+			Package: "subpkg",
+		},
+		WorkspaceName: "ws",
+		Revision:      1,
+	}
+
+	upstreamPR := &fakeextrepo.FakePackageRevision{
+		PrKey: upstreamPrKey,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					"Kptfile": "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: subpkg\n",
+				},
+			},
+		},
+		Kptfile: kptfilev1.KptFile{
+			Upstream: &kptfilev1.Upstream{
+				Type: kptfilev1.GitOrigin,
+				Git:  &kptfilev1.Git{Repo: "https://github.com/example/repo.git", Ref: "main", Directory: "/subpkg"},
+			},
+			UpstreamLock: &kptfilev1.Locator{
+				Type: kptfilev1.GitOrigin,
+				Git:  &kptfilev1.GitLock{Repo: "https://github.com/example/repo.git", Ref: "main", Directory: "/subpkg", Commit: "abc123"},
+			},
+		},
+	}
+
+	fakeRepo := &fakeextrepo.Repository{
+		PackageRevisions: []repository.PackageRevision{upstreamPR},
+	}
+
+	obj := &porchapi.PackageRevision{
+		Spec: porchapi.PackageRevisionSpec{
+			Tasks: []porchapi.Task{
+				{Type: porchapi.TaskTypeClone, Clone: &porchapi.PackageCloneTaskSpec{}},
+				{
+					Type: porchapi.TaskTypeClone,
+					Clone: &porchapi.PackageCloneTaskSpec{
+						SubpackageDir: "INVALID_UPPERCASE",
+						Upstream: porchapi.UpstreamPackage{
+							UpstreamRef: &porchapi.PackageRevisionRef{
+								Name: "upstream-repo.subpkg.ws",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	draft := &fakeextrepo.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: "default",
+					Name:      "test-repo",
+				},
+				Package: "test-pkg",
+			},
+			WorkspaceName: "ws",
+		},
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{},
+			},
+		},
+	}
+
+	th := &genericTaskHandler{
+		referenceResolver: &mockReferenceResolver{repo: &configapi.Repository{}},
+		repoOpener:        &mockRepositoryOpener{repo: fakeRepo},
+	}
+
+	err := th.applySubpackageTask(context.Background(), draft, obj, repository.PackageResources{Contents: map[string]string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subpackage resource name")
+	assert.Contains(t, err.Error(), "lowercase RFC 1123 subdomain")
 }
 
 type mockReferenceResolver struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -351,9 +351,8 @@ func RetryOnError(retries int, f func(retryNumber int) error) error {
 	return err
 }
 
-// FindBestSemverMatch selects the cache key whose semver tag best satisfies
-// the constraint for the given imageName. It returns the full cache key
-// (e.g. "ghcr.io/foo/bar:v1.2.3") of the highest matching version.
+// FindBestSemverMatch selects the highest semver tag from cachedTags that satisfies constraint.
+// It returns the selected tag (e.g. "v1.2.3") for the given imageName (used for logging only).
 func FindBestSemverMatch(constraint string, imageName string, cachedTags []string) (string, error) {
 	c, err := semver.NewConstraint(constraint)
 	if err != nil {
@@ -445,8 +444,8 @@ func GetRepoPackageRefFromUpstream(upstream *kptfilev1.Upstream) (upstreamRepoSp
 		return
 	}
 
-	if !porchapi.IsValidSubpackageDir(upstream.Git.Directory) {
-		err = pkgerrors.Errorf("git directory reference %q in upstream is invalid", upstream.Git.Directory)
+	if validationErr := porchapi.IsValidSubpackageDir(upstream.Git.Directory); validationErr != nil {
+		err = pkgerrors.Wrapf(validationErr, "git directory reference %q in upstream is invalid", upstream.Git.Directory)
 		return
 	}
 

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"path"
 	"strings"
 
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
@@ -88,7 +87,9 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -154,7 +155,9 @@ func (t *PorchSuite) TestSubpackageUpgradeNonexisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -169,7 +172,7 @@ func (t *PorchSuite) TestSubpackageUpgradeNonexisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v2")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -263,13 +266,18 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+	expectedSubpackagName2, _ := porchapi.ComposeSubpkgObjName(subpackageDir2)
+	expectedSubpackagName3, _ := porchapi.ComposeSubpkgObjName(subpackageDir3)
+	expectedSubpackagName4, _ := porchapi.ComposeSubpkgObjName(subpackageDir4)
+
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+path.Base(subpackageDir2))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+path.Base(subpackageDir3))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+path.Base(subpackageDir4))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -296,13 +304,13 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+path.Base(subpackageDir2))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+path.Base(subpackageDir3))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+path.Base(subpackageDir4))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v2")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -332,13 +340,13 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPRV2.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+path.Base(subpackageDir1))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+path.Base(subpackageDir2))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+path.Base(subpackageDir3))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+path.Base(subpackageDir4))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v3")
 
 	assert.Equal(t, 1, len(parentPRV2.Spec.Tasks))
@@ -384,7 +392,9 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+path.Base(subpackageDir))
+	expectedSubpackagName, _ := porchapi.ComposeSubpkgObjName(subpackageDir)
+
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspace+": "+parentWorkspace)
@@ -403,7 +413,7 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+path.Base(subpackageDir))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v2")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspace+": "+parentWorkspace)
@@ -426,7 +436,7 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPRV2.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+path.Base(subpackageDir))
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v3")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspaceV2+": "+parentWorkspaceV2)

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -87,9 +87,9 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+	expectedSubpackageName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -155,9 +155,9 @@ func (t *PorchSuite) TestSubpackageUpgradeNonexisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+	expectedSubpackageName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -172,7 +172,7 @@ func (t *PorchSuite) TestSubpackageUpgradeNonexisting() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"/v2")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -266,18 +266,18 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	expectedSubpackagName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
-	expectedSubpackagName2, _ := porchapi.ComposeSubpkgObjName(subpackageDir2)
-	expectedSubpackagName3, _ := porchapi.ComposeSubpkgObjName(subpackageDir3)
-	expectedSubpackagName4, _ := porchapi.ComposeSubpkgObjName(subpackageDir4)
+	expectedSubpackageName1, _ := porchapi.ComposeSubpkgObjName(subpackageDir1)
+	expectedSubpackageName2, _ := porchapi.ComposeSubpkgObjName(subpackageDir2)
+	expectedSubpackageName3, _ := porchapi.ComposeSubpkgObjName(subpackageDir3)
+	expectedSubpackageName4, _ := porchapi.ComposeSubpkgObjName(subpackageDir4)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackageName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackageName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v1")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackageName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v1")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -304,13 +304,13 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackageName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackageName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v2")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackageName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v2")
 
 	assert.Equal(t, 1, len(parentPR.Spec.Tasks))
@@ -340,13 +340,13 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 		Name:      parentPRV2.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackagName1)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "name: "+expectedSubpackageName1)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/Kptfile"], "ref: "+cloneePackageName+"-1/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackagName2)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "name: "+expectedSubpackageName2)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/Kptfile"], "ref: "+cloneePackageName+"-2/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackagName3)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "name: "+expectedSubpackageName3)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/Kptfile"], "ref: "+cloneePackageName+"-3/v3")
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackagName4)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "name: "+expectedSubpackageName4)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir4+"/Kptfile"], "ref: "+cloneePackageName+"-4/v3")
 
 	assert.Equal(t, 1, len(parentPRV2.Spec.Tasks))
@@ -392,9 +392,9 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	expectedSubpackagName, _ := porchapi.ComposeSubpkgObjName(subpackageDir)
+	expectedSubpackageName, _ := porchapi.ComposeSubpkgObjName(subpackageDir)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackageName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v1")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspace+": "+parentWorkspace)
@@ -413,7 +413,7 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackageName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v2")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspace+": "+parentWorkspace)
@@ -436,7 +436,7 @@ func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, sub
 		Name:      parentPRV2.Name,
 	}, &parentPRResources)
 
-	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackagName)
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "name: "+expectedSubpackageName)
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir+"/Kptfile"], "ref: "+cloneePackageName+"/v3")
 
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "test-label-"+parentWorkspaceV2+": "+parentWorkspaceV2)


### PR DESCRIPTION
## Cherrypick: Make subpackage name unique in independent subpackage Kptfiles
---

## Description
- What changed:  When a subpackage clone or upgrade is performed, Porch composes a subpackage name that is unique within the PR
- Why it’s needed:  The same subpackage can be cloned many times into a PR and if the same subpackage name exists in different directory trees in the PR, Porch did not assign a unique name
- How it works:  Porch now uses the full path of the subpackage to compose the `metadata.name` of an independent subpackage and updates it in the Kptfile of the subpackage

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**
I used Amazon Q to create the unit tests for the bug fix and hand-checked the unit tests it created.