### PR TITLE
Support passing direct go version to the setup kpt action

### DIFF
--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -23,7 +23,10 @@ inputs:
   kpt-fallback-version:
     description: "Fallback kpt version if extraction from go.mod fails"
     required: false
-    default: "v1.0.0-beta.64"
+    default: "v1.0.0-beta.65"
+  go-version:
+    description: "Exact version for Go version setup, go-version-file is ignored if set"
+    required: false
   go-version-file:
     description: "Path to go.mod file for Go version setup"
     required: false
@@ -48,6 +51,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
+        go-version: ${{ inputs.go-version }}
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.go-cache == 'true' }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}


### PR DESCRIPTION
## Title
Support passing direct go version to the setup kpt action

---

## Description
- What changed: Added the `go-version` input to the setup-go-kpt action
- Why it’s needed: Better parity with the original setup-go action
- How it works: We just forward the input

---

## Related Issue(s)
None

---

## Type of Change
- [x] Enhancement
---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] ~~Tests added/updated~~
- [ ] ~~Documentation added/updated~~
- [ ] All tests and gating checks pass

---

## Additional notes

I also bumped the fallback version to beta 65

---

## AI Disclosure

*I have not used AI in the creation of this PR.*