### PR TITLE
Validate resource file paths in package operations

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -558,6 +558,10 @@ func (cad *cadEngine) UpdatePackageResourcesWithoutRender(ctx context.Context, r
 		return nil, err
 	}
 
+	if err := util.ValidateResourcePaths(newRes.Spec.Resources); err != nil {
+		return nil, err
+	}
+
 	prr := &porchapi.PackageRevisionResources{
 		Spec: porchapi.PackageRevisionResourcesSpec{
 			Resources: newRes.Spec.Resources,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -549,16 +549,16 @@ func (cad *cadEngine) UpdatePackageResourcesWithoutRender(ctx context.Context, r
 		return nil, fmt.Errorf("cannot update a package revision with lifecycle value %q; package must be Draft", lifecycle)
 	}
 
+	if err := util.ValidateResourcePaths(newRes.Spec.Resources); err != nil {
+		return nil, err
+	}
+
 	repo, err := cad.cache.OpenRepository(ctx, repositoryObj)
 	if err != nil {
 		return nil, err
 	}
 	draft, err := repo.UpdatePackageRevision(ctx, pr2Update)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := util.ValidateResourcePaths(newRes.Spec.Resources); err != nil {
 		return nil, err
 	}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -898,6 +898,7 @@ func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 		lifecycle     porchapi.PackageRevisionLifecycle
 		oldRV         string
 		newRV         string
+		resources     map[string]string
 		closeErr      error
 		expectError   bool
 		errorContains string
@@ -941,6 +942,15 @@ func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 			expectError:   true,
 			errorContains: "git push failed",
 		},
+		{
+			name:          "failure - path traversal rejected",
+			lifecycle:     porchapi.PackageRevisionLifecycleDraft,
+			oldRV:         "1",
+			newRV:         "1",
+			resources:     map[string]string{"../../etc/config": "content"},
+			expectError:   true,
+			errorContains: "path traversal not allowed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -963,31 +973,40 @@ func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 					ResourceVersion: tt.oldRV,
 				},
 			}
+			resources := tt.resources
+			if resources == nil {
+				resources = map[string]string{"Kptfile": "test"}
+			}
 			newRes := &porchapi.PackageRevisionResources{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "test-pkg",
 					ResourceVersion: tt.newRV,
 				},
 				Spec: porchapi.PackageRevisionResourcesSpec{
-					Resources: map[string]string{"Kptfile": "test"},
+					Resources: resources,
 				},
 			}
 
 			mockPkgRev.On("Lifecycle", mock.Anything).Return(tt.lifecycle).Maybe()
 			mockPkgRev.On("Key").Return(repository.PackageRevisionKey{}).Maybe()
 
