### PR TITLE
Expose apiserver library metrics on otel port (default 9464)

### DIFF
--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 	controllerruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -208,6 +209,7 @@ func startMetricsServerIfConfigured(res *OTelResources) error {
 	gatherers := prometheus.Gatherers{
 		prometheus.DefaultGatherer,
 		controllerruntimemetrics.Registry,
+		legacyregistry.DefaultGatherer,
 	}
 	handler := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.ContinueOnError,

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -29,6 +29,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	otlpmetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	otlptraces "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -60,6 +62,16 @@ func TestPrometheusHTTPServer(t *testing.T) {
 	t.Setenv(ENV_OTEL_EXPORTER_PROMETHEUS_HOST, "0.0.0.0")
 	t.Setenv(ENV_OTEL_EXPORTER_PROMETHEUS_PORT, fmt.Sprintf("%d", port))
 
+	// Register a trivial metric into the k8s legacy registry to verify it
+	// appears in the unified /metrics response.
+	legacyCounter := compbasemetrics.NewCounter(&compbasemetrics.CounterOpts{
+		Name: "test_legacy_registry_total",
+		Help: "A test counter registered in the k8s legacy registry",
+	})
+	legacyregistry.MustRegister(legacyCounter)
+	legacyCounter.Inc()
+	defer legacyregistry.Reset()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -74,7 +86,16 @@ func TestPrometheusHTTPServer(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Contains(t, string(body), "target_info")
+	bodyStr := string(body)
+
+	// Verify OTel metrics are present
+	assert.Contains(t, bodyStr, "target_info")
+
+	// Verify the legacy registry metric appears (apiserver library metrics path)
+	assert.Contains(t, bodyStr, "test_legacy_registry_total")
+
+	// Verify no gather errors are reported in the response
+	assert.NotContains(t, bodyStr, "error gathering metrics")
 }
 
 func TestPrometheusHTTPServerInvalidPort(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Expose apiserver library metrics on otel port (9464)

resolves #1049 
---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Add legacyregistry.DefaultGatherer to the Prometheus gatherers list in internal/telemetry/otel.go, merging k8s apiserver library metrics into the OTel metrics server on port 9464.
- Why it’s needed: With a single endpoint, Prometheus can scrape all metrics (application + apiserver) without auth or RBAC setup, which is really helpful for analysis and debugging.
- How it works:  The k8s apiserver library registers its metrics (apiserver_request_total, apiserver_request_duration_seconds, admission, workqueue, flow control, etc.) into a separate legacyregistry rather than prometheus.DefaultRegisterer. By adding legacyregistry.DefaultGatherer to the gatherers slice in startMetricsServerIfConfigured(), the unauthenticated HTTP server on port 9464 now collects and exposes those metrics alongside the existing OTel and controller-runtime metrics on every /metrics scrape.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Microsoft Copilot to analyse the code.
  - Kiro to generate unit tests.
