### PR TITLE
Add release artifact verification step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,3 +50,8 @@ jobs:
           args: release --skip=validate -f release/tag/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify release artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/verify-release-artifacts.sh "${{ github.ref_name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,5 +53,5 @@ jobs:
 
       - name: Verify release artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: ./scripts/verify-release-artifacts.sh "${{ github.ref_name }}"

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/kptdev/kpt/api v0.0.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -57,6 +57,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# verify-release-artifacts.sh
+#
+# Verifies that all expected artifacts are published to a GitHub release
+# and that their checksums match the published checksums.txt.
+#
+# Usage:
+#   ./scripts/verify-release-artifacts.sh <tag>
+#
+# Requirements:
+#   - gh CLI installed and authenticated (gh auth login)
+#   - For CI: GITHUB_TOKEN env var is set automatically by GitHub Actions
+#
+# Example:
+#   ./scripts/verify-release-artifacts.sh v1.5.11
+
+set -euo pipefail
+
+TAG="${1:-}"
+if [[ -z "${TAG}" ]]; then
+  echo "ERROR: tag argument is required"
+  echo "Usage: $0 <tag>"
+  exit 1
+fi
+
+# Ensure gh CLI is available
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI is not installed. Install from https://cli.github.com/"
+  exit 1
+fi
+
+# Determine the checksum command (Linux: sha256sum, macOS: shasum -a 256)
+if command -v sha256sum &>/dev/null; then
+  SHA256_CMD="sha256sum"
+elif command -v shasum &>/dev/null; then
+  SHA256_CMD="shasum -a 256"
+else
+  echo "ERROR: neither sha256sum nor shasum found"
+  exit 1
+fi
+
+# Strip leading 'v' to get the version number (goreleaser uses version without 'v')
+VERSION="${TAG#v}"
+
+# Repository in owner/name format — detect from env or infer from gh
+REPO="${GITHUB_REPOSITORY:-}"
+if [[ -z "${REPO}" ]]; then
+  REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
+fi
+if [[ -z "${REPO}" ]]; then
+  echo "ERROR: could not determine repository. Set GITHUB_REPOSITORY or run from a git checkout."
+  exit 1
+fi
+
+echo "==> Verifying release artifacts for ${TAG} in ${REPO}"
+
+# Expected artifact names based on goreleaser.yaml configuration
+EXPECTED_ASSETS=(
+  "porchctl_${VERSION}_darwin_amd64.tar.gz"
+  "porchctl_${VERSION}_darwin_arm64.tar.gz"
+  "porchctl_${VERSION}_linux_amd64.tar.gz"
+  "porchctl_${VERSION}_linux_arm64.tar.gz"
+  "porch_blueprint.tar.gz"
+  "checksums.txt"
+)
+
+# Retry logic for asset listing — the release may take a moment to propagate
+MAX_RETRIES=5
+RETRY_DELAY=10
+ASSETS=""
+
+for ((i = 1; i <= MAX_RETRIES; i++)); do
+  echo "  Attempt ${i}/${MAX_RETRIES}: listing release assets..."
+  ASSETS=$(gh release view "${TAG}" --repo "${REPO}" --json assets -q '.assets[].name' 2>/dev/null || true)
+  if [[ -n "${ASSETS}" ]]; then
+    break
+  fi
+  if [[ ${i} -lt ${MAX_RETRIES} ]]; then
+    echo "  Release not found yet, retrying in ${RETRY_DELAY}s..."
+    sleep "${RETRY_DELAY}"
+  fi
+done
+
+if [[ -z "${ASSETS}" ]]; then
+  echo "ERROR: could not retrieve release assets for tag ${TAG}"
+  echo "       The release may not exist or has no assets."
+  exit 1
+fi
+
+echo ""
+echo "==> Assets found on release:"
+while IFS= read -r asset; do
+  echo "    ${asset}"
+done <<< "${ASSETS}"
+echo ""
+
+# Check all expected assets are present
+MISSING=()
+for expected in "${EXPECTED_ASSETS[@]}"; do
+  if ! grep -qxF "${expected}" <<< "${ASSETS}"; then
+    MISSING+=("${expected}")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "ERROR: the following expected artifacts are MISSING from the release:"
+  for m in "${MISSING[@]}"; do
+    echo "  - ${m}"
+  done
+  exit 1
+fi
+
+echo "==> All expected artifacts are present."
+
+# Download artifacts and verify checksums
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+echo ""
+echo "==> Downloading artifacts to verify checksums..."
+gh release download "${TAG}" --repo "${REPO}" --dir "${WORKDIR}"
+
+echo ""
+echo "==> Verifying checksums..."
+cd "${WORKDIR}"
+
+if [[ ! -f "checksums.txt" ]]; then
+  echo "ERROR: checksums.txt was not found after download"
+  exit 1
+fi
+
+echo "  Contents of checksums.txt:"
+sed 's/^/    /' < checksums.txt
+echo ""
+
+# Verify each file listed in checksums.txt
+FAILED=0
+CHECKED=0
+while IFS= read -r line; do
+  # Skip empty lines
+  [[ -z "${line}" ]] && continue
+  # Each line is: <hash>  <filename> (two spaces between hash and name)
+  CHECKSUM=$(awk '{print $1}' <<< "${line}")
+  FILENAME=$(awk '{print $2}' <<< "${line}")
+
+  if [[ -z "${FILENAME}" || -z "${CHECKSUM}" ]]; then
+    echo "  ! Skipping malformed line: ${line}"
+    continue
+  fi
+
+  if [[ -f "${FILENAME}" ]]; then
+    ACTUAL=$(${SHA256_CMD} "${FILENAME}" | awk '{print $1}')
+    if [[ "${ACTUAL}" == "${CHECKSUM}" ]]; then
+      echo "  ✓ ${FILENAME}"
+      CHECKED=$((CHECKED + 1))
+    else
+      echo "  ✗ ${FILENAME} — CHECKSUM MISMATCH"
+      echo "    expected: ${CHECKSUM}"
+      echo "    actual:   ${ACTUAL}"
+      FAILED=1
+    fi
+  else
+    echo "  ? ${FILENAME} — not downloaded (skipped)"
+  fi
+done < checksums.txt
+
+echo ""
+if [[ ${FAILED} -ne 0 ]]; then
+  echo "ERROR: one or more checksum verifications FAILED"
+  exit 1
+fi
+
+if [[ ${CHECKED} -eq 0 ]]; then
+  echo "ERROR: no files were checked against checksums — something is wrong"
+  exit 1
+fi
+
+echo "==> All checksums verified successfully (${CHECKED} files)."
+echo "==> Release ${TAG} is complete and valid."

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -207,6 +207,16 @@ while IFS= read -r line; do
   fi
 done < checksums.txt
 
