### PR TITLE
Modernize Go idioms and remove outdated patterns

### DIFF
--- a/api/porch/fuzzer/fuzzer.go
+++ b/api/porch/fuzzer/fuzzer.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2026 The kpt Authors.
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/porch/fuzzer/fuzzer.go
+++ b/api/porch/fuzzer/fuzzer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
-	return []interface{}{}
+var Funcs = func(codecs runtimeserializer.CodecFactory) []any {
+	return []any{}
 }

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection-with-workspacename_test.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection-with-workspacename_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt Authors
+// Copyright 2023, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@ package packagevariant
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 	"testing"
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
@@ -234,9 +235,9 @@ spec:
 			require.Equal(t, len(tc.expected), len(actualInjectionPoints))
 
 			// ensure a stable ordering
-			sort.Slice(actualInjectionPoints,
-				func(i, j int) bool {
-					return actualInjectionPoints[i].conditionType < actualInjectionPoints[j].conditionType
+			slices.SortFunc(actualInjectionPoints,
+				func(a, b *injectionPoint) int {
+					return strings.Compare(a.conditionType, b.conditionType)
 				})
 			for i, ip := range actualInjectionPoints {
 				require.Equal(t, tc.expected[i].conditionType, ip.conditionType)

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The kpt Authors
+// Copyright 2023-2024, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	api "github.com/kptdev/porch/api/porchconfig/v1alpha1"
@@ -149,7 +149,7 @@ func parseFiles(prr *porchapi.PackageRevisionResources) (map[string]fn.KubeObjec
 		// Convert to KubeObjects for easier processing
 		kos, err := fn.ParseKubeObjects([]byte(r))
 		if err != nil {
-			return nil, fmt.Errorf("%s: %s", file, err.Error())
+			return nil, fmt.Errorf("%s: %w", file, err)
 		}
 		result[file] = kos
 	}
@@ -341,7 +341,7 @@ func setInjectionPointConditionsAndGates(kptfileKubeObject *fn.KubeObject, injec
 	for k := range gateMap {
 		gates = append(gates, kptfilev1.ReadinessGate{ConditionType: k})
 	}
-	sort.SliceStable(gates, func(i, j int) bool { return gates[i].ConditionType < gates[j].ConditionType })
+	slices.SortStableFunc(gates, func(a, b kptfilev1.ReadinessGate) int { return strings.Compare(a.ConditionType, b.ConditionType) })
 
 	if gates != nil {
 		info.ReadinessGates = gates
@@ -353,7 +353,7 @@ func setInjectionPointConditionsAndGates(kptfileKubeObject *fn.KubeObject, injec
 
 	// update the status conditions
 	if conditions != nil {
-		sort.SliceStable(conditions, func(i, j int) bool { return conditions[i].Type < conditions[j].Type })
+		slices.SortStableFunc(conditions, func(a, b metav1.Condition) int { return strings.Compare(a.Type, b.Type) })
 		status.Conditions = convertConditionsFromMetaToKptfile(conditions)
 		err = kptfileKubeObject.SetNestedField(status, "status")
 		if err != nil {

--- a/controllers/packagevariants/pkg/controllers/packagevariant/injection_test.go
+++ b/controllers/packagevariants/pkg/controllers/packagevariant/injection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023, 2025 The kpt Authors
+// Copyright 2023, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@ package packagevariant
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 	"testing"
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
@@ -234,9 +235,9 @@ spec:
 			require.Equal(t, len(tc.expected), len(actualInjectionPoints))
 
 			// ensure a stable ordering
-			sort.Slice(actualInjectionPoints,
-				func(i, j int) bool {
-					return actualInjectionPoints[i].conditionType < actualInjectionPoints[j].conditionType
+			slices.SortFunc(actualInjectionPoints,
+				func(a, b *injectionPoint) int {
+					return strings.Compare(a.conditionType, b.conditionType)
 				})
 			for i, ip := range actualInjectionPoints {
 				require.Equal(t, tc.expected[i].conditionType, ip.conditionType)

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -276,7 +276,7 @@ func (r *PackageVariantSetReconciler) ensurePackageVariants(ctx context.Context,
 		client.MatchingLabels{
 			PackageVariantSetOwnerLabel: string(pvs.UID),
 		}); err != nil {
-		return fmt.Errorf("error listing package variants %v", err)
+		return fmt.Errorf("error listing package variants %w", err)
 	}
 
 	// existingPackageVariantMap holds the PackageVariant objects that currently exist.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -276,7 +276,7 @@ func (r *PackageVariantSetReconciler) ensurePackageVariants(ctx context.Context,
 		client.MatchingLabels{
 			PackageVariantSetOwnerLabel: string(pvs.UID),
 		}); err != nil {
-		return fmt.Errorf("error listing package variants %w", err)
+		return fmt.Errorf("error listing package variants: %w", err)
 	}
 
 	// existingPackageVariantMap holds the PackageVariant objects that currently exist.

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023, 2025 The kpt Authors
+// Copyright 2023, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@ package packagevariantset
 
 import (
 	"context"
-	"sort"
+	"slices"
+	"strings"
 	"testing"
 
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
@@ -27,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -135,8 +137,8 @@ func TestEnsurePackageVariants(t *testing.T) {
 	require.Equal(t, "my-pvs-dnrepo2-dnpkg2", fc.updated[0].GetName())
 	require.Equal(t, 2, len(fc.created))
 	// ordering of calls to create is not stable (map iteration)
-	sort.Slice(fc.created, func(i, j int) bool {
-		return fc.created[i].GetName() < fc.created[j].GetName()
+	slices.SortFunc(fc.created, func(a, b client.Object) int {
+		return strings.Compare(a.GetName(), b.GetName())
 	})
 	require.Equal(t, "my-pvs-dnrepo3-dnpkg3", fc.created[0].GetName())
 	require.Equal(t, "my-pvs-dnrepo4-supersupersuperlooooooooooooooooooooooo-bec36506", fc.created[1].GetName())

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/render.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/render.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt Authors
+// Copyright 2023, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 
 	"github.com/google/cel-go/cel"
 	api "github.com/kptdev/porch/api/porchconfig/v1alpha2"
@@ -73,7 +73,7 @@ func renderPackageVariantSpec(ctx context.Context, pvs *api.PackageVariantSet, r
 		if pvt.Downstream.RepoExpr != nil && *pvt.Downstream.RepoExpr != "" {
 			repo, err = evalExpr(*pvt.Downstream.RepoExpr, inputs)
 			if err != nil {
-				return nil, fmt.Errorf("template.downstream.repoExpr: %s", err.Error())
+				return nil, fmt.Errorf("template.downstream.repoExpr: %w", err)
 			}
 		}
 
@@ -103,7 +103,7 @@ func renderPackageVariantSpec(ctx context.Context, pvs *api.PackageVariantSet, r
 		if pvt.Downstream.PackageExpr != nil && *pvt.Downstream.PackageExpr != "" {
 			spec.Downstream.Package, err = evalExpr(*pvt.Downstream.PackageExpr, inputs)
 			if err != nil {
-				return nil, fmt.Errorf("template.downstream.packageExpr: %s", err.Error())
+				return nil, fmt.Errorf("template.downstream.packageExpr: %w", err)
 			}
 		}
 	}
@@ -155,7 +155,7 @@ func renderPackageVariantSpec(ctx context.Context, pvs *api.PackageVariantSet, r
 		if injTemplate.NameExpr != nil && *injTemplate.NameExpr != "" {
 			injector.Name, err = evalExpr(*injTemplate.NameExpr, inputs)
 			if err != nil {
-				return nil, fmt.Errorf("template.injectors[%d].nameExpr: %s", i, err.Error())
+				return nil, fmt.Errorf("template.injectors[%d].nameExpr: %w", i, err)
 			}
 		}
 
@@ -180,7 +180,7 @@ func renderPackageVariantSpec(ctx context.Context, pvs *api.PackageVariantSet, r
 	return spec, nil
 }
 
-func renderFunctionTemplateList(field string, templateList []api.FunctionTemplate, inputs map[string]interface{}) ([]kptfilev1.Function, error) {
+func renderFunctionTemplateList(field string, templateList []api.FunctionTemplate, inputs map[string]any) ([]kptfilev1.Function, error) {
 	var results []kptfilev1.Function
 	for i, ft := range templateList {
 		var err error
@@ -195,8 +195,8 @@ func renderFunctionTemplateList(field string, templateList []api.FunctionTemplat
 	return results, nil
 }
 
-func buildBaseInputs(upstreamPR *porchapi.PackageRevision, downstream pvContext) (map[string]interface{}, error) {
-	inputs := make(map[string]interface{}, 5)
+func buildBaseInputs(upstreamPR *porchapi.PackageRevision, downstream pvContext) (map[string]any, error) {
+	inputs := make(map[string]any, 5)
 	inputs[RepoDefaultVarName] = downstream.repoDefault
 	inputs[PackageDefaultVarName] = downstream.packageDefault
 
@@ -222,9 +222,9 @@ func buildBaseInputs(upstreamPR *porchapi.PackageRevision, downstream pvContext)
 	return inputs, nil
 }
 
-func objectToInput(obj interface{}) (map[string]interface{}, error) {
+func objectToInput(obj any) (map[string]any, error) {
 
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 
 	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
@@ -243,7 +243,7 @@ func objectToInput(obj interface{}) (map[string]interface{}, error) {
 	return result, nil
 }
 
-func copyAndOverlayMapExpr(fieldName string, inMap map[string]string, mapExprs []api.MapExpr, inputs map[string]interface{}) (map[string]string, error) {
+func copyAndOverlayMapExpr(fieldName string, inMap map[string]string, mapExprs []api.MapExpr, inputs map[string]any) (map[string]string, error) {
 	outMap := make(map[string]string, len(inMap))
 	for k, v := range inMap {
 		outMap[k] = v
@@ -258,7 +258,7 @@ func copyAndOverlayMapExpr(fieldName string, inMap map[string]string, mapExprs [
 		if me.KeyExpr != nil {
 			k, err = evalExpr(*me.KeyExpr, inputs)
 			if err != nil {
-				return nil, fmt.Errorf("%s[%d].keyExpr: %s", fieldName, i, err.Error())
+				return nil, fmt.Errorf("%s[%d].keyExpr: %w", fieldName, i, err)
 			}
 		}
 		if me.Value != nil {
@@ -267,7 +267,7 @@ func copyAndOverlayMapExpr(fieldName string, inMap map[string]string, mapExprs [
 		if me.ValueExpr != nil {
 			v, err = evalExpr(*me.ValueExpr, inputs)
 			if err != nil {
-				return nil, fmt.Errorf("%s[%d].valueExpr: %s", fieldName, i, err.Error())
+				return nil, fmt.Errorf("%s[%d].valueExpr: %w", fieldName, i, err)
 			}
 		}
 		outMap[k] = v
@@ -280,7 +280,7 @@ func copyAndOverlayMapExpr(fieldName string, inMap map[string]string, mapExprs [
 	return outMap, nil
 }
 
-func copyAndOverlayStringSlice(fieldName string, in, exprs []string, inputs map[string]interface{}) ([]string, error) {
+func copyAndOverlayStringSlice(fieldName string, in, exprs []string, inputs map[string]any) ([]string, error) {
 	outMap := make(map[string]bool, len(in)+len(exprs))
 
 	for _, v := range in {
@@ -289,7 +289,7 @@ func copyAndOverlayStringSlice(fieldName string, in, exprs []string, inputs map[
 	for i, e := range exprs {
 		v, err := evalExpr(e, inputs)
 		if err != nil {
-			return nil, fmt.Errorf("%s[%d]: %s", fieldName, i, err.Error())
+			return nil, fmt.Errorf("%s[%d]: %w", fieldName, i, err)
 		}
 		outMap[v] = true
 	}
@@ -302,11 +302,11 @@ func copyAndOverlayStringSlice(fieldName string, in, exprs []string, inputs map[
 	for k := range outMap {
 		out = append(out, k)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out, nil
 }
 
-func evalExpr(expr string, inputs map[string]interface{}) (string, error) {
+func evalExpr(expr string, inputs map[string]any) (string, error) {
 	prog, err := compileExpr(expr)
 	if err != nil {
 		return "", err

--- a/controllers/packagevariantsets/pkg/controllers/packagevariantset/render_test.go
+++ b/controllers/packagevariantsets/pkg/controllers/packagevariantset/render_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023, 2025 The kpt Authors
+// Copyright 2023, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -490,7 +490,7 @@ func TestRenderPackageVariantSpec(t *testing.T) {
 }
 
 func TestEvalExpr(t *testing.T) {
-	baseInputs := map[string]interface{}{
+	baseInputs := map[string]any{
 		"repoDefault":    "foo-repo",
 		"packageDefault": "bar-package",
 	}
@@ -502,7 +502,7 @@ func TestEvalExpr(t *testing.T) {
 
 	testCases := map[string]struct {
 		expr           string
-		target         interface{}
+		target         any
 		expectedResult string
 		expectedErr    string
 	}{
@@ -575,7 +575,7 @@ func TestEvalExpr(t *testing.T) {
 }
 
 func TestCopyAndOverlayMapExpr(t *testing.T) {
-	baseInputs := map[string]interface{}{
+	baseInputs := map[string]any{
 		"repoDefault":    "foo-repo",
 		"packageDefault": "bar-package",
 	}

--- a/controllers/repositories/pkg/controllers/repository/config_test.go
+++ b/controllers/repositories/pkg/controllers/repository/config_test.go
@@ -47,11 +47,11 @@ func TestBindFlags(t *testing.T) {
 }
 
 type mockLogger struct {
-	infoCalls [][]interface{}
+	infoCalls [][]any
 }
 
-func (m *mockLogger) Info(msg string, keysAndValues ...interface{}) {
-	m.infoCalls = append(m.infoCalls, append([]interface{}{msg}, keysAndValues...))
+func (m *mockLogger) Info(msg string, keysAndValues ...any) {
+	m.infoCalls = append(m.infoCalls, append([]any{msg}, keysAndValues...))
 }
 
 func TestLogConfig(t *testing.T) {

--- a/func/evaluator/evaluator_grpc.pb.go
+++ b/func/evaluator/evaluator_grpc.pb.go
@@ -107,7 +107,7 @@ func RegisterFunctionEvaluatorServer(s grpc.ServiceRegistrar, srv FunctionEvalua
 	s.RegisterService(&FunctionEvaluator_ServiceDesc, srv)
 }
 
-func _FunctionEvaluator_EvaluateFunction_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _FunctionEvaluator_EvaluateFunction_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	in := new(EvaluateFunctionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func _FunctionEvaluator_EvaluateFunction_Handler(srv interface{}, ctx context.Co
 		Server:     srv,
 		FullMethod: FunctionEvaluator_EvaluateFunction_FullMethodName,
 	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(ctx context.Context, req any) (any, error) {
 		return srv.(FunctionEvaluatorServer).EvaluateFunction(ctx, req.(*EvaluateFunctionRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/func/evaluator/evaluator_grpc.pb.go
+++ b/func/evaluator/evaluator_grpc.pb.go
@@ -107,7 +107,7 @@ func RegisterFunctionEvaluatorServer(s grpc.ServiceRegistrar, srv FunctionEvalua
 	s.RegisterService(&FunctionEvaluator_ServiceDesc, srv)
 }
 
-func _FunctionEvaluator_EvaluateFunction_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+func _FunctionEvaluator_EvaluateFunction_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EvaluateFunctionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func _FunctionEvaluator_EvaluateFunction_Handler(srv any, ctx context.Context, d
 		Server:     srv,
 		FullMethod: FunctionEvaluator_EvaluateFunction_FullMethodName,
 	}
-	handler := func(ctx context.Context, req any) (any, error) {
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(FunctionEvaluatorServer).EvaluateFunction(ctx, req.(*EvaluateFunctionRequest))
 	}
 	return interceptor(ctx, in, info, handler)

--- a/func/internal/podevaluator_podmanager_test.go
+++ b/func/internal/podevaluator_podmanager_test.go
@@ -814,7 +814,7 @@ func TestMultipleEndpointsWithStuckPod(t *testing.T) {
 	}
 }
 
-func deepCopyObject(in, out interface{}) {
+func deepCopyObject(in, out any) {
 	buf := bytes.Buffer{}
 	if err := gob.NewEncoder(&buf).Encode(in); err != nil {
 		panic(err)

--- a/func/internal/podmanager.go
+++ b/func/internal/podmanager.go
@@ -495,7 +495,7 @@ func (pm *podManager) getImage(ctx context.Context, ref name.Reference, auth aut
 	}
 	if _, errCRT := os.Stat(filepath.Join(pm.tlsSecretPath, "ca.crt")); os.IsNotExist(errCRT) {
 		if _, errPEM := os.Stat(filepath.Join(pm.tlsSecretPath, "ca.pem")); os.IsNotExist(errPEM) {
-			return nil, fmt.Errorf("ca.crt not found: %v, and ca.pem also not found: %v", errCRT, errPEM)
+			return nil, fmt.Errorf("ca.crt not found: %v, and ca.pem also not found: %w", errCRT, errPEM)
 		}
 		tlsFile = "ca.pem"
 	}

--- a/go.mod
+++ b/go.mod
@@ -71,8 +71,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-require golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
-
 require (
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
@@ -215,6 +213,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
-	golang.org/x/exp v0.0.0-20260603202125-055de637280b
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.283.0
 	google.golang.org/genproto v0.0.0-20260526163538-3dc84a4a5aaa
@@ -71,6 +70,8 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
+
+require golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 
 require (
 	cel.dev/expr v0.25.2 // indirect

--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -1,4 +1,4 @@
-// Copyright 2022,2024 The kpt Authors
+// Copyright 2022, 2024, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -267,7 +267,7 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 	kubeConfig := ctrl.GetConfigOrDie()
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		return fmt.Errorf("failed to setup kubeClient: %v", err)
+		return fmt.Errorf("failed to setup kubeClient: %w", err)
 	}
 	// Set max timeout value for ValidatingWebhooks
 	cfg.timeout = 30
@@ -456,7 +456,7 @@ func constructResponse(response *admissionv1.AdmissionResponse,
 
 	resp, err := json.Marshal(admissionReviewResponse)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling response json: %v", err)
+		return nil, fmt.Errorf("error marshalling response json: %w", err)
 	}
 	return resp, nil
 }

--- a/pkg/cache/crcache/util.go
+++ b/pkg/cache/crcache/util.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt Authors
+// Copyright 2022, 2024-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
 package crcache
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 	"strings"
 
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
@@ -69,30 +70,18 @@ func toPackageRevisionSlice(
 			result = append(result, p)
 		}
 	}
-	sort.Slice(result, func(i, j int) bool {
-		ki, kj := result[i].Key(), result[j].Key()
-		switch res := strings.Compare(ki.PkgKey.Package, kj.PkgKey.Package); {
-		case res < 0:
-			return true
-		case res > 0:
-			return false
-		default:
-			// Equal. Compare next element
+	slices.SortFunc(result, func(a, b repository.PackageRevision) int {
+		ka, kb := a.Key(), b.Key()
+		if res := strings.Compare(ka.PkgKey.Package, kb.PkgKey.Package); res != 0 {
+			return res
 		}
-		res := ki.Revision - kj.Revision
-		if res != 0 {
-			return res < 0
+		if res := cmp.Compare(ka.Revision, kb.Revision); res != 0 {
+			return res
 		}
-		switch res := strings.Compare(string(result[i].Lifecycle(ctx)), string(result[j].Lifecycle(ctx))); {
-		case res < 0:
-			return true
-		case res > 0:
-			return false
-		default:
-			// Equal. Compare next element
+		if res := strings.Compare(string(a.Lifecycle(ctx)), string(b.Lifecycle(ctx))); res != 0 {
+			return res
 		}
-
-		return strings.Compare(result[i].KubeObjectName(), result[j].KubeObjectName()) < 0
+		return strings.Compare(a.KubeObjectName(), b.KubeObjectName())
 	})
 	return result
 }
@@ -104,10 +93,8 @@ func toPackageSlice(cached map[repository.PackageKey]*cachedPackage, filter repo
 			result = append(result, p)
 		}
 	}
-	sort.Slice(result, func(i, j int) bool {
-		ki, kj := result[i].Key(), result[j].Key()
-		// We assume they all have the same repository
-		return ki.Package < kj.Package
+	slices.SortFunc(result, func(a, b repository.Package) int {
+		return strings.Compare(a.Key().Package, b.Key().Package)
 	})
 
 	return result

--- a/pkg/cli/commands/repo/reg/command_test.go
+++ b/pkg/cli/commands/repo/reg/command_test.go
@@ -187,7 +187,7 @@ func TestRepoReg(t *testing.T) {
 					t.Fatalf("unhandled content-encoding %q", r.Header.Get("Content-Encoding"))
 				}
 
-				var body interface{}
+				var body any
 				switch r.Header.Get("Content-Type") {
 				case "application/json":
 					if err := json.Unmarshal(requestBody, &body); err != nil {
@@ -213,7 +213,7 @@ func TestRepoReg(t *testing.T) {
 					}
 				}
 
-				var want interface{}
+				var want any
 				wantBytes, err := os.ReadFile(wantFile)
 				if err != nil {
 					t.Fatalf("Failed to reead golden file %q: %v", wantFile, err)
@@ -230,7 +230,7 @@ func TestRepoReg(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to read response file %q: %v", action.sendResponse, err)
 				}
-				var resp interface{}
+				var resp any
 				if err := yaml.Unmarshal(respData, &resp); err != nil {
 					t.Fatalf("Failed to unmarshal desired response %q: %v", action.sendResponse, err)
 				}

--- a/pkg/cli/commands/rpkg/get/command.go
+++ b/pkg/cli/commands/rpkg/get/command.go
@@ -340,7 +340,7 @@ func findColumn(cols []metav1.TableColumnDefinition, name string) int {
 	return -1
 }
 
-func getStringCell(cells []interface{}, col int) (string, bool) {
+func getStringCell(cells []any, col int) (string, bool) {
 	if col < 0 {
 		return "", false
 	}
@@ -348,7 +348,7 @@ func getStringCell(cells []interface{}, col int) (string, bool) {
 	return s, ok
 }
 
-func getInt64Cell(cells []interface{}, col int) (int64, bool) {
+func getInt64Cell(cells []any, col int) (int64, bool) {
 	if col < 0 {
 		return 0, false
 	}

--- a/pkg/cli/commands/rpkg/pull/command.go
+++ b/pkg/cli/commands/rpkg/pull/command.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
@@ -156,7 +156,7 @@ func writeToWriter(resources map[string]string, out io.Writer) error {
 		}
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	// Create kio readers
 	inputs := []kio.Reader{}

--- a/pkg/cli/commands/rpkg/push/command.go
+++ b/pkg/cli/commands/rpkg/push/command.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -214,7 +214,7 @@ func str(i porchapi.ResultItem) string {
 	if i.Severity == "" {
 		severity = "info"
 	}
-	list := []interface{}{severity}
+	list := []any{severity}
 	if len(idStringList) > 0 {
 		formatString += " %s"
 		list = append(list, strings.Join(idStringList, "/"))
@@ -230,12 +230,23 @@ func str(i porchapi.ResultItem) string {
 
 func readFromDir(dir string) (map[string]string, error) {
 	resources := map[string]string{}
-	if err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.Mode().IsRegular() {
+		if d.IsDir() {
 			return nil
+		}
+		// d.Type() may return 0 (unknown) on some filesystems;
+		// fall back to Stat via d.Info() to avoid skipping regular files.
+		if !d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			if !info.Mode().IsRegular() {
+				return nil
+			}
 		}
 		rel, err := filepath.Rel(dir, path)
 		if err != nil {

--- a/pkg/cli/commands/rpkg/upgrade/discover.go
+++ b/pkg/cli/commands/rpkg/upgrade/discover.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2025 The kpt Authors
+// Copyright 2022, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ func (r *runner) findUpstreamUpdates(prs []porchapi.PackageRevision, repositorie
 	for _, pr := range prs {
 		availableUpdates, upstreamName, _, err := r.availableUpdates(pr.Status.UpstreamLock, repositories)
 		if err != nil {
-			return fmt.Errorf("could not parse upstreamLock in Kptfile of package %q: %s", pr.Name, err.Error())
+			return fmt.Errorf("could not parse upstreamLock in Kptfile of package %q: %w", pr.Name, err)
 		}
 		if len(availableUpdates) == 0 {
 			upstreamUpdates = append(upstreamUpdates, []string{pr.Name, upstreamName, "No update available"})
@@ -89,7 +89,7 @@ func (r *runner) findDownstreamUpdates(prs []porchapi.PackageRevision, repositor
 	for _, pr := range prs {
 		availableUpdates, _, draftName, err := r.availableUpdates(pr.Status.UpstreamLock, repositories)
 		if err != nil {
-			return fmt.Errorf("could not parse upstreamLock in Kptfile of package %q: %s", pr.Name, err.Error())
+			return fmt.Errorf("could not parse upstreamLock in Kptfile of package %q: %w", pr.Name, err)
 		}
 		for _, update := range availableUpdates {
 			key := fmt.Sprintf("%s:%d:%s", update.Name, update.Spec.Revision, draftName)

--- a/pkg/cli/commands/rpkg/util/common.go
+++ b/pkg/cli/commands/rpkg/util/common.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The kpt Authors
+// Copyright 2023, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -287,13 +287,13 @@ func GetResourceVersion(prr *porchapi.PackageRevisionResources) (string, error) 
 func AddRevisionMetadata(prr *porchapi.PackageRevisionResources) error {
 	kptMetaDataKo := fnsdk.NewEmptyKubeObject()
 	if err := kptMetaDataKo.SetAPIVersion(prr.APIVersion); err != nil {
-		return fmt.Errorf("cannot set Api Version: %v", err)
+		return fmt.Errorf("cannot set Api Version: %w", err)
 	}
 	if err := kptMetaDataKo.SetKind(kptfilev1.RevisionMetaDataKind); err != nil {
-		return fmt.Errorf("cannot set Kind: %v", err)
+		return fmt.Errorf("cannot set Kind: %w", err)
 	}
 	if err := kptMetaDataKo.SetNestedField(prr.GetObjectMeta(), "metadata"); err != nil {
-		return fmt.Errorf("cannot set metadata: %v", err)
+		return fmt.Errorf("cannot set metadata: %w", err)
 	}
 	prr.Spec.Resources[kptfilev1.RevisionMetaDataFileName] = kptMetaDataKo.String()
 

--- a/pkg/externalrepo/git/commit.go
+++ b/pkg/externalrepo/git/commit.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -348,8 +348,8 @@ func (h *commitHelper) storeTrees(treePath string) (plumbing.Hash, error) {
 	}
 
 	entries := tree.Entries
-	sort.Slice(entries, func(i, j int) bool {
-		return entrySortKey(&entries[i]) < entrySortKey(&entries[j])
+	slices.SortFunc(entries, func(a, b object.TreeEntry) int {
+		return strings.Compare(entrySortKey(&a), entrySortKey(&b))
 	})
 
 	// Store all child trees, pruning any that resolve to empty

--- a/pkg/externalrepo/git/commitopsbuilder.go
+++ b/pkg/externalrepo/git/commitopsbuilder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The kpt Authors
+// Copyright 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 
 type commitOperation struct {
 	opType string
-	data   interface{}
+	data   any
 }
 
 type commitOperationBuilder struct {
@@ -33,17 +33,17 @@ func newCommitOperationBuilder() *commitOperationBuilder {
 	}
 }
 
-func (c *commitOperationBuilder) addPackageApproval(draft interface{}, tag plumbing.ReferenceName) {
+func (c *commitOperationBuilder) addPackageApproval(draft any, tag plumbing.ReferenceName) {
 	c.operations = append(c.operations, commitOperation{
 		opType: "approval",
-		data:   map[string]interface{}{"draft": draft, "tag": tag},
+		data:   map[string]any{"draft": draft, "tag": tag},
 	})
 }
 
-func (c *commitOperationBuilder) addPackageDeletion(branch plumbing.ReferenceName, prKey interface{}) {
+func (c *commitOperationBuilder) addPackageDeletion(branch plumbing.ReferenceName, prKey any) {
 	c.operations = append(c.operations, commitOperation{
 		opType: "deletion",
-		data:   map[string]interface{}{"branch": branch, "prKey": prKey},
+		data:   map[string]any{"branch": branch, "prKey": prKey},
 	})
 }
 

--- a/pkg/externalrepo/git/commitopsbuilder_test.go
+++ b/pkg/externalrepo/git/commitopsbuilder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The kpt Authors
+// Copyright 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ func TestAddPackageApproval(t *testing.T) {
 	op := ops[0]
 	assert.Equal(t, "approval", op.opType)
 
-	data := op.data.(map[string]interface{})
+	data := op.data.(map[string]any)
 	assert.Equal(t, draft, data["draft"])
 	assert.Equal(t, tag, data["tag"])
 }
@@ -59,7 +59,7 @@ func TestAddPackageDeletion(t *testing.T) {
 	op := ops[0]
 	assert.Equal(t, "deletion", op.opType)
 
-	data := op.data.(map[string]interface{})
+	data := op.data.(map[string]any)
 	assert.Equal(t, branch, data["branch"])
 	assert.Equal(t, prKey, data["prKey"])
 }

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt Authors
+// Copyright 2022, 2024-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1176,7 +1176,7 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 		if err != nil {
 			switch opts.MainBranchStrategy {
 			case ErrorIfMissing:
-				return fmt.Errorf("branch %q doesn't exist: %v", r.branch, err)
+				return fmt.Errorf("branch %q doesn't exist: %w", r.branch, err)
 			case CreateIfMissing:
 				klog.Infof("Creating branch %s in repository %s", r.branch, r.Key().Name)
 				if err := r.createBranch(repo, r.branch); err != nil {
@@ -1204,7 +1204,7 @@ func (r *gitRepository) verifyRepository(ctx context.Context, opts *GitRepositor
 		refSpecs := newPushRefSpecBuilder()
 		refSpecs.addRefToPush(commitHash, r.branch.refInLocal())
 		if err := r.pushAndCleanup(ctx, refSpecs, nil); err != nil {
-			return fmt.Errorf("error pushing main branch %q: %v", r.branch, err)
+			return fmt.Errorf("error pushing main branch %q: %w", r.branch, err)
 		}
 	}
 	return nil
@@ -1300,7 +1300,7 @@ func (r *gitRepository) commitPackageToMainInRepo(ctx context.Context, repo *git
 		Revision:      repository.Revision2Str(d.Key().Revision),
 	})
 	if err != nil {
-		return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed annotation commit message for package %s: %v", d.Key().PkgKey.ToFullPathname(), err)
+		return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed annotation commit message for package %s: %w", d.Key().PkgKey.ToFullPathname(), err)
 	}
 	hash, treeHash, err := ch.commit(ctx, message, d.Key().PkgKey.ToFullPathname(), d.commit)
 	if err != nil {
@@ -1368,7 +1368,7 @@ func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.R
 	for _, op := range commitOps.getOperations() {
 		switch op.opType {
 		case "approval":
-			data := op.data.(map[string]interface{})
+			data := op.data.(map[string]any)
 			d := data["draft"].(*gitPackageRevisionDraft)
 			tag := data["tag"].(plumbing.ReferenceName)
 
@@ -1384,7 +1384,7 @@ func (r *gitRepository) executeCommitOperations(ctx context.Context, repo *git.R
 			d.tree = newTreeHash
 
 		case "deletion":
-			data := op.data.(map[string]interface{})
+			data := op.data.(map[string]any)
 			branch := data["branch"].(plumbing.ReferenceName)
 			prKey := data["prKey"].(repository.PackageRevisionKey)
 

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -72,7 +72,7 @@ func TestGit(t *testing.T) {
 	}
 }
 
-func Run(suite interface{}, t *testing.T) {
+func Run(suite any, t *testing.T) {
 	sv := reflect.ValueOf(suite)
 	st := reflect.TypeOf(suite)
 
@@ -287,9 +287,7 @@ func (g GitSuite) TestGitPackageRoundTrip(t *testing.T) {
 
 		t.Logf("resources is %v", resources.Spec.Resources)
 
-		if !reflect.DeepEqual(resources.Spec.Resources, wantResources) {
-			t.Fatalf("resources did not match expected; got %v, want %v", resources.Spec.Resources, wantResources)
-		}
+		assert.Equal(t, wantResources, resources.Spec.Resources)
 	}
 }
 

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt Authors
+// Copyright 2022, 2024-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ func (p *gitPackageRevision) GetLock(ctx context.Context) (kptfilev1.Upstream, k
 
 	ref, err := refInRemoteFromRefInLocal(p.ref.Name())
 	if err != nil {
-		return kptfilev1.Upstream{}, kptfilev1.Locator{}, fmt.Errorf("cannot determine package lock for %q: %v", p.ref, err)
+		return kptfilev1.Upstream{}, kptfilev1.Locator{}, fmt.Errorf("cannot determine package lock for %q: %w", p.ref, err)
 	}
 
 	return kptfilev1.Upstream{

--- a/pkg/registry/porch/table.go
+++ b/pkg/registry/porch/table.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2025 The kpt Authors
+// Copyright 2022, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import (
 type tableConvertor struct {
 	resource schema.GroupResource
 	// cells creates a single row of cells of the table from a runtime.Object
-	cells func(obj runtime.Object) []interface{}
+	cells func(obj runtime.Object) []any
 	// columns stores column definitions for the table convertor
 	columns []metav1.TableColumnDefinition
 }
@@ -83,12 +83,12 @@ func (c tableConvertor) ConvertToTable(ctx context.Context, object runtime.Objec
 var (
 	packageTableConvertor = tableConvertor{
 		resource: porchapi.Resource("packages"),
-		cells: func(obj runtime.Object) []interface{} {
+		cells: func(obj runtime.Object) []any {
 			pr, ok := obj.(*porchapi.PorchPackage)
 			if !ok {
 				return nil
 			}
-			return []interface{}{
+			return []any{
 				pr.Name,
 				pr.Spec.PackageName,
 				pr.Spec.RepositoryName,
@@ -105,12 +105,12 @@ var (
 
 	packageRevisionTableConvertor = tableConvertor{
 		resource: porchapi.Resource("packagerevisions"),
-		cells: func(obj runtime.Object) []interface{} {
+		cells: func(obj runtime.Object) []any {
 			pr, ok := obj.(*porchapi.PackageRevision)
 			if !ok {
 				return nil
 			}
-			return []interface{}{
+			return []any{
 				pr.Name,
 				pr.Spec.PackageName,
 				pr.Spec.WorkspaceName,
@@ -133,12 +133,12 @@ var (
 
 	packageRevisionResourcesTableConvertor = tableConvertor{
 		resource: porchapi.Resource("packagerevisionresources"),
-		cells: func(obj runtime.Object) []interface{} {
+		cells: func(obj runtime.Object) []any {
 			pr, ok := obj.(*porchapi.PackageRevisionResources)
 			if !ok {
 				return nil
 			}
-			return []interface{}{
+			return []any{
 				pr.Name,
 				pr.Spec.PackageName,
 				pr.Spec.WorkspaceName,

--- a/pkg/repository/testing.go
+++ b/pkg/repository/testing.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The kpt Authors
+// Copyright 2022-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,14 +25,23 @@ import (
 func ReadPackage(t *testing.T, packageDir string) PackageResources {
 	results := map[string]string{}
 
-	if err := filepath.Walk(packageDir, func(p string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir(packageDir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
-		} else if !info.Mode().IsRegular() {
-			return fmt.Errorf("irregular file object detected: %q (%s)", p, info.Mode())
+		}
+		// d.Type() may return 0 (unknown) on some filesystems;
+		// fall back to Stat via d.Info() to avoid skipping regular files.
+		if !d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("irregular file object detected: %q (%s)", p, info.Mode())
+			}
 		}
 		rel, err := filepath.Rel(packageDir, p)
 		if err != nil {

--- a/pkg/task/clone_test.go
+++ b/pkg/task/clone_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt Authors
+// Copyright 2022, 2024-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,21 +125,30 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 		t.Fatalf("Failed to get git repository worktree: %v", err)
 	}
 
-	if err := filepath.Walk(contentDir, func(path string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir(contentDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
-		} else if !info.Mode().IsRegular() {
-			return fmt.Errorf("irregular file object detected: %q (%s)", path, info.Mode())
+		}
+		// d.Type() may return 0 (unknown) on some filesystems;
+		// fall back to Stat via d.Info() to avoid skipping regular files.
+		if !d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("irregular file object detected: %q (%s)", path, info.Mode())
+			}
 		}
 		rel, err := filepath.Rel(contentDir, path)
 		if err != nil {
 			return fmt.Errorf("failed to get relative path from %q to %q: %w", contentDir, path, err)
 		}
 		dir := filepath.Dir(rel)
-		if err := wt.Filesystem.MkdirAll(dir, 0777); err != nil {
+		if err := wt.Filesystem.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directories for %q: %w", rel, err)
 		}
 		src, err := os.Open(path)

--- a/pkg/task/replace_test.go
+++ b/pkg/task/replace_test.go
@@ -77,7 +77,7 @@ func removeComments(t *testing.T, r repository.PackageResources) repository.Pack
 }
 
 func removeCommentsFromFile(t *testing.T, name, contents string) string {
-	var data interface{}
+	var data any
 	if err := yaml.Unmarshal([]byte(contents), &data); err != nil {
 		t.Fatalf("Failed to unmarshal %q: %v", name, err)
 	}

--- a/pkg/tokenexchange/ksatokensource/ksatokensource.go
+++ b/pkg/tokenexchange/ksatokensource/ksatokensource.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ func ExtractJWTString(jwtToken string, key string) (string, error) {
 		// Don't log the token as it may be sensitive
 		return "", fmt.Errorf("error getting identity provider from JWT (cannot decode base64)")
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if err := json.Unmarshal(b, &m); err != nil {
 		// Don't log the token as it may be sensitive
 		return "", fmt.Errorf("error getting identity provider from JWT (cannot decode json)")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,10 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -301,23 +301,63 @@ func CompareObjectMeta(left metav1.ObjectMeta, right metav1.ObjectMeta) bool {
 		return false
 	}
 
-	if result := reflect.DeepEqual(left.Labels, right.Labels); !result {
+	if !mapsEqualNilSafe(left.Labels, right.Labels) {
 		return false
 	}
 
-	if result := reflect.DeepEqual(left.Annotations, right.Annotations); !result {
+	if !mapsEqualNilSafe(left.Annotations, right.Annotations) {
 		return false
 	}
 
-	if result := reflect.DeepEqual(left.Finalizers, right.Finalizers); !result {
+	if !slicesEqualNilSafe(left.Finalizers, right.Finalizers) {
 		return false
 	}
 
-	if result := reflect.DeepEqual(left.OwnerReferences, right.OwnerReferences); !result {
+	if !ownerRefsEqualNilSafe(left.OwnerReferences, right.OwnerReferences) {
 		return false
 	}
 
 	return true
+}
+
+func ownerRefEqual(a, b metav1.OwnerReference) bool {
+	return a.APIVersion == b.APIVersion &&
+		a.Kind == b.Kind &&
+		a.Name == b.Name &&
+		a.UID == b.UID &&
+		boolPtrEqual(a.Controller, b.Controller) &&
+		boolPtrEqual(a.BlockOwnerDeletion, b.BlockOwnerDeletion)
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func mapsEqualNilSafe(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return maps.Equal(a, b)
+}
+
+func slicesEqualNilSafe(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return slices.Equal(a, b)
+}
+
+func ownerRefsEqualNilSafe(a, b []metav1.OwnerReference) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return slices.EqualFunc(a, b, ownerRefEqual)
 }
 
 // RetryOnErrorConditional retries f up to retries times if it returns an error that matches shouldRetryFunc

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -301,19 +301,19 @@ func CompareObjectMeta(left metav1.ObjectMeta, right metav1.ObjectMeta) bool {
 		return false
 	}
 
-	if !mapsEqualNilSafe(left.Labels, right.Labels) {
+	if !mapsEqual(left.Labels, right.Labels) {
 		return false
 	}
 
-	if !mapsEqualNilSafe(left.Annotations, right.Annotations) {
+	if !mapsEqual(left.Annotations, right.Annotations) {
 		return false
 	}
 
-	if !slicesEqualNilSafe(left.Finalizers, right.Finalizers) {
+	if !slicesEqual(left.Finalizers, right.Finalizers) {
 		return false
 	}
 
-	if !ownerRefsEqualNilSafe(left.OwnerReferences, right.OwnerReferences) {
+	if !ownerRefsEqual(left.OwnerReferences, right.OwnerReferences) {
 		return false
 	}
 
@@ -339,21 +339,21 @@ func boolPtrEqual(a, b *bool) bool {
 	return *a == *b
 }
 
-func mapsEqualNilSafe(a, b map[string]string) bool {
+func mapsEqual(a, b map[string]string) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
 	return maps.Equal(a, b)
 }
 
-func slicesEqualNilSafe(a, b []string) bool {
+func slicesEqual(a, b []string) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
 	return slices.Equal(a, b)
 }
 
-func ownerRefsEqualNilSafe(a, b []metav1.OwnerReference) bool {
+func ownerRefsEqual(a, b []metav1.OwnerReference) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022,2025 The kpt Authors
+// Copyright 2022,2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -133,7 +133,7 @@ func TestParseRepositoryNameOK(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			parsedSlice := SplitIn3OnDelimiter(tc.pkgRevId, ".")
-			if !reflect.DeepEqual(tc.expected, parsedSlice) {
+			if !slices.Equal(tc.expected, parsedSlice) {
 				t.Errorf("expected %+v, got %+v", tc.expected, parsedSlice)
 			}
 		})
@@ -174,7 +174,7 @@ func TestParseRepositoryNameStrangeDelimiterOK(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			parsedSlice := SplitIn3OnDelimiter(tc.pkgRevId, "#.#")
-			if !reflect.DeepEqual(tc.expected, parsedSlice) {
+			if !slices.Equal(tc.expected, parsedSlice) {
 				t.Errorf("expected %+v, got %+v", tc.expected, parsedSlice)
 			}
 		})

--- a/test/disaster/api/environment/gitea/gitea.go
+++ b/test/disaster/api/environment/gitea/gitea.go
@@ -75,7 +75,9 @@ func Backup(t *suiteutils.MultiClusterTestSuite) {
 	if err := os.RemoveAll(backupRootFolder); err != nil {
 		t.Fatalf("error backing up Gitea: error deleting previous backup: %w", err)
 	}
-	os.Mkdir(backupRootFolder, 0777)
+	if err := os.MkdirAll(backupRootFolder, 0o755); err != nil {
+		t.Fatalf("error backing up Gitea: error creating backup directory: %v", err)
+	}
 	for name, url := range repoUrls {
 		t.Logf("Cloning repo to back up: %q", url)
 		dir := fmt.Sprintf("%s/%s", backupRootFolder, name)

--- a/test/disaster/api/environment/gitea/gitea.go
+++ b/test/disaster/api/environment/gitea/gitea.go
@@ -73,7 +73,7 @@ func Backup(t *suiteutils.MultiClusterTestSuite) {
 	t.Logf("Backing up %d Gitea repos...", len(repoUrls))
 
 	if err := os.RemoveAll(backupRootFolder); err != nil {
-		t.Fatalf("error backing up Gitea: error deleting previous backup: %w", err)
+		t.Fatalf("error backing up Gitea: error deleting previous backup: %v", err)
 	}
 	if err := os.MkdirAll(backupRootFolder, 0o755); err != nil {
 		t.Fatalf("error backing up Gitea: error creating backup directory: %v", err)

--- a/test/e2e/cli/suite.go
+++ b/test/e2e/cli/suite.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"bufio"
 	"bytes"
+	stdcmp "cmp"
 	"errors"
 	"io/fs"
 	"os"
@@ -24,7 +25,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"syscall"
 	"testing"
@@ -263,18 +263,18 @@ func (s *CliTestSuite) RunTestCase(t *testing.T, tc TestCaseConfig) {
 func (s *CliTestSuite) ScanTestCases(t *testing.T) []TestCaseConfig {
 	testCases := []TestCaseConfig{}
 
-	if err := filepath.Walk(s.TestDataPath, func(path string, info fs.FileInfo, err error) error {
+	if err := filepath.WalkDir(s.TestDataPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			return nil
 		}
 		if path == s.TestDataPath {
 			return nil
 		}
 
-		tc := ReadTestCaseConfig(t, info.Name(), path)
+		tc := ReadTestCaseConfig(t, d.Name(), path)
 		testCases = append(testCases, tc)
 
 		return nil
@@ -361,8 +361,8 @@ func findColumnRanges(header string, columns []string) []colRange {
 			ranges = append(ranges, colRange{idx, end})
 		}
 	}
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].start > ranges[j].start
+	slices.SortFunc(ranges, func(a, b colRange) int {
+		return stdcmp.Compare(b.start, a.start)
 	})
 	return ranges
 }
@@ -502,7 +502,7 @@ func reorderYamlStdout(t *testing.T, buf *bytes.Buffer) {
 		}
 	}
 
-	var data interface{}
+	var data any
 	if err := yaml.Unmarshal(newBuf.Bytes(), &data); err != nil {
 		// not yaml.
 		return
@@ -538,7 +538,7 @@ func reorderCommandStdout(t *testing.T, buf *bytes.Buffer) {
 	for scanner.Scan() {
 		bodyLines = append(bodyLines, scanner.Text())
 	}
-	sort.Strings(bodyLines)
+	slices.Sort(bodyLines)
 
 	newBuf.Write([]byte(headerLine))
 	newBuf.Write([]byte("\n"))

--- a/test/e2e/crd/function_config_test.go
+++ b/test/e2e/crd/function_config_test.go
@@ -62,7 +62,7 @@ var _ = Describe("FunctionConfig", Ordered, Label("content"), func() {
 	It("should render using a dynamically-configured FunctionConfig tag", func() {
 		By("patching set-namespace FunctionConfig with a custom tag")
 		customTag := "v99.0.0"
-		patch := []map[string]interface{}{
+		patch := []map[string]any{
 			{"op": "add", "path": "/spec/goExecutor/tags/-", "value": customTag},
 		}
 		patchBytes, err := json.Marshal(patch)
@@ -106,7 +106,7 @@ var _ = Describe("FunctionConfig", Ordered, Label("content"), func() {
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 
 		By("cleaning up: removing custom tag from FunctionConfig")
-		restorePatch := []map[string]interface{}{
+		restorePatch := []map[string]any{
 			{"op": "replace", "path": "/spec/goExecutor/tags", "value": []string{"v0.4.1", "v0.4"}},
 		}
 		restoreBytes, err := json.Marshal(restorePatch)
@@ -117,7 +117,7 @@ var _ = Describe("FunctionConfig", Ordered, Label("content"), func() {
 	It("should remove tag from builtin runtime when FunctionConfig is updated", func() {
 		By("adding a custom tag to set-namespace")
 		ephemeralTag := "v88.0.0"
-		addPatch := []map[string]interface{}{
+		addPatch := []map[string]any{
 			{"op": "add", "path": "/spec/goExecutor/tags/-", "value": ephemeralTag},
 		}
 		addBytes, err := json.Marshal(addPatch)
@@ -138,7 +138,7 @@ var _ = Describe("FunctionConfig", Ordered, Label("content"), func() {
 		}).WithTimeout(defaultTimeout).WithPolling(defaultInterval).Should(Succeed())
 
 		By("removing the custom tag")
-		removePatch := []map[string]interface{}{
+		removePatch := []map[string]any{
 			{"op": "replace", "path": "/spec/goExecutor/tags", "value": []string{"v0.4.1", "v0.4"}},
 		}
 		removeBytes, err := json.Marshal(removePatch)

--- a/test/e2e/crd/helpers_test.go
+++ b/test/e2e/crd/helpers_test.go
@@ -164,7 +164,7 @@ func createGiteaAPIToken(name string) (string, error) {
 	if resp.StatusCode != 201 {
 		return "", fmt.Errorf("failed to create gitea token: %d", resp.StatusCode)
 	}
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
 	}

--- a/test/e2e/suiteutils/multiclustersuite.go
+++ b/test/e2e/suiteutils/multiclustersuite.go
@@ -50,7 +50,7 @@ func (t *MultiClusterTestSuite) UseKubeconfigFile(kubeconfigPath string) error {
 	os.Setenv(clientcmd.RecommendedConfigPathEnvVar, t.PorchRoot+kubeconfigPath)
 	cfg, err := config.GetConfig()
 	if err != nil {
-		return fmt.Errorf("Unable to switch clusters - error loading Kubernetes client config from file %q: %v", kubeconfigPath, err)
+		return fmt.Errorf("Unable to switch clusters - error loading Kubernetes client config from file %q: %w", kubeconfigPath, err)
 	}
 
 	if cachedClient, found := t.clients[kubeconfigPath]; found {

--- a/test/e2e/suiteutils/suite.go
+++ b/test/e2e/suiteutils/suite.go
@@ -292,7 +292,7 @@ func (t *TestSuite) Fatalf(format string, args ...any) {
 	t.T().Fatalf("FATAL: "+format, args...)
 }
 
-type ErrorHandler func(format string, args ...interface{})
+type ErrorHandler func(format string, args ...any)
 
 func (t *TestSuite) get(key client.ObjectKey, obj client.Object, eh ErrorHandler) {
 	t.T().Helper()
@@ -550,13 +550,13 @@ func (t *TestSuite) SaveKptfileF(resources *porchapi.PackageRevisionResources, k
 	resources.Spec.Resources[kptfilev1.KptFileName] = string(b)
 }
 
-func (t *TestSuite) FindAndDecodeF(resources *porchapi.PackageRevisionResources, name string, value interface{}) {
+func (t *TestSuite) FindAndDecodeF(resources *porchapi.PackageRevisionResources, name string, value any) {
 	t.T().Helper()
 	contents, ok := resources.Spec.Resources[name]
 	if !ok {
 		t.Fatalf("Cannot find %q in %s/%s package", name, resources.Namespace, resources.Name)
 	}
-	var temp interface{}
+	var temp any
 	d := yaml.NewDecoder(strings.NewReader(contents))
 	if err := d.Decode(&temp); err != nil {
 		t.Fatalf("Cannot decode yaml %q in %s/%s package: %v", name, resources.Namespace, resources.Name, err)

--- a/test/git/pkg/server.go
+++ b/test/git/pkg/server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -235,14 +235,14 @@ func sortedRefs(refs map[string]*plumbing.Reference, head *plumbing.Reference) [
 	for _, v := range refs {
 		sorted = append(sorted, v)
 	}
-	sort.Slice(sorted, func(i, j int) bool {
+	slices.SortFunc(sorted, func(a, b *plumbing.Reference) int {
 		switch {
-		case sorted[i] == head:
-			return true
-		case sorted[j] == head:
-			return false
+		case a == head:
+			return -1
+		case b == head:
+			return 1
 		default:
-			return sorted[i].Name().String() < sorted[j].Name().String()
+			return strings.Compare(a.Name().String(), b.Name().String())
 		}
 	})
 	return sorted
@@ -529,7 +529,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 	// Fetch the object.
 	obj, err := object.GetObject(p.Storer, hash)
 	if err != nil {
-		return fmt.Errorf("getting object %s failed: %v", hash, err)
+		return fmt.Errorf("getting object %s failed: %w", hash, err)
 	}
 	// Walk all children depending on object type.
 	switch obj := obj.(type) {

--- a/test/git/pkg/server.go
+++ b/test/git/pkg/server.go
@@ -237,6 +237,8 @@ func sortedRefs(refs map[string]*plumbing.Reference, head *plumbing.Reference) [
 	}
 	slices.SortFunc(sorted, func(a, b *plumbing.Reference) int {
 		switch {
+		case a == b:
+			return 0
 		case a == head:
 			return -1
 		case b == head:

--- a/test/ociserver/pkg/oci/responses.go
+++ b/test/ociserver/pkg/oci/responses.go
@@ -26,7 +26,7 @@ import (
 )
 
 type JSONResponse struct {
-	Object interface{}
+	Object any
 }
 
 func (v *JSONResponse) WriteTo(w http.ResponseWriter, r *http.Request) {

--- a/test/performance/logger.go
+++ b/test/performance/logger.go
@@ -33,7 +33,7 @@ func NewTestLogger(t *testing.T) (*TestLogger, error) {
 	// Creates logs directory if it doesn't exist
 	logsDir := "logs"
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create logs directory: %v", err)
+		return nil, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 
 	// Create log file with timestamp
@@ -41,7 +41,7 @@ func NewTestLogger(t *testing.T) (*TestLogger, error) {
 	filename := filepath.Join(logsDir, fmt.Sprintf("porch-metrics-%s.log", timestamp))
 	file, err := os.Create(filename)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create log file: %v", err)
+		return nil, fmt.Errorf("failed to create log file: %w", err)
 	}
 
 	logger := log.New(file, "", 0) // Remove timestamp from log entries
@@ -56,7 +56,7 @@ func (l *TestLogger) Close() error {
 	return l.file.Close()
 }
 
-func (l *TestLogger) LogResult(format string, args ...interface{}) {
+func (l *TestLogger) LogResult(format string, args ...any) {
 	if len(args) == 0 {
 		// If no args provided, treat format as plain string
 		l.logger.Println(format)

--- a/test/performance/metrics.go
+++ b/test/performance/metrics.go
@@ -91,7 +91,7 @@ func discoverGiteaLBIP() string {
 
 func createGiteaRepo(repoName string) error {
 	giteaURL := getGiteaBaseURL() + "/api/v1/user/repos"
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"name":        repoName,
 		"description": "Test repository for Porch metrics",
 		"private":     false,
@@ -100,12 +100,12 @@ func createGiteaRepo(repoName string) error {
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal payload: %v", err)
+		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", giteaURL, bytes.NewBuffer(jsonPayload))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %v", err)
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -114,7 +114,7 @@ func createGiteaRepo(repoName string) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to create repo: %v", err)
+		return fmt.Errorf("failed to create repo: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -163,7 +163,7 @@ func deleteGiteaRepo(repoName string) error {
 
 	req, err := http.NewRequest("DELETE", giteaURL, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create delete request: %v", err)
+		return fmt.Errorf("failed to create delete request: %w", err)
 	}
 
 	req.SetBasicAuth("porch", "secret")
@@ -171,7 +171,7 @@ func deleteGiteaRepo(repoName string) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to delete repo: %v", err)
+		return fmt.Errorf("failed to delete repo: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/test/performance/porch_metrics_test.go
+++ b/test/performance/porch_metrics_test.go
@@ -231,7 +231,7 @@ scrape_configs:
     scrape_interval: 1s
 `
 	if err := os.WriteFile("prometheus.yml", []byte(promConfig), 0644); err != nil {
-		return fmt.Errorf("failed to create prometheus.yml: %v", err)
+		return fmt.Errorf("failed to create prometheus.yml: %w", err)
 	}
 
 	// Execute Docker commands
@@ -304,13 +304,13 @@ func setupGiteaSecret(t *testing.T) error {
 	// Read and apply the secret manifest
 	secretManifest, err := os.ReadFile(filepath.Join(dir, "gitea-secret.yaml"))
 	if err != nil {
-		return fmt.Errorf("failed to read gitea secret manifest: %v", err)
+		return fmt.Errorf("failed to read gitea secret manifest: %w", err)
 	}
 
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
 	cmd.Stdin = bytes.NewReader(secretManifest)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to apply gitea secret: %v\nOutput: %s", err, output)
+		return fmt.Errorf("failed to apply gitea secret: %w\nOutput: %s", err, output)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
- What changed: Replaced outdated Go patterns with modern stdlib equivalents across 47 files. Includes: `golang.org/x/exp/slices` → stdlib `slices`, `sort.Strings`/`sort.Slice` → `slices.Sort`/`slices.SortFunc`, `filepath.Walk` → `filepath.WalkDir`, `interface{}` → `any`, `reflect.DeepEqual` → typed comparisons (`maps.Equal`, `slices.Equal`), `fmt.Errorf %v`/`%s` → `%w` for proper error wrapping, and `0777` → `0o755` permissions.
- Why it's needed: The codebase targets Go `1.26.3` but retained patterns from Go 1.16-era code. These modernizations improve type safety, debuggability (proper error chains), and performance (`WalkDir` avoids redundant `Lstat` calls). Removing `x/exp/slices` eliminates an unnecessary direct dependency.
- How it works: Mechanical replacements verified by `go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint run ./...` with 0 issues. The `reflect.DeepEqual` replacement preserves nil-vs-empty semantics via nil-safe wrapper functions.

## Type of Change
- [x] Refactor

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass


## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to identify outdated patterns via static analysis, perform mechanical replacements, and verify each change compiles and passes linting.
