### PR TITLE
Fix E2E deploy timeout caused by reconcile race in kpt live apply

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -105,6 +105,9 @@ run-in-kind-db-cache-no-git-push-drafts: load-images-to-kind deployment-config d
 
 .PHONY: destroy
 destroy:## Deletes all porch resources installed by the last run-in-kind-* command
+	@if [ -d "$(DEPLOYPORCHCONFIGDIR)-post" ]; then \
+		kubectl delete -f "$(DEPLOYPORCHCONFIGDIR)-post/" --ignore-not-found; \
+	fi
 	kpt live destroy $(DEPLOYPORCHCONFIGDIR)
 
 .PHONY: deployment-config 
@@ -138,7 +141,7 @@ deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYP
 		kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s; \
 	fi
 	@if [ -d "$(DEPLOYPORCHCONFIGDIR)-post" ]; then \
-		kubectl apply --server-side -f $(DEPLOYPORCHCONFIGDIR)-post/; \
+		kubectl apply --server-side --force-conflicts -f "$(DEPLOYPORCHCONFIGDIR)-post/"; \
 	fi
 	@echo "Done."
 

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -137,6 +137,9 @@ deploy-current-config:## Deploy the configuration that is currently in $(DEPLOYP
 	@if [ "$(SKIP_CONTROLLER_BUILD)" != "true" ]; then \
 		kubectl rollout status deployment porch-controllers --namespace porch-system --timeout=180s; \
 	fi
+	@if [ -d "$(DEPLOYPORCHCONFIGDIR)-post" ]; then \
+		kubectl apply --server-side -f $(DEPLOYPORCHCONFIGDIR)-post/; \
+	fi
 	@echo "Done."
 
 .PHONY: reload-function-runner

--- a/scripts/create-deployment-blueprint.sh
+++ b/scripts/create-deployment-blueprint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022-2025 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -357,6 +357,12 @@ function main() {
 
   # Porch Deployment Config
   cp ${PORCH_DIR}/deployments/porch/*.yaml "${PORCH_DIR}/deployments/porch/Kptfile" "${DESTINATION}"
+
+  # Move functionconfig/servicetemplate CR instances to a separate post-deploy directory.
+  # These are applied after porch-server is healthy to avoid kpt live apply reconcile timeouts
+  # caused by applying a CRD and its instances in the same operation.
+  mkdir -p "${DESTINATION}-post"
+  mv "${DESTINATION}/22-function-templates.yaml" "${DESTINATION}/23-function-configurations.yaml" "${DESTINATION}-post/"
   # Copy Porch controller manager rbac
   cp ${PORCH_DIR}/controllers/config/rbac/role.yaml "${DESTINATION}/9-porch-controller-clusterrole.yaml"
 

--- a/scripts/create-deployment-blueprint.sh
+++ b/scripts/create-deployment-blueprint.sh
@@ -358,9 +358,10 @@ function main() {
   # Porch Deployment Config
   cp ${PORCH_DIR}/deployments/porch/*.yaml "${PORCH_DIR}/deployments/porch/Kptfile" "${DESTINATION}"
 
-  # Move functionconfig/servicetemplate CR instances to a separate post-deploy directory.
-  # These are applied after porch-server is healthy to avoid kpt live apply reconcile timeouts
+  # Move FunctionConfig/ServiceTemplate CR instances to a separate post-deploy directory.
+  # These are applied after the main deployment rollout checks pass to avoid kpt live apply reconcile timeouts
   # caused by applying a CRD and its instances in the same operation.
+  rm -rf "${DESTINATION}-post"
   mkdir -p "${DESTINATION}-post"
   mv "${DESTINATION}/22-function-templates.yaml" "${DESTINATION}/23-function-configurations.yaml" "${DESTINATION}-post/"
   # Copy Porch controller manager rbac

--- a/scripts/create-deployment-config.sh
+++ b/scripts/create-deployment-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 The kpt Authors
+# Copyright 2025-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ source "$(dirname "$0")/common.sh"
 
 echo "Creating deployment configuration..."
 
-rm -rf "${DEPLOYPORCHCONFIGDIR}" || true
+rm -rf "${DEPLOYPORCHCONFIGDIR}" "${DEPLOYPORCHCONFIGDIR}-post" || true
 mkdir -p "${DEPLOYPORCHCONFIGDIR}"
 
 ./scripts/create-deployment-blueprint.sh \

--- a/scripts/create-deployment-kpt.sh
+++ b/scripts/create-deployment-kpt.sh
@@ -118,6 +118,11 @@ function deploy-porch-dev-pkg {
   kpt fn render ${DESTINATION}/porch
   kpt live init ${DESTINATION}/porch
   kpt live apply ${DESTINATION}/porch
+  # Apply CRD instances after the main deployment to avoid reconcile timeouts
+  # caused by applying a CRD and its instances in the same operation.
+  if [ -d "${DESTINATION}/porch-post" ]; then
+    kubectl apply --server-side --force-conflicts -f "${DESTINATION}/porch-post/"
+  fi
 }
 
 function load-custom-images {
@@ -166,6 +171,16 @@ for resource in ctx.resource_list["items"]:
   "${WRAPPER_SERVER_IMAGE}"
 
   echo "Deploying porch with newly built images..."
+  # Move FunctionConfig/ServiceTemplate CR instances to a separate post-deploy directory.
+  # These are applied after the main deployment to avoid kpt live apply reconcile timeouts
+  # caused by applying a CRD and its instances in the same operation.
+  rm -rf "${DESTINATION}/porch-post"
+  mkdir -p "${DESTINATION}/porch-post"
+  for f in "${DESTINATION}/porch/22-function-templates.yaml" "${DESTINATION}/porch/23-function-configurations.yaml"; do
+    if [ -f "$f" ]; then
+      mv "$f" "${DESTINATION}/porch-post/"
+    fi
+  done
   deploy-porch-dev-pkg
 
   echo


### PR DESCRIPTION
 ## Description
  - **What changed**: Moved `FunctionConfig` and `ServiceTemplate` CR instances out of the main `kpt live apply` package and applied them separately with `kubectl apply` after all deployments are healthy.
  - **Why it's needed**: The E2E CI workflow intermittently gets stuck at the "Deploy porch kpt pkg" step, timing out after 300s. This happens because `kpt live apply` cannot reliably track the reconcile status of CR instances when their CRD is created in the same apply operation - the status watcher fails to establish a watch on the newly-created type within a single apply.
  - **How it works**:
    - `create-deployment-blueprint.sh` now moves `22-function-templates.yaml` and `23-function-configurations.yaml` to a `${DESTINATION}-post` directory after copying all deployment files.
    - `deploy-current-config` in `make/deploy.mk` applies the post-deploy CRs with `kubectl apply` after all rollout status checks pass.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to analyse CI failure logs, identify root cause.