### PR TITLE
Fix Rendered condition observedGeneration stale after lifecycle changes

### DIFF
--- a/controllers/packagerevisions/pkg/controllers/packagerevision/packagerevision_controller.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/packagerevision_controller.go
@@ -234,6 +234,7 @@ func (r *PackageRevisionReconciler) reconcileRender(ctx context.Context, pr *por
 
 	requested, annotationTrigger, sourceTrigger := renderTrigger(pr)
 	if !annotationTrigger && !sourceTrigger {
+		r.refreshRenderedGeneration(ctx, pr)
 		return nil, nil
 	}
 

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status.go
@@ -113,6 +113,23 @@ func (r *PackageRevisionReconciler) updateRenderStatus(ctx context.Context, pr *
 	}
 }
 
+// refreshRenderedGeneration bumps the Rendered condition's observedGeneration
+// when no render is needed but the condition is stale (e.g. after lifecycle patch).
+// It preserves all other condition fields (reason, message, lastTransitionTime)
+// to avoid misleading status churn.
+func (r *PackageRevisionReconciler) refreshRenderedGeneration(ctx context.Context, pr *porchv1alpha2.PackageRevision) {
+	for _, c := range pr.Status.Conditions {
+		if c.Type == porchv1alpha2.ConditionRendered && c.Status == metav1.ConditionTrue && c.ObservedGeneration < pr.Generation {
+			// Only bump observedGeneration — preserve existing reason, message, and transition time.
+			c.ObservedGeneration = pr.Generation
+			r.updateRenderStatus(ctx, pr, pr.Status.RenderingPrrResourceVersion, "",
+				c,
+			)
+			return
+		}
+	}
+}
+
 // setSourceFailed logs the error and sets Ready=False and Rendered=False.
 // Rendered is set even though rendering was never attempted — the package
 // content didn't land successfully, so "not rendered" is accurate.

--- a/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
+++ b/controllers/packagerevisions/pkg/controllers/packagerevision/status_test.go
@@ -158,6 +158,68 @@ func TestUpdateRenderStatusComplete(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, captured.Conditions[0].Status)
 }
 
+func TestRefreshRenderedGenerationBumpsStale(t *testing.T) {
+	mockClient := mockclient.NewMockClient(t)
+	captured := captureStatusPatch(t, mockClient)
+
+	r := &PackageRevisionReconciler{Client: mockClient}
+	pr := basePR()
+	pr.Generation = 5
+	originalTime := metav1.NewTime(time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC))
+	pr.Status.RenderingPrrResourceVersion = "prev-render-version"
+	pr.Status.Conditions = []metav1.Condition{
+		{
+			Type:               porchv1alpha2.ConditionRendered,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 2,
+			Reason:             porchv1alpha2.ReasonRendered,
+			Message:            "render complete",
+			LastTransitionTime: originalTime,
+		},
+	}
+
+	r.refreshRenderedGeneration(t.Context(), pr)
+
+	assert.Len(t, captured.Conditions, 1)
+	assert.Equal(t, porchv1alpha2.ConditionRendered, captured.Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, captured.Conditions[0].Status)
+	assert.Equal(t, int64(5), captured.Conditions[0].ObservedGeneration)
+	// Verify existing fields are preserved, not overwritten.
+	assert.Equal(t, porchv1alpha2.ReasonRendered, captured.Conditions[0].Reason)
+	assert.Equal(t, "render complete", captured.Conditions[0].Message)
+	assert.Equal(t, originalTime, captured.Conditions[0].LastTransitionTime)
+	// Verify renderingPrrResourceVersion is preserved.
+	assert.Equal(t, "prev-render-version", captured.RenderingPrrResourceVersion)
+}
+
+func TestRefreshRenderedGenerationSkipsWhenCurrent(t *testing.T) {
+	mockClient := mockclient.NewMockClient(t)
+	// No Status().Patch expected — should be a no-op.
+
+	r := &PackageRevisionReconciler{Client: mockClient}
+	pr := basePR()
+	pr.Generation = 3
+	pr.Status.Conditions = []metav1.Condition{
+		{Type: porchv1alpha2.ConditionRendered, Status: metav1.ConditionTrue, ObservedGeneration: 3},
+	}
+
+	r.refreshRenderedGeneration(t.Context(), pr)
+}
+
+func TestRefreshRenderedGenerationSkipsWhenNotTrue(t *testing.T) {
+	mockClient := mockclient.NewMockClient(t)
+	// No Status().Patch expected — Rendered is False, not our concern.
+
+	r := &PackageRevisionReconciler{Client: mockClient}
+	pr := basePR()
+	pr.Generation = 5
+	pr.Status.Conditions = []metav1.Condition{
+		{Type: porchv1alpha2.ConditionRendered, Status: metav1.ConditionFalse, ObservedGeneration: 2},
+	}
+
+	r.refreshRenderedGeneration(t.Context(), pr)
+}
+
 func TestSetRenderFailed(t *testing.T) {
 	mockClient := mockclient.NewMockClient(t)
 

--- a/test/e2e/crd/lifecycle_test.go
+++ b/test/e2e/crd/lifecycle_test.go
@@ -51,6 +51,18 @@ var _ = Describe("Lifecycle", Ordered, Label("lifecycle"), func() {
 		By("verifying publish metadata")
 		Expect(pr.Status.PublishedBy).NotTo(BeEmpty())
 		Expect(pr.Status.PublishedAt).NotTo(BeNil())
+
+		By("verifying Rendered condition observedGeneration is current after lifecycle changes")
+		Expect(k8sClient.Get(env.Ctx, client.ObjectKeyFromObject(pr), pr)).To(Succeed())
+		foundRendered := false
+		for _, c := range pr.Status.Conditions {
+			if c.Type == porchv1alpha2.ConditionRendered {
+				foundRendered = true
+				Expect(c.ObservedGeneration).To(Equal(pr.Generation),
+					"Rendered observedGeneration should match current generation after lifecycle transition")
+			}
+		}
+		Expect(foundRendered).To(BeTrue(), "expected Rendered condition to be present on the PackageRevision")
 	})
 
 	It("should transition Published → DeletionProposed → Published (undo)", func() {


### PR DESCRIPTION
## Description
- What changed: Added `refreshRenderedGeneration()` — bumps the Rendered condition's `observedGeneration` when no render is needed but the condition is behind `metadata.generation`.
- Why it's needed: After a lifecycle patch (e.g. propose/publish), `metadata.generation` increments but the Rendered condition's `observedGeneration` stayed at the render-time generation. `kubectl wait --for=condition=Rendered` (kubectl v1.35+) treats this as stale and hangs forever.
- How it works: In the `reconcileRender` skip path (no render trigger), check if Rendered=True with a stale generation. If so, SSA-patch it with the current generation via the existing render field manager.

## Related Issue(s)
- Fixes #1075

## Type of Change
- [x] Bug fix
- [x] Tests

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [x] All tests and gating checks pass

## Testing Instructions
1. `make run-in-kind-v1alpha2`
2. Create a v1alpha2 package, push content, wait for Rendered=True
3. Patch lifecycle to Proposed
4. `kubectl wait --for=condition=Rendered --timeout=10s` — should succeed immediately (previously hung)
5. `make test-e2e-crd` — lifecycle test verifies observedGeneration is current

## AI Disclosure
- [x] **I have used AI in the creation of this PR.**

- Kiro to identify the root cause (split field manager design causing stale observedGeneration), implement the fix, and generate unit + E2E tests.
- The author has fully verified all code.