### PR TITLE
Make PackageMetadata and ReadinessGates persist on main revision

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -351,6 +351,7 @@ func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) reposito
 		},
 		meta: metav1.ObjectMeta{},
 		spec: &porchapi.PackageRevisionSpec{
+			ReadinessGates:  append([]porchapi.ReadinessGate(nil), pr.specReadinessGates()...),
 			PackageMetadata: pr.specPackageMetadata().DeepCopy(),
 		},
 		updated:            time.Now(),

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -349,8 +349,10 @@ func (pr *dbPackageRevision) ToMainPackageRevision(ctx context.Context) reposito
 			Revision:      -1,
 			WorkspaceName: pr.Key().RKey().PlaceholderWSname,
 		},
-		meta:               metav1.ObjectMeta{},
-		spec:               &porchapi.PackageRevisionSpec{},
+		meta: metav1.ObjectMeta{},
+		spec: &porchapi.PackageRevisionSpec{
+			PackageMetadata: pr.specPackageMetadata().DeepCopy(),
+		},
 		updated:            time.Now(),
 		updatedBy:          getCurrentUser(),
 		lifecycle:          pr.lifecycle,

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -267,7 +267,7 @@ upstreamLock:
 
 	// Kptfile has no labels, so PackageMetadata should have nil labels
 	t.Require().NotNil(prDef.Spec.PackageMetadata)
-	t.Require().Nil(prDef.Spec.PackageMetadata.Labels, "PackageMetadata should not be present on main revision after publish ")
+	t.Len(prDef.Spec.PackageMetadata.Labels, 0, "expected no labels when Kptfile has none")
 
 	err = testRepo.DeletePackageRevision(ctx, dbPR)
 	t.Require().NoError(err)

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -121,6 +121,9 @@ func (t *DbTestSuite) TestDBPackageRevision() {
 kind: Kptfile
 metadata:
   name: my-kptfile
+  labels:
+    app: my-app
+    team: platform
   annotations:
     config.kubernetes.io/local-config: "true"
 info:
@@ -152,6 +155,30 @@ info:
 	dbPR, err = testRepo.ClosePackageRevisionDraft(ctx, dbPR.(repository.PackageRevisionDraft), 0)
 	t.Require().NoError(err)
 	t.Require().NotNil(dbPR)
+
+	// Verify that PackageMetadata (Kptfile labels) persists on the published revision itself
+	prDef, err = dbPR.GetPackageRevision(ctx)
+	t.Require().NoError(err)
+	t.Require().NotNil(prDef.Spec.PackageMetadata, "PackageMetadata should be present on published revision")
+	t.Equal("my-app", prDef.Spec.PackageMetadata.Labels["app"])
+	t.Equal("platform", prDef.Spec.PackageMetadata.Labels["team"])
+
+	// After publishing, the main revision is automatically created in the DB.
+	// Verify that PackageMetadata (Kptfile labels) persists on it.
+	mainKey := repository.PackageRevisionKey{
+		PkgKey:        dbPR.Key().PKey(),
+		Revision:      -1,
+		WorkspaceName: branch,
+	}
+	mainFromDB, err := pkgRevReadFromDB(ctx, mainKey, false)
+	t.Require().NoError(err)
+	t.Require().NotNil(mainFromDB)
+
+	mainPRDef, err := mainFromDB.GetPackageRevision(ctx)
+	t.Require().NoError(err)
+	t.Require().NotNil(mainPRDef.Spec.PackageMetadata, "PackageMetadata should be present on main revision after publish")
+	t.Equal("my-app", mainPRDef.Spec.PackageMetadata.Labels["app"])
+	t.Equal("platform", mainPRDef.Spec.PackageMetadata.Labels["team"])
 
 	dbPRdb := dbPR.(*dbPackageRevision)
 	dbPR2 := dbPackageRevision{
@@ -237,6 +264,10 @@ upstreamLock:
 	prDef, err = dbPR.GetPackageRevision(ctx)
 	t.Require().NoError(err)
 	t.Equal("basens-edit", prDef.Status.UpstreamLock.Git.Directory)
+
+	// Kptfile has no labels, so PackageMetadata should have nil labels
+	t.Require().NotNil(prDef.Spec.PackageMetadata)
+	t.Require().Nil(prDef.Spec.PackageMetadata.Labels, "PackageMetadata should not be present on main revision after publish ")
 
 	err = testRepo.DeletePackageRevision(ctx, dbPR)
 	t.Require().NoError(err)

--- a/test/e2e/api/advanced_test.go
+++ b/test/e2e/api/advanced_test.go
@@ -530,6 +530,10 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 				"porch.dev/added-annotation": "added-annotation-value",
 			},
 		}
