### PR TITLE
Add dependabot config for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps"
+  - package-ecosystem: gomod
+    directory: /docs
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: gomod
+    directory: /examples/apps/hello-server
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: 2
 updates:
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Description
- What changed: Added `.github/dependabot.yml` with `github-actions` and `gomod` ecosystems
- Why it's needed: Actions are now pinned to SHAs (PR #1057) but need automated update PRs when new versions release. Go module updates were UI-configured only.
- How it works: Dependabot will open weekly PRs bumping pinned action SHAs (with version comments) and Go module versions.

---

## Related Issue(s)
- Follows up on #1057

---

## Type of Change
- [x] Enhancement

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to generate the dependabot configuration.
  - The author has fully verified all code.