### PR TITLE
Docs redirecting navbar porch section to the docs rather than entry page

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -211,3 +211,7 @@ enable = false
   name = "Guides"
   url = "https://kpt.dev/guides/"
   weight = 40
+[[menu.main]]
+  name = "Porch"
+  url = "/docs/"
+  weight = 50

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Porch
 description: Kubernetes-native package orchestration for KRM configuration packages
-menu: {main: {weight: 50}}
 toc_hide: true
 ---
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Docs redirecting navbar porch section to the docs rather than entry page

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  redirecting navbar porch section to the docs rather than entry page
- Why it’s needed:  it would redirect to the main menu instead of the docs
- How it works:  just a redirect

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  
- linked with https://github.com/kptdev/krm-functions-catalog/pull/1270 & https://github.com/kptdev/kpt/pull/4611

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [ ] Tests added/updated  
- [x] Documentation added/updated  
- [ ] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

No AI used/needed