+# Ensure checksums.txt covers all expected artifacts (except itself)
+CHECKSUM_FILENAMES=$(awk 'NF {print $2}' checksums.txt)
+for expected in "${EXPECTED_ASSETS[@]}"; do
+  [[ "${expected}" == "checksums.txt" ]] && continue
+  if ! grep -qxF "${expected}" <<< "${CHECKSUM_FILENAMES}"; then
+    echo "  ✗ ${expected} — missing from checksums.txt"
+    FAILED=1
+  fi
+done
+
 echo ""
 if [[ ${FAILED} -ne 0 ]]; then
   echo "ERROR: one or more checksum verifications FAILED"

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -85,10 +85,12 @@ ASSETS=""
 
 for ((i = 1; i <= MAX_RETRIES; i++)); do
   echo "  Attempt ${i}/${MAX_RETRIES}: listing release assets..."
-  ASSETS=$(gh release view "${TAG}" --repo "${REPO}" --json assets -q '.assets[].name' 2>/dev/null || true)
-  if [[ -n "${ASSETS}" ]]; then
-    break
+  if ASSETS=$(gh release view "${TAG}" --repo "${REPO}" --json assets -q '.assets[].name' 2>&1); then
+    if [[ -n "${ASSETS}" ]]; then
+      break
+    fi
   fi
+  ASSETS=""
   if [[ ${i} -lt ${MAX_RETRIES} ]]; then
     echo "  Release not found yet, retrying in ${RETRY_DELAY}s..."
     sleep "${RETRY_DELAY}"
