### PR TITLE
Remove dangling line ending whitespaces from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,21 @@
 <!--  Thanks for sending a pull request! -->
 
-## Title
 <!-- Short, descriptive title for the PR -->
-[Add title here]
+# [Add title here]
 
 ---
 
 ## Description
 <!-- Describe what this PR does and why -->
-- What changed:  
-- Why it’s needed:  
-- How it works:  
+- What changed: 
+- Why it’s needed: 
+- How it works: 
 
 ---
 
 ## Related Issue(s)
 <!-- Link issues using #ISSUE_NUMBER -->
-- Closes/Fixes #  
+- Closes/Fixes #
 
 ---
 
@@ -33,25 +32,25 @@
 ---
 
 ## Checklist
-- [ ] Code follows project style guidelines  
-- [ ] Self-reviewed changes  
-- [ ] Tests added/updated  
-- [ ] Documentation added/updated  
-- [ ] All tests and gating checks pass  
+- [ ] Code follows project style guidelines
+- [ ] Self-reviewed changes
+- [ ] Tests added/updated
+- [ ] Documentation added/updated
+- [ ] All tests and gating checks pass
 
 ---
 
 ## Testing Instructions (Optional)
-1.  
-2.  
-3.  
+1. 
+2. 
+3. 
 
 ---
 
 ## Additional Notes (Optional)
-- Known issues:  
-- Further improvements:  
-- Review notes:  
+- Known issues: 
+- Further improvements: 
+- Review notes: 
 
 ---
 


### PR DESCRIPTION
# Remove dangling line ending whitespaces from PR template

---

## Description
- What changed: Removed dangling and double line ending whitespaces, made the title h1
- Why it’s needed: It has been annoying for a while
- How it works: 

---

## Related Issue(s)
None

---

## Type of Change
- [x] Other: Governance

---

## Checklist
- [ ] ~~Code follows project style guidelines~~  
- [x] Self-reviewed changes  
- [ ] ~~Tests added/updated~~  
- [ ] ~~Documentation added/updated~~  
- [ ] All tests and gating checks pass  
---

## AI Disclosure

*I have not used AI in the creation of this PR.*