+		clonePr.Spec.ReadinessGates = []porchapi.ReadinessGate{
+			{ConditionType: "Ready"},
+			{ConditionType: "Deployed"},
+		}
 		t.UpdateF(clonePr)
 		t.GetF(client.ObjectKeyFromObject(clonePr), clonePr)
 
@@ -550,6 +554,12 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 			t.Require().Equal(v, actual)
 		}
 
+		expectedGates := []porchapi.ReadinessGate{
+			{ConditionType: "Ready"},
+			{ConditionType: "Deployed"},
+		}
+		t.Require().Equal(expectedGates, clonePr.Spec.ReadinessGates)
+
 		var packageResources porchapi.PackageRevisionResources
 		t.GetF(client.ObjectKeyFromObject(clonePr), &packageResources)
 		kptfile := t.ParseKptfileF(&packageResources)
@@ -559,6 +569,47 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 			t.Require().True(ok)
 			t.Require().Equal(v, actual)
 		}
+	})
+
+	t.Run("Metadata persists on main revision after publish", func() {
+		// Propose the package
+		clonePr.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
+		t.UpdateF(clonePr)
+		t.GetF(client.ObjectKeyFromObject(clonePr), clonePr)
+
+		// Publish (approve) the package
+		clonePr.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
+		t.UpdateApprovalF(clonePr)
+		t.GetF(client.ObjectKeyFromObject(clonePr), clonePr)
+
+		// Find the main revision
+		mainPrName := strings.Replace(clonePr.Name, workspace, "main", 1)
+		mainPr := &porchapi.PackageRevision{}
+		t.GetF(client.ObjectKey{Namespace: t.Namespace, Name: mainPrName}, mainPr)
+
+		// Verify metadata persists on main revision
+		t.Require().NotNil(mainPr.Spec.PackageMetadata, "main revision should have PackageMetadata")
+
+		expectedLabels := map[string]string{
+			"porch.dev/new-label":   "changed-label-value",
+			"porch.dev/added-label": "added-label-value",
+		}
+		expectedAnnotations := map[string]string{
+			"porch.dev/new-annotation":   "changed-annotation-value",
+			"porch.dev/added-annotation": "added-annotation-value",
+		}
+		expectedGates := []porchapi.ReadinessGate{
+			{ConditionType: "Ready"},
+			{ConditionType: "Deployed"},
+		}
+
+		t.Require().Equal(expectedLabels, mainPr.Spec.PackageMetadata.Labels, "main revision metadata labels should match v1")
+		for k, v := range expectedAnnotations {
+			actual, ok := mainPr.Spec.PackageMetadata.Annotations[k]
+			t.Require().True(ok, "annotation key %s should exist", k)
+			t.Require().Equal(v, actual, "annotation %s value should match", k)
+		}
+		t.Require().Equal(expectedGates, mainPr.Spec.ReadinessGates, "main revision ReadinessGates should match v1")
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Make PackageMetadata and ReadinessGates persist on main revision

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  In ToMainPackageRevision, initialize the main revision's spec with cached metadata and readiness gates by copying from the workspace revision: PackageMetadata: pr.specPackageMetadata().DeepCopy() and ReadinessGates: append([]porchapi.ReadinessGate(nil), pr.specReadinessGates()...).

- Why it's needed: Without this, the .main revision has empty PackageMetadata and no ReadinessGates, so labels, annotations, and readiness conditions from the Kptfile are missing.

- How it works: When a package is approved, ToMainPackageRevision now copies both the cached spec.PackageMetadata (deep-copied to prevent mutations) and spec.ReadinessGates (shallow-copied via append) from the workspace revision into the main revision's spec. This ensures the main revision has the same Kptfile metadata (labels, annotations, readiness gates) as the workspace package without needing to re-parse the Kptfile.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  
2.  
3.  

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

Used Kiro to write the E2E sub test