-			// Only expect repo open + draft flow when we pass validation
-			needsDraft := tt.newRV != "" && tt.oldRV == tt.newRV && tt.lifecycle == porchapi.PackageRevisionLifecycleDraft
+			// Only expect repo open + draft flow when we pass all pre-draft validation
+			needsDraft := tt.newRV != "" && tt.oldRV == tt.newRV &&
+				tt.lifecycle == porchapi.PackageRevisionLifecycleDraft
 			if needsDraft {
 				mockCache.On("OpenRepository", mock.Anything, repositoryObj).Return(mockRepo, nil)
 				mockRepo.On("UpdatePackageRevision", mock.Anything, mockPkgRev).Return(mockDraft, nil)
-				mockDraft.On("UpdateResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-				closeRet := mockrepo.MockPackageRevision{}
-				if tt.closeErr != nil {
-					mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(nil, tt.closeErr)
-				} else {
-					mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(&closeRet, nil)
+				// Only expect write+close when resources pass validation
+				if tt.resources == nil {
+					mockDraft.On("UpdateResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+					closeRet := mockrepo.MockPackageRevision{}
+					if tt.closeErr != nil {
+						mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(nil, tt.closeErr)
+					} else {
+						mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(&closeRet, nil)
+					}
 				}
 			}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -894,14 +894,15 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 
 func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 	tests := []struct {
-		name          string
-		lifecycle     porchapi.PackageRevisionLifecycle
-		oldRV         string
-		newRV         string
-		resources     map[string]string
-		closeErr      error
-		expectError   bool
-		errorContains string
+		name           string
+		lifecycle      porchapi.PackageRevisionLifecycle
+		oldRV          string
+		newRV          string
+		resources      map[string]string
+		closeErr       error
+		skipWriteClose bool
+		expectError    bool
+		errorContains  string
 	}{
 		{
 			name:      "success - draft lifecycle",
@@ -943,13 +944,14 @@ func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 			errorContains: "git push failed",
 		},
 		{
-			name:          "failure - path traversal rejected",
-			lifecycle:     porchapi.PackageRevisionLifecycleDraft,
-			oldRV:         "1",
-			newRV:         "1",
-			resources:     map[string]string{"../../etc/config": "content"},
-			expectError:   true,
-			errorContains: "path traversal not allowed",
+			name:           "failure - path traversal rejected",
+			lifecycle:      porchapi.PackageRevisionLifecycleDraft,
+			oldRV:          "1",
+			newRV:          "1",
+			resources:      map[string]string{"../../etc/config": "content"},
+			skipWriteClose: true,
+			expectError:    true,
+			errorContains:  "invalid resource path",
 		},
 	}
 
@@ -991,22 +993,18 @@ func TestUpdatePackageResourcesWithoutRender(t *testing.T) {
 			mockPkgRev.On("Key").Return(repository.PackageRevisionKey{}).Maybe()
 
 			// Only expect repo open + draft flow when we pass all pre-draft validation
-			needsDraft := tt.newRV != "" && tt.oldRV == tt.newRV &&
+			needsDraft := !tt.skipWriteClose && tt.newRV != "" && tt.oldRV == tt.newRV &&
 				tt.lifecycle == porchapi.PackageRevisionLifecycleDraft
 			if needsDraft {
 				mockCache.On("OpenRepository", mock.Anything, repositoryObj).Return(mockRepo, nil)
 				mockRepo.On("UpdatePackageRevision", mock.Anything, mockPkgRev).Return(mockDraft, nil)
+				mockDraft.On("UpdateResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-				// Only expect write+close when resources pass validation
-				if tt.resources == nil {
-					mockDraft.On("UpdateResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-
-					closeRet := mockrepo.MockPackageRevision{}
-					if tt.closeErr != nil {
-						mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(nil, tt.closeErr)
-					} else {
-						mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(&closeRet, nil)
-					}
+				closeRet := mockrepo.MockPackageRevision{}
+				if tt.closeErr != nil {
+					mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(nil, tt.closeErr)
+				} else {
+					mockRepo.On("ClosePackageRevisionDraft", mock.Anything, mockDraft, 0).Return(&closeRet, nil)
 				}
 			}
 

--- a/pkg/repository/update.go
+++ b/pkg/repository/update.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The kpt Authors
+// Copyright 2022-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kptdev/kpt/pkg/lib/update"
 	updatetypes "github.com/kptdev/kpt/pkg/lib/update/updatetypes"
+	"github.com/kptdev/porch/pkg/util"
 )
 
 const LocalUpdateDir = "kpt-pkg-update-*"
@@ -99,13 +100,16 @@ func (m *DefaultPackageUpdater) do(_ context.Context, localPkgDir, originalPkgDi
 
 func writeResourcesToDirectory(dir string, resources PackageResources) error {
 	for k, v := range resources.Contents {
-		p := filepath.Join(dir, k)
-		dir := filepath.Dir(p)
-		if err := os.MkdirAll(dir, 0750); err != nil {
-			return fmt.Errorf("failed to create directory %q: %w", dir, err)
+		p, err := util.FilepathSafeJoin(dir, k)
+		if err != nil {
+			return fmt.Errorf("invalid resource path %q: %w", k, err)
+		}
+		d := filepath.Dir(p)
+		if err := os.MkdirAll(d, 0750); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", d, err)
 		}
 		if err := os.WriteFile(p, []byte(v), 0600); err != nil {
-			return fmt.Errorf("failed to write file %q: %w", dir, err)
+			return fmt.Errorf("failed to write file %q: %w", p, err)
 		}
 	}
 	return nil

--- a/pkg/repository/update_test.go
+++ b/pkg/repository/update_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt Authors
+// Copyright 2022, 2024, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,4 +148,30 @@ func TestDefaultPackageUpdaterdo(t *testing.T) {
 	updatedResources, err := loadResourcesFromDirectory(localPkgDir)
 	assert.NoError(t, err)
 	assert.Equal(t, "upstream content", updatedResources.Contents["file1.txt"])
+}
+
+func TestWriteResourcesToDirectoryRejectsInvalidPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"relative path escapes base", "../escape.txt"},
+		{"nested relative path escapes base", "a/../../escape.txt"},
+		{"absolute path", "/etc/file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources := PackageResources{
+				Contents: map[string]string{
+					tt.key: "content",
+				},
+			}
+			err := writeResourcesToDirectory(dir, resources)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid resource path")
+		})
+	}
 }

--- a/pkg/task/replace_test.go
+++ b/pkg/task/replace_test.go
@@ -120,7 +120,7 @@ func TestReplaceResourcesRejectsInvalidPaths(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid path, got nil")
 	}
-	if !bytes.Contains([]byte(err.Error()), []byte("path traversal not allowed")) {
+	if !bytes.Contains([]byte(err.Error()), []byte("invalid resource path")) {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/pkg/task/replace_test.go
+++ b/pkg/task/replace_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024 The kpt Authors
+// Copyright 2022, 2024, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,4 +90,37 @@ func removeCommentsFromFile(t *testing.T, name, contents string) string {
 	}
 
 	return nocomment.String()
+}
+
+func TestReplaceResourcesRejectsInvalidPaths(t *testing.T) {
+	ctx := context.Background()
+
+	replace := &replaceResourcesMutation{
+		newResources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					"../../../etc/config": "content",
+				},
+			},
+		},
+		oldResources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					"Kptfile": "existing",
+				},
+			},
+		},
+	}
+
+	input := repository.PackageResources{
+		Contents: map[string]string{"Kptfile": "existing"},
+	}
+
+	_, _, err := replace.apply(ctx, input)
+	if err == nil {
+		t.Fatal("expected error for invalid path, got nil")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("path traversal not allowed")) {
+		t.Errorf("unexpected error message: %v", err)
+	}
 }

