### PR TITLE
Filter nil upstream values from sql query - align with 1.5 code

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -486,6 +486,7 @@ func findUpstreamRefsFromDB(ctx context.Context, namespace, prName string) (stri
 		SELECT k8s_name FROM package_revisions
 		WHERE k8s_name_space=$1
 		  AND revision != -1
+		  AND upstream_ref_name != ''
 		  AND upstream_ref_name=$2
 		LIMIT 1
 	`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Filter nil upstream values from sql query - align with 1.5 code

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  Added AND upstream_ref_name != '' to the findUpstreamRefsFromDB SQL WHERE clause.
- Why it’s needed:  This allows for better partial indexing and aligns with 1.5 branch's code.
- How it works:  Sql filters out nil values of upstream_ref_name.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [ ] Tests added/updated  
- [ ] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

If so, please describe how:
  - E.g. Microsoft Copilot to analyse the code.
  - E.g. Claude code to generate the function someNewFunctionIAdded().
  - E.g. Kiro to generate unit tests.