@@ -125,6 +127,32 @@ if [[ ${#MISSING[@]} -gt 0 ]]; then
 fi
 
 echo "==> All expected artifacts are present."
+
+# Verify that checksums.txt has an entry for each expected asset (excluding checksums.txt itself)
+echo ""
+echo "==> Verifying checksums.txt coverage..."
+CHECKSUMS_CONTENT=$(gh release download "${TAG}" --repo "${REPO}" --pattern "checksums.txt" --output - 2>/dev/null || true)
+if [[ -z "${CHECKSUMS_CONTENT}" ]]; then
+  echo "ERROR: could not download checksums.txt to validate coverage"
+  exit 1
+fi
+
+UNCOVERED=()
+for expected in "${EXPECTED_ASSETS[@]}"; do
+  [[ "${expected}" == "checksums.txt" ]] && continue
+  if ! grep -qF "${expected}" <<< "${CHECKSUMS_CONTENT}"; then
+    UNCOVERED+=("${expected}")
+  fi
+done
+
+if [[ ${#UNCOVERED[@]} -gt 0 ]]; then
+  echo "ERROR: the following expected artifacts are NOT listed in checksums.txt:"
+  for u in "${UNCOVERED[@]}"; do
+    echo "  - ${u}"
+  done
+  exit 1
+fi
+echo "  All expected artifacts have checksum entries."
 
 # Download artifacts and verify checksums
 WORKDIR=$(mktemp -d)
@@ -174,7 +202,8 @@ while IFS= read -r line; do
       FAILED=1
     fi
   else
-    echo "  ? ${FILENAME} — not downloaded (skipped)"
+    echo "  ✗ ${FILENAME} — MISSING from download directory"
+    FAILED=1
   fi
 done < checksums.txt
 

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -23,7 +23,7 @@
 #
 # Requirements:
 #   - gh CLI installed and authenticated (gh auth login)
-#   - For CI: GITHUB_TOKEN env var is set automatically by GitHub Actions
+#   - For CI: set GH_TOKEN in the workflow step env (or GITHUB_TOKEN)
 #
 # Example:
 #   ./scripts/verify-release-artifacts.sh v1.5.11
@@ -85,7 +85,7 @@ ASSETS=""
 
 for ((i = 1; i <= MAX_RETRIES; i++)); do
   echo "  Attempt ${i}/${MAX_RETRIES}: listing release assets..."
-  if ASSETS=$(gh release view "${TAG}" --repo "${REPO}" --json assets -q '.assets[].name' 2>&1); then
+  if ASSETS=$(gh release view "${TAG}" --repo "${REPO}" --json assets -q '.assets[].name'); then
     if [[ -n "${ASSETS}" ]]; then
       break
     fi
@@ -131,9 +131,12 @@ echo "==> All expected artifacts are present."
 # Verify that checksums.txt has an entry for each expected asset (excluding checksums.txt itself)
 echo ""
 echo "==> Verifying checksums.txt coverage..."
-CHECKSUMS_CONTENT=$(gh release download "${TAG}" --repo "${REPO}" --pattern "checksums.txt" --output - 2>/dev/null || true)
-if [[ -z "${CHECKSUMS_CONTENT}" ]]; then
+if ! CHECKSUMS_CONTENT=$(gh release download "${TAG}" --repo "${REPO}" --pattern "checksums.txt" --output -); then
   echo "ERROR: could not download checksums.txt to validate coverage"
+  exit 1
+fi
+if [[ -z "${CHECKSUMS_CONTENT}" ]]; then
+  echo "ERROR: checksums.txt is empty"
   exit 1
 fi
 
@@ -155,7 +158,7 @@ fi
 echo "  All expected artifacts have checksum entries."
 
 # Download artifacts and verify checksums
-WORKDIR=$(mktemp -d)
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/verify-release.XXXXXX")
 trap 'rm -rf "${WORKDIR}"' EXIT
 
 echo ""


### PR DESCRIPTION
## Description
- What changed: Added a verification step to the release workflow that runs after goreleaser, plus a reusable script at `scripts/verify-release-artifacts.sh`
- Why it's needed: Goreleaser recently failed silently — no artifacts published to the GH release page. We need the workflow to fail visibly when this happens.
- How it works: After goreleaser completes, the new step lists release assets via `gh`, checks all expected artifacts are present, downloads them, and validates SHA256 checksums against `checksums.txt`. Fails the workflow on any missing artifact or checksum mismatch.

---

## Type of Change
- [x] Enhancement

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [x] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. Run locally against an existing release: `./scripts/verify-release-artifacts.sh v1.5.11`
2. Trigger via `workflow_dispatch` on a test tag to validate end-to-end

---

## Additional Notes (Optional)
- The script is portable (Linux + macOS) and shellcheck-clean
- Retry logic handles release propagation delays (up to 50s)
- Can be run standalone for ad-hoc verification of past releases

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to generate the verification script and workflow integration.
  - The author has fully verified all code.