--- a/pkg/task/replaceresources.go
+++ b/pkg/task/replaceresources.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The kpt Authors
+// Copyright 2024, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -33,6 +34,10 @@ type replaceResourcesMutation struct {
 func (m *replaceResourcesMutation) apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *porchapi.TaskResult, error) {
 	_, span := tracer.Start(ctx, "mutationReplaceResources::apply", trace.WithAttributes())
 	defer span.End()
+
+	if err := util.ValidateResourcePaths(m.newResources.Spec.Resources); err != nil {
+		return repository.PackageResources{}, nil, err
+	}
 
 	old := resources.Contents
 	newRes, err := healConfig(old, m.newResources.Spec.Resources)

--- a/pkg/util/safejoin.go
+++ b/pkg/util/safejoin.go
@@ -22,9 +22,12 @@ import (
 
 // Relevant: https://github.com/golang/go/issues/20126
 
-// FilepathSafeJoin joins dir and relative, returning an error if the result
-// would escape dir via path traversal.
-func FilepathSafeJoin(dir string, relative string) (string, error) {
+// FilepathSafeJoin joins dir and relative, returning an error if relative is
+// not a clean, canonical relative path within dir. It rejects path traversal
+// (.. sequences), absolute paths, the bare "." and ".." entries, and any path
+// that would be altered by filepath.Clean (e.g. leading "./", redundant
+// separators, or internal "a/../b" segments).
+func FilepathSafeJoin(dir, relative string) (string, error) {
 	p := filepath.Join(dir, relative)
 	p = filepath.Clean(p)
 
@@ -32,18 +35,20 @@ func FilepathSafeJoin(dir string, relative string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid relative path %q", relative)
 	}
-	if rel != relative || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || strings.HasPrefix(rel, "."+string(filepath.Separator)) {
+	if rel == "." || rel == ".." || rel != relative || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || strings.HasPrefix(rel, "."+string(filepath.Separator)) {
 		return "", fmt.Errorf("invalid relative path %q", relative)
 	}
 	return p, nil
 }
 
-// ValidateResourcePaths checks that none of the keys in a resource map
-// contain path traversal sequences. Returns an error on the first invalid key.
+// ValidateResourcePaths checks that all keys in a resource map are valid
+// relative file paths within a package. It rejects path traversal sequences,
+// absolute paths, and non-canonical paths (e.g. leading "./", bare "." or "..").
+// Returns an error on the first invalid key.
 func ValidateResourcePaths(resources map[string]string) error {
 	for k := range resources {
 		if _, err := FilepathSafeJoin(".", k); err != nil {
-			return fmt.Errorf("invalid resource path %q: path traversal not allowed", k)
+			return fmt.Errorf("invalid resource path %q: %w", k, err)
 		}
 	}
 	return nil

--- a/pkg/util/safejoin.go
+++ b/pkg/util/safejoin.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package engine
+package util
 
 import (
 	"fmt"
@@ -22,7 +22,9 @@ import (
 
 // Relevant: https://github.com/golang/go/issues/20126
 
-func filepathSafeJoin(dir string, relative string) (string, error) {
+// FilepathSafeJoin joins dir and relative, returning an error if the result
+// would escape dir via path traversal.
+func FilepathSafeJoin(dir string, relative string) (string, error) {
 	p := filepath.Join(dir, relative)
 	p = filepath.Clean(p)
 
@@ -34,4 +36,15 @@ func filepathSafeJoin(dir string, relative string) (string, error) {
 		return "", fmt.Errorf("invalid relative path %q", relative)
 	}
 	return p, nil
+}
+
+// ValidateResourcePaths checks that none of the keys in a resource map
+// contain path traversal sequences. Returns an error on the first invalid key.
+func ValidateResourcePaths(resources map[string]string) error {
+	for k := range resources {
+		if _, err := FilepathSafeJoin(".", k); err != nil {
+			return fmt.Errorf("invalid resource path %q: path traversal not allowed", k)
+		}
+	}
+	return nil
 }

--- a/pkg/util/safejoin_test.go
+++ b/pkg/util/safejoin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package engine
+package util
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 
 // Relevant: https://github.com/golang/go/issues/20126
 
-func TestSafeJoin(t *testing.T) {
+func TestFilepathSafeJoin(t *testing.T) {
 	grid := []struct {
 		base      string
 		relative  string
@@ -82,7 +82,7 @@ func TestSafeJoin(t *testing.T) {
 
 	for _, g := range grid {
 		t.Run(fmt.Sprintf("%#v", g), func(t *testing.T) {
-			got, err := filepathSafeJoin(g.base, g.relative)
+			got, err := FilepathSafeJoin(g.base, g.relative)
 			if g.wantError {
 				if err == nil {
 					t.Errorf("got %q and nil error, want error", got)
@@ -91,6 +91,52 @@ func TestSafeJoin(t *testing.T) {
 				if g.want != got {
 					t.Errorf("unexpected value; got %q, want %q", got, g.want)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateResourcePaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources map[string]string
+		wantError bool
+	}{
+		{
+			name:      "valid simple path",
+			resources: map[string]string{"Kptfile": "content", "subdir/file.yaml": "content"},
+			wantError: false,
+		},
+		{
+			name:      "path traversal with ..",
+			resources: map[string]string{"../etc/config": "content"},
+			wantError: true,
+		},
+		{
+			name:      "path traversal nested",
+			resources: map[string]string{"a/../../etc/file": "content"},
+			wantError: true,
+		},
+		{
+			name:      "absolute path",
+			resources: map[string]string{"/etc/cron.d/job": "content"},
+			wantError: true,
+		},
+		{
+			name:      "empty map is valid",
+			resources: map[string]string{},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateResourcePaths(tt.resources)
+			if tt.wantError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/pkg/util/safejoin_test.go
+++ b/pkg/util/safejoin_test.go
@@ -64,6 +64,16 @@ func TestFilepathSafeJoin(t *testing.T) {
 			wantError: true,
 		},
 		{
+			base:      "/tmp",
+			relative:  "..",
+			wantError: true,
+		},
+		{
+			base:      "/tmp",
+			relative:  ".",
+			wantError: true,
+		},
+		{
 			base:      "tmp/",
 			relative:  "a/../foo",
 			wantError: true,
@@ -110,6 +120,16 @@ func TestValidateResourcePaths(t *testing.T) {
 		{
 			name:      "path traversal with ..",
 			resources: map[string]string{"../etc/config": "content"},
+			wantError: true,
+		},
+		{
+			name:      "bare .. without trailing path",
+			resources: map[string]string{"..": "content"},
+			wantError: true,
+		},
+		{
+			name:      "dot refers to directory not a file",
+			resources: map[string]string{".": "content"},
 			wantError: true,
 		},
 		{

--- a/test/e2e/api/rpkg_edit_test.go
+++ b/test/e2e/api/rpkg_edit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The kpt Authors
+// Copyright 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -214,6 +214,30 @@ metadata:
 		t.Errorf("Unexpected updated config map contents: (-want,+got): %s", diff)
 	}
 	t.Logf("ConfigMap content matches expected result after KRM function processing")
+}
+
+func (t *PorchSuite) TestUpdateResourcesRejectsInvalidPaths() {
+	const (
+		repository  = "invalid-path-test"
+		packageName = "invalid-path-pkg"
+		workspace   = defaultWorkspace
+	)
+
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repository, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+	pr := t.CreatePackageDraftF(repository, packageName, workspace)
+
+	var prResources porchapi.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      pr.Name,
+	}, &prResources)
+
+	// Attempt to add a resource with a relative path that escapes the package directory
+	prResources.Spec.Resources["../../etc/config"] = "content"
+
+	err := t.Client.Update(t.GetContext(), &prResources)
+	t.Require().Error(err, "update with invalid resource path should be rejected")
+	t.Require().ErrorContains(err, "path traversal not allowed")
 }
 
 func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {

--- a/test/e2e/api/rpkg_edit_test.go
+++ b/test/e2e/api/rpkg_edit_test.go
@@ -237,7 +237,7 @@ func (t *PorchSuite) TestUpdateResourcesRejectsInvalidPaths() {
 
 	err := t.Client.Update(t.GetContext(), &prResources)
 	t.Require().Error(err, "update with invalid resource path should be rejected")
-	t.Require().ErrorContains(err, "path traversal not allowed")
+	t.Require().ErrorContains(err, "invalid resource path")
 }
 
 func (t *PorchSuite) TestUpdateResourcesEmptyPatch() {


### PR DESCRIPTION
## Description
  - **What changed**: Added path validation for resource file paths in package operations. Resource map keys (file paths) are now validated to reject relative paths containing `..` sequences or absolute paths.
  - **Why it's needed**: Resource paths should be valid relative paths within a package. Rejecting malformed paths early gives users clear error messages and prevents unexpected behaviour downstream.
  - **How it works**: Moved the existing `FilepathSafeJoin` utility from `pkg/engine` to `pkg/util` (exported, reusable) and added a `ValidateResourcePaths` function that checks all keys in a resource map. Validation is called from the resource update and replace paths.

  ## Type of Change
  - [ ] Bug fix
  - [x] Enhancement
  - [x] Tests

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro CLI has been used for creation of PR and PR message