### PR TITLE
Reject watch resume main

### DIFF
--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -36,19 +36,21 @@ import (
 
 // createGenericWatch creates a watch.Interface that monitors package changes.
 func createGenericWatch(ctx context.Context, r packageReader, filter repository.ListPackageRevisionFilter, extractor objectExtractor, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	// A non-zero resourceVersion without sendInitialEvents is a plain watch resume.
-	// Porch doesn't support RV-based resumption; return 410 to force a full re-list.
-	if utilfeature.DefaultFeatureGate.Enabled(features.WatchList) &&
-		options != nil && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0" && options.SendInitialEvents == nil {
-		klog.V(2).Infof("watch: returning 410 Gone for plain watch resume (resourceVersion=%q)", options.ResourceVersion)
-		return nil, apierrors.NewGone("resourceVersion is not supported for watch without sendInitialEvents")
-	}
 
 	ctx, cancel := context.WithCancel(ctx)
 
 	allowWatchBookmarks := options != nil && options.AllowWatchBookmarks
 	sendInitialEvents := options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents
+	hasExactResourceVersion := options != nil && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0"
 	allowWatchBookmarks = effectiveAllowWatchBookmarks(allowWatchBookmarks, sendInitialEvents)
+
+	// A non-zero resourceVersion without sendInitialEvents is a plain watch resume.
+	// Porch doesn't support RV-based resumption; return 410 to force a full re-list.
+	if utilfeature.DefaultFeatureGate.Enabled(features.WatchList) && hasExactResourceVersion && !sendInitialEvents {
+		klog.V(2).Infof("watch: returning 410 Gone for plain watch resume (resourceVersion=%q)", options.ResourceVersion)
+		cancel()
+		return nil, apierrors.NewResourceExpired("resourceVersion is not supported for watch without sendInitialEvents")
+	}
 
 	w := &watcher{
 		cancel:              cancel,

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 )
 
@@ -36,7 +38,8 @@ import (
 func createGenericWatch(ctx context.Context, r packageReader, filter repository.ListPackageRevisionFilter, extractor objectExtractor, options *metainternalversion.ListOptions) (watch.Interface, error) {
 	// A non-zero resourceVersion without sendInitialEvents is a plain watch resume.
 	// Porch doesn't support RV-based resumption; return 410 to force a full re-list.
-	if options != nil && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0" && options.SendInitialEvents == nil {
+	if utilfeature.DefaultFeatureGate.Enabled(features.WatchList) &&
+		options != nil && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0" && options.SendInitialEvents == nil {
 		klog.V(2).Infof("watch: returning 410 Gone for plain watch resume (resourceVersion=%q)", options.ResourceVersion)
 		return nil, apierrors.NewGone("resourceVersion is not supported for watch without sendInitialEvents")
 	}

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -36,7 +36,6 @@ import (
 
 // createGenericWatch creates a watch.Interface that monitors package changes.
 func createGenericWatch(ctx context.Context, r packageReader, filter repository.ListPackageRevisionFilter, extractor objectExtractor, options *metainternalversion.ListOptions) (watch.Interface, error) {
-
 	ctx, cancel := context.WithCancel(ctx)
 
 	allowWatchBookmarks := options != nil && options.AllowWatchBookmarks

--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kptdev/porch/pkg/engine"
 	"github.com/kptdev/porch/pkg/repository"
 	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,13 @@ import (
 
 // createGenericWatch creates a watch.Interface that monitors package changes.
 func createGenericWatch(ctx context.Context, r packageReader, filter repository.ListPackageRevisionFilter, extractor objectExtractor, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	// A non-zero resourceVersion without sendInitialEvents is a plain watch resume.
+	// Porch doesn't support RV-based resumption; return 410 to force a full re-list.
+	if options != nil && len(options.ResourceVersion) > 0 && options.ResourceVersion != "0" && options.SendInitialEvents == nil {
+		klog.V(2).Infof("watch: returning 410 Gone for plain watch resume (resourceVersion=%q)", options.ResourceVersion)
+		return nil, apierrors.NewGone("resourceVersion is not supported for watch without sendInitialEvents")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	allowWatchBookmarks := options != nil && options.AllowWatchBookmarks

--- a/pkg/registry/porch/watch_test.go
+++ b/pkg/registry/porch/watch_test.go
@@ -31,6 +31,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -377,6 +380,8 @@ done:
 // resume). This forces the reflector to exit its watch() loop and do a full re-list
 // with sendInitialEvents=true, which correctly reconciles the informer cache via Replace.
 func TestCreateGenericWatch410OnPlainWatchResume(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+
 	tests := []struct {
 		name        string
 		options     *metainternalversion.ListOptions
@@ -471,10 +476,40 @@ func TestCreateGenericWatch410OnPlainWatchResume(t *testing.T) {
 	}
 }
 
+// TestCreateGenericWatchNoGoneWhenWatchListDisabled verifies that the 410 behavior
+// is not active when the WatchList feature gate is disabled.
+func TestCreateGenericWatchNoGoneWhenWatchListDisabled(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &fakePackageReader{}
+	r.Add(1)
+	filter := repository.ListPackageRevisionFilter{}
+	extractor := func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {
+		return pr.GetPackageRevision(ctx)
+	}
+
+	// With WatchList disabled, a plain watch resume should proceed (no 410).
+	options := &metainternalversion.ListOptions{
+		ResourceVersion: "some-rv.12345",
+	}
+
+	w, err := createGenericWatch(ctx, r, filter, extractor, options)
+	require.NoError(t, err, "Should not return 410 when WatchList feature gate is disabled")
+	require.NotNil(t, w)
+	w.Stop()
+	for range w.ResultChan() {
+	}
+}
+
 // TestCreateGenericWatch410ErrorCodeAndReason verifies the specific HTTP status code
 // and reason in the 410 error response, which is what client-go's reflector uses
 // to decide to exit the watch loop and trigger a re-list.
 func TestCreateGenericWatch410ErrorCodeAndReason(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+
 	ctx := context.Background()
 
 	r := &fakePackageReader{}
@@ -503,6 +538,8 @@ func TestCreateGenericWatch410ErrorCodeAndReason(t *testing.T) {
 // with sendInitialEvents=true proceed normally (list all objects as ADDED events
 // followed by a bookmark).
 func TestCreateGenericWatchAllowsWatchWithSendInitialEvents(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/registry/porch/watch_test.go
+++ b/pkg/registry/porch/watch_test.go
@@ -26,9 +26,12 @@ import (
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/ptr"
 )
 
 // Helper to create fake package revisions
@@ -367,4 +370,197 @@ done:
 	if obj, ok := bookmarks[1].Object.(*porchapi.PackageRevision); ok {
 		assert.Empty(t, obj.Annotations, "Periodic bookmark should not have annotations")
 	}
+}
+
+// TestCreateGenericWatch410OnPlainWatchResume tests that createGenericWatch returns
+// 410 Gone when a client sends resourceVersion without sendInitialEvents (plain watch
+// resume). This forces the reflector to exit its watch() loop and do a full re-list
+// with sendInitialEvents=true, which correctly reconciles the informer cache via Replace.
+func TestCreateGenericWatch410OnPlainWatchResume(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     *metainternalversion.ListOptions
+		expect410   bool
+		description string
+	}{
+		{
+			name: "plain watch resume - resourceVersion set, no sendInitialEvents",
+			options: &metainternalversion.ListOptions{
+				ResourceVersion: "some-rv.12345",
+			},
+			expect410:   true,
+			description: "Client is resuming watch from a specific RV without sendInitialEvents - porch cannot fulfill this",
+		},
+		{
+			name: "initial list with sendInitialEvents=true and resourceVersion",
+			options: &metainternalversion.ListOptions{
+				ResourceVersion:     "some-rv.12345",
+				SendInitialEvents:   ptr.To(true),
+				AllowWatchBookmarks: true,
+			},
+			expect410:   false,
+			description: "Client requests full initial events - porch can fulfill this by listing all objects",
+		},
+		{
+			name: "fresh watch - empty resourceVersion, no sendInitialEvents",
+			options: &metainternalversion.ListOptions{
+				ResourceVersion: "",
+			},
+			expect410:   false,
+			description: "Empty RV means 'start fresh' - not a resume attempt",
+		},
+		{
+			name:        "nil options",
+			options:     nil,
+			expect410:   false,
+			description: "Nil options should be treated as a fresh watch",
+		},
+		{
+			name: "sendInitialEvents=false with resourceVersion",
+			options: &metainternalversion.ListOptions{
+				ResourceVersion:   "some-rv.12345",
+				SendInitialEvents: ptr.To(false),
+			},
+			expect410:   false,
+			description: "sendInitialEvents explicitly set (even to false) means the client is aware of the protocol",
+		},
+		{
+			name: "resourceVersion=0 without sendInitialEvents",
+			options: &metainternalversion.ListOptions{
+				ResourceVersion: "0",
+			},
+			expect410:   false,
+			description: "RV=0 means 'serve from cache / any version' — not a resume, porch can handle it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			r := &fakePackageReader{}
+			r.Add(1)
+			filter := repository.ListPackageRevisionFilter{}
+			extractor := func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {
+				return pr.GetPackageRevision(ctx)
+			}
+
+			w, err := createGenericWatch(ctx, r, filter, extractor, tt.options)
+
+			if tt.expect410 {
+				require.Error(t, err, tt.description)
+				assert.Nil(t, w, "Watch interface should be nil on 410")
+				assert.True(t, apierrors.IsGone(err), "Expected 410 Gone error, got: %v", err)
+
+				// Verify the error message is informative
+				statusErr, ok := err.(*apierrors.StatusError)
+				require.True(t, ok)
+				assert.Contains(t, statusErr.ErrStatus.Message, "sendInitialEvents")
+			} else {
+				require.NoError(t, err, tt.description)
+				require.NotNil(t, w, "Watch interface should not be nil")
+
+				// Clean up the watch
+				w.Stop()
+				// Drain the channel to let the goroutine exit
+				for range w.ResultChan() {
+				}
+			}
+		})
+	}
+}
+
+// TestCreateGenericWatch410ErrorCodeAndReason verifies the specific HTTP status code
+// and reason in the 410 error response, which is what client-go's reflector uses
+// to decide to exit the watch loop and trigger a re-list.
+func TestCreateGenericWatch410ErrorCodeAndReason(t *testing.T) {
+	ctx := context.Background()
+
+	r := &fakePackageReader{}
+	r.Add(1)
+	filter := repository.ListPackageRevisionFilter{}
+	extractor := func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {
+		return pr.GetPackageRevision(ctx)
+	}
+
+	options := &metainternalversion.ListOptions{
+		ResourceVersion: "test-repo.pkg-name.v1.1234567890",
+	}
+
+	w, err := createGenericWatch(ctx, r, filter, extractor, options)
+	require.Nil(t, w)
+	require.Error(t, err)
+
+	// Verify it's a proper StatusError with correct code
+	statusErr, ok := err.(*apierrors.StatusError)
+	require.True(t, ok, "Error should be a StatusError")
+	assert.Equal(t, int32(410), statusErr.ErrStatus.Code)
+	assert.Equal(t, metav1.StatusReasonGone, statusErr.ErrStatus.Reason)
+}
+
+// TestCreateGenericWatchAllowsWatchWithSendInitialEvents verifies that watches
+// with sendInitialEvents=true proceed normally (list all objects as ADDED events
+// followed by a bookmark).
+func TestCreateGenericWatchAllowsWatchWithSendInitialEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	packages := []repository.PackageRevision{
+		createFakePackageRevision("rv1"),
+		createFakePackageRevision("rv2"),
+	}
+
+	r := &fakePackageReader{packages: packages}
+	r.Add(1)
+	filter := repository.ListPackageRevisionFilter{}
+	extractor := func(ctx context.Context, pr repository.PackageRevision) (runtime.Object, error) {
+		return pr.GetPackageRevision(ctx)
+	}
+
+	options := &metainternalversion.ListOptions{
+		ResourceVersion:     "old-rv.12345",
+		SendInitialEvents:   ptr.To(true),
+		AllowWatchBookmarks: true,
+	}
+
+	w, err := createGenericWatch(ctx, r, filter, extractor, options)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	defer w.Stop()
+
+	// Should receive 2 ADDED events + 1 bookmark
+	var events []watch.Event
+	timeout := time.After(2 * time.Second)
+
+	for {
+		select {
+		case ev, ok := <-w.ResultChan():
+			if !ok {
+				goto done
+			}
+			events = append(events, ev)
+			if ev.Type == watch.Bookmark {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+
+done:
+	cancel()
+
+	require.GreaterOrEqual(t, len(events), 3, "Expected at least 2 ADDED + 1 bookmark, got %d events", len(events))
+
+	// First two should be ADDED
+	assert.Equal(t, watch.Added, events[0].Type)
+	assert.Equal(t, watch.Added, events[1].Type)
+
+	// Last should be a bookmark with initial-events-end annotation
+	lastEvent := events[len(events)-1]
+	assert.Equal(t, watch.Bookmark, lastEvent.Type)
+	obj, ok := lastEvent.Object.(*porchapi.PackageRevision)
+	require.True(t, ok)
+	assert.Equal(t, "true", obj.Annotations["k8s.io/initial-events-end"])
 }

--- a/pkg/registry/porch/watch_test.go
+++ b/pkg/registry/porch/watch_test.go
@@ -241,29 +241,8 @@ func TestWatcherBookmarks(t *testing.T) {
 			r.Wait()
 
 			// Wait for initial bookmark
-			timeout := time.After(500 * time.Millisecond)
-			foundInitial := false
+			foundInitial := waitForInitialBookmark(w.resultChan, 500*time.Millisecond)
 
-			for {
-				select {
-				case ev, ok := <-w.resultChan:
-					if !ok {
-						goto done
-					}
-					if ev.Type == watch.Bookmark {
-						if obj, ok := ev.Object.(*porchapi.PackageRevision); ok {
-							if obj.Annotations != nil && obj.Annotations["k8s.io/initial-events-end"] == "true" {
-								foundInitial = true
-								goto done
-							}
-						}
-					}
-				case <-timeout:
-					goto done
-				}
-			}
-
-		done:
 			cancelFunc()
 			if tt.expectInitial {
 				assert.True(t, foundInitial, "Expected initial bookmark but none found")
@@ -296,25 +275,9 @@ func TestWatcherBookmarkResourceVersion(t *testing.T) {
 	r.Wait()
 
 	// Wait for initial bookmark
-	timeout := time.After(1 * time.Second)
-	var bookmarkRV string
+	bookmarkRV := waitForBookmarkRV(w.resultChan, 1*time.Second)
+	cancelFunc()
 
-	for {
-		select {
-		case ev := <-w.resultChan:
-			if ev.Type == watch.Bookmark {
-				if obj, ok := ev.Object.(*porchapi.PackageRevision); ok {
-					bookmarkRV = obj.ResourceVersion
-					cancelFunc()
-					goto done
-				}
-			}
-		case <-timeout:
-			require.Fail(t, "Timeout waiting for bookmark")
-		}
-	}
-
-done:
 	assert.Equal(t, "123", bookmarkRV, "Expected bookmark resource version '123'")
 }
 
@@ -341,26 +304,9 @@ func TestWatcherPeriodicBookmark(t *testing.T) {
 	go w.listAndWatch(ctx, r, filter)
 	r.Wait()
 
-	var bookmarks []watch.Event
-	timeout := time.After(500 * time.Millisecond)
+	bookmarks := waitForBookmarks(w.resultChan, 2, 500*time.Millisecond)
+	cancelFunc()
 
-	for {
-		select {
-		case ev := <-w.resultChan:
-			if ev.Type == watch.Bookmark {
-				bookmarks = append(bookmarks, ev)
-				if len(bookmarks) >= 2 {
-					cancelFunc()
-					goto done
-				}
-			}
-		case <-timeout:
-			cancelFunc()
-			goto done
-		}
-	}
-
-done:
 	require.GreaterOrEqual(t, len(bookmarks), 2, "Expected at least 2 bookmarks (initial + periodic)")
 
 	// First should be initial bookmark
@@ -426,8 +372,8 @@ func TestCreateGenericWatch410OnPlainWatchResume(t *testing.T) {
 				ResourceVersion:   "some-rv.12345",
 				SendInitialEvents: ptr.To(false),
 			},
-			expect410:   false,
-			description: "sendInitialEvents explicitly set (even to false) means the client is aware of the protocol",
+			expect410:   true,
+			description: "sendInitialEvents=false with a resourceVersion is still a plain resume - porch cannot fulfill this",
 		},
 		{
 			name: "resourceVersion=0 without sendInitialEvents",
@@ -456,7 +402,7 @@ func TestCreateGenericWatch410OnPlainWatchResume(t *testing.T) {
 			if tt.expect410 {
 				require.Error(t, err, tt.description)
 				assert.Nil(t, w, "Watch interface should be nil on 410")
-				assert.True(t, apierrors.IsGone(err), "Expected 410 Gone error, got: %v", err)
+				assert.True(t, apierrors.IsResourceExpired(err), "Expected 410 ResourceExpired error, got: %v", err)
 
 				// Verify the error message is informative
 				statusErr, ok := err.(*apierrors.StatusError)
@@ -531,7 +477,7 @@ func TestCreateGenericWatch410ErrorCodeAndReason(t *testing.T) {
 	statusErr, ok := err.(*apierrors.StatusError)
 	require.True(t, ok, "Error should be a StatusError")
 	assert.Equal(t, int32(410), statusErr.ErrStatus.Code)
-	assert.Equal(t, metav1.StatusReasonGone, statusErr.ErrStatus.Reason)
+	assert.Equal(t, metav1.StatusReasonExpired, statusErr.ErrStatus.Reason)
 }
 
 // TestCreateGenericWatchAllowsWatchWithSendInitialEvents verifies that watches
@@ -567,25 +513,7 @@ func TestCreateGenericWatchAllowsWatchWithSendInitialEvents(t *testing.T) {
 	defer w.Stop()
 
 	// Should receive 2 ADDED events + 1 bookmark
-	var events []watch.Event
-	timeout := time.After(2 * time.Second)
-
-	for {
-		select {
-		case ev, ok := <-w.ResultChan():
-			if !ok {
-				goto done
-			}
-			events = append(events, ev)
-			if ev.Type == watch.Bookmark {
-				goto done
-			}
-		case <-timeout:
-			goto done
-		}
-	}
-
-done:
+	events := collectEventsUntilBookmark(w.ResultChan(), 2*time.Second)
 	cancel()
 
 	require.GreaterOrEqual(t, len(events), 3, "Expected at least 2 ADDED + 1 bookmark, got %d events", len(events))
@@ -600,4 +528,86 @@ done:
 	obj, ok := lastEvent.Object.(*porchapi.PackageRevision)
 	require.True(t, ok)
 	assert.Equal(t, "true", obj.Annotations["k8s.io/initial-events-end"])
+}
+
+// waitForInitialBookmark reads from the channel until an initial-events-end
+// bookmark is found, the channel closes, or the timeout elapses.
+func waitForInitialBookmark(ch chan watch.Event, timeout time.Duration) bool {
+	timer := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return false
+			}
+			if ev.Type == watch.Bookmark {
+				if obj, ok := ev.Object.(*porchapi.PackageRevision); ok {
+					if obj.Annotations != nil && obj.Annotations["k8s.io/initial-events-end"] == "true" {
+						return true
+					}
+				}
+			}
+		case <-timer:
+			return false
+		}
+	}
+}
+
+// waitForBookmarkRV reads from the channel until a bookmark event is found and
+// returns its resourceVersion, or returns empty string on timeout.
+func waitForBookmarkRV(ch chan watch.Event, timeout time.Duration) string {
+	timer := time.After(timeout)
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == watch.Bookmark {
+				if obj, ok := ev.Object.(*porchapi.PackageRevision); ok {
+					return obj.ResourceVersion
+				}
+			}
+		case <-timer:
+			return ""
+		}
+	}
+}
+
+// waitForBookmarks reads from the channel until at least `count` bookmark events
+// are collected or the timeout elapses.
+func waitForBookmarks(ch chan watch.Event, count int, timeout time.Duration) []watch.Event {
+	timer := time.After(timeout)
+	var bookmarks []watch.Event
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == watch.Bookmark {
+				bookmarks = append(bookmarks, ev)
+				if len(bookmarks) >= count {
+					return bookmarks
+				}
+			}
+		case <-timer:
+			return bookmarks
+		}
+	}
+}
+
+// collectEventsUntilBookmark reads events from the channel until a bookmark is
+// received, the channel closes, or the timeout elapses.
+func collectEventsUntilBookmark(ch <-chan watch.Event, timeout time.Duration) []watch.Event {
+	timer := time.After(timeout)
+	var events []watch.Event
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+			if ev.Type == watch.Bookmark {
+				return events
+			}
+		case <-timer:
+			return events
+		}
+	}
 }

--- a/test/e2e/api/watch_test.go
+++ b/test/e2e/api/watch_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
+	suiteutils "github.com/kptdev/porch/test/e2e/suiteutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// TestWatchReturns410OnPlainResume verifies that porch returns 410 Gone when
+// a watch request is made with a resourceVersion but without sendInitialEvents.
+// This is the key behavior that forces client-go's reflector to do a full re-list
+// (Replace) instead of a plain watch resume, which prevents stale cache entries.
+func (t *PorchSuite) TestWatchReturns410OnPlainResume() {
+	const repoName = "watch-410-test"
+
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repoName, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	// Create a package so we have at least one PackageRevision with a real RV
+	pr := t.CreatePackageDraftF(repoName, "test-pkg", defaultWorkspace)
+
+	// Get the resource version from the created PackageRevision
+	rv := pr.ResourceVersion
+	require.NotEmpty(t.T(), rv, "PackageRevision should have a resourceVersion")
+
+	// Create a dynamic client for making raw watch requests
+	dynamicClient, err := dynamic.NewForConfig(t.Kubeconfig)
+	require.NoError(t.T(), err)
+
+	gvr := schema.GroupVersionResource{
+		Group:    porchapi.SchemeGroupVersion.Group,
+		Version:  porchapi.SchemeGroupVersion.Version,
+		Resource: "packagerevisions",
+	}
+
+	// Test 1: Plain watch resume (resourceVersion set, no sendInitialEvents)
+	// This should return 410 Gone.
+	t.Run("plain_watch_resume_returns_410", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// A plain watch resume sends resourceVersion without sendInitialEvents.
+		// The dynamic client's Watch method sets watch=true and resourceVersion.
+		// It does NOT set sendInitialEvents by default — this mimics a reflector
+		// that's been in watch() mode and is trying to resume.
+		watcher, err := dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+			ResourceVersion: rv,
+			// No SendInitialEvents — this is the key: a plain watch resume
+		})
+
+		// Porch should return 410 Gone, which surfaces as an error from Watch()
+		if err != nil {
+			// Expected: 410 Gone error
+			assert.True(t.T(), apierrors.IsGone(err),
+				"Expected 410 Gone error for plain watch resume, got: %v", err)
+			assert.Contains(t.T(), err.Error(), "sendInitialEvents",
+				"Error message should mention sendInitialEvents")
+			return
+		}
+
+		// If Watch() didn't return an error directly, it might come as an ERROR event
+		// on the watch stream (some API server versions wrap 410 as a watch event)
+		defer watcher.Stop()
+		select {
+		case ev, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatalf("Watch channel closed unexpectedly without an error event")
+			}
+			if ev.Type == watch.Error {
+				// 410 came as an error event on the stream - this is also valid
+				t.Logf("Received error event on watch stream (expected): %v", ev.Object)
+			} else {
+				t.Errorf("Expected 410 Gone or error event, but got event type %s", ev.Type)
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for watch response - expected immediate 410")
+		}
+	})
+
+	// Test 2: Watch with sendInitialEvents=true should succeed and deliver events
+	t.Run("watch_with_sendInitialEvents_succeeds", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		sendInitialEvents := true
+		watcher, err := dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+			ResourceVersion:      rv,
+			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+			SendInitialEvents:    &sendInitialEvents,
+			AllowWatchBookmarks:  true,
+		})
+		require.NoError(t.T(), err, "Watch with sendInitialEvents=true should succeed")
+		defer watcher.Stop()
+
+		// Should receive ADDED events for existing PackageRevisions + a BOOKMARK
+		var addedCount int
+		var gotBookmark bool
+
+		for {
+			select {
+			case ev, ok := <-watcher.ResultChan():
+				if !ok {
+					t.Fatalf("Watch channel closed unexpectedly")
+				}
+				switch ev.Type {
+				case watch.Added:
+					addedCount++
+				case watch.Bookmark:
+					gotBookmark = true
+					goto doneEvents
+				case watch.Error:
+					t.Fatalf("Unexpected error event: %v", ev.Object)
+				}
+			case <-ctx.Done():
+				t.Fatalf("Timeout waiting for watch events (got %d ADDED, bookmark=%v)", addedCount, gotBookmark)
+			}
+		}
+
+	doneEvents:
+		assert.GreaterOrEqual(t.T(), addedCount, 1,
+			"Should receive at least 1 ADDED event (the package we created)")
+		assert.True(t.T(), gotBookmark,
+			"Should receive a BOOKMARK event marking end of initial events")
+	})
+
+	// Test 3: Fresh watch (empty resourceVersion) should succeed
+	t.Run("fresh_watch_succeeds", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		sendInitialEvents := true
+		watcher, err := dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+			ResourceVersion:      "",
+			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+			SendInitialEvents:    &sendInitialEvents,
+			AllowWatchBookmarks:  true,
+		})
+		require.NoError(t.T(), err, "Fresh watch should succeed")
+		defer watcher.Stop()
+
+		// Should receive events
+		select {
+		case ev, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatalf("Watch channel closed unexpectedly")
+			}
+			assert.NotEqual(t.T(), watch.Error, ev.Type,
+				"Fresh watch should not produce error events")
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for first watch event")
+		}
+	})
+}
+
+// TestWatchCacheHealsAfterReconnect verifies the end-to-end behavior:
+// an informer that loses its watch connection correctly heals its cache
+// when porch returns 410 on the plain resume attempt, forcing a full re-list.
+func (t *PorchSuite) TestWatchCacheHealsAfterReconnect() {
+	const repoName = "watch-heal-test"
+
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repoName, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	// Create initial packages so the informer has something in its cache
+	pr1 := t.CreatePackageDraftF(repoName, "pkg-one", defaultWorkspace)
+	require.NotEmpty(t.T(), pr1.Name)
+
+	// Create a dynamic client for watch operations
+	dynamicClient, err := dynamic.NewForConfig(t.Kubeconfig)
+	require.NoError(t.T(), err)
+
+	gvr := schema.GroupVersionResource{
+		Group:    porchapi.SchemeGroupVersion.Group,
+		Version:  porchapi.SchemeGroupVersion.Version,
+		Resource: "packagerevisions",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Step 1: Start a watch with sendInitialEvents to get the initial state
+	sendInitialEvents := true
+	watcher1, err := dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+		SendInitialEvents:    &sendInitialEvents,
+		AllowWatchBookmarks:  true,
+	})
+	require.NoError(t.T(), err)
+
+	// Collect all initial ADDED events and the bookmark
+	var lastRV string
+	var initialNames []string
+	for {
+		select {
+		case ev, ok := <-watcher1.ResultChan():
+			require.True(t.T(), ok, "Watch channel closed unexpectedly")
+			switch ev.Type {
+			case watch.Added:
+				obj, ok := ev.Object.(metav1.Object)
+				require.True(t.T(), ok)
+				initialNames = append(initialNames, obj.GetName())
+				lastRV = obj.GetResourceVersion()
+			case watch.Bookmark:
+				obj, ok := ev.Object.(metav1.Object)
+				require.True(t.T(), ok)
+				lastRV = obj.GetResourceVersion()
+				goto initialDone
+			case watch.Error:
+				t.Fatalf("Unexpected error during initial watch: %v", ev.Object)
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timeout during initial watch")
+		}
+	}
+initialDone:
+	watcher1.Stop()
+
+	require.NotEmpty(t.T(), lastRV, "Should have received a resourceVersion from the initial watch")
+	t.Logf("Initial watch complete: %d objects, lastRV=%s", len(initialNames), lastRV)
+
+	// Step 2: Create another package while the watch is disconnected
+	pr2 := t.CreatePackageDraftF(repoName, "pkg-two", defaultWorkspace)
+	require.NotEmpty(t.T(), pr2.Name)
+	t.Logf("Created pkg-two while disconnected: %s", pr2.Name)
+
+	// Step 3: Try a plain watch resume (simulating what a reflector does after disconnect)
+	// This should get 410, proving that the client MUST do a full re-list.
+	_, err = dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+		ResourceVersion: lastRV,
+		// No SendInitialEvents — plain resume
+	})
+	require.Error(t.T(), err, "Plain watch resume should fail with 410")
+	assert.True(t.T(), apierrors.IsGone(err),
+		"Error should be 410 Gone, got: %v", err)
+
+	// Step 4: Do the correct reconnection (sendInitialEvents=true) — what the reflector
+	// does after receiving 410 (it exits watch() and goes back to ListAndWatch)
+	watcher2, err := dynamicClient.Resource(gvr).Namespace(t.Namespace).Watch(ctx, metav1.ListOptions{
+		ResourceVersion:      lastRV,
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+		SendInitialEvents:    &sendInitialEvents,
+		AllowWatchBookmarks:  true,
+	})
+	require.NoError(t.T(), err)
+	defer watcher2.Stop()
+
+	// Step 5: Verify we receive the NEW package (pkg-two) in the re-list
+	var reconnectNames []string
+	for {
+		select {
+		case ev, ok := <-watcher2.ResultChan():
+			require.True(t.T(), ok, "Watch channel closed unexpectedly on reconnect")
+			switch ev.Type {
+			case watch.Added:
+				obj, ok := ev.Object.(metav1.Object)
+				require.True(t.T(), ok)
+				reconnectNames = append(reconnectNames, obj.GetName())
+			case watch.Bookmark:
+				goto reconnectDone
+			case watch.Error:
+				t.Fatalf("Unexpected error during reconnect watch: %v", ev.Object)
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timeout during reconnect watch")
+		}
+	}
+reconnectDone:
+
+	// The reconnected watch should contain pkg-two (created while disconnected)
+	foundPkgTwo := false
+	for _, name := range reconnectNames {
+		if name == pr2.Name {
+			foundPkgTwo = true
+			break
+		}
+	}
+	assert.True(t.T(), foundPkgTwo,
+		fmt.Sprintf("Reconnected watch with sendInitialEvents should include pkg-two (%s) that was created during disconnect. Got names: %v",
+			pr2.Name, reconnectNames))
+
+	// The reconnected watch should have MORE objects than the initial watch
+	// (because pkg-two was created in between)
+	t.Logf("Reconnect watch: %d objects (initial had %d)", len(reconnectNames), len(initialNames))
+	assert.Greater(t.T(), len(reconnectNames), len(initialNames),
+		fmt.Sprintf("Reconnect should have more objects than initial watch (initial=%d, reconnect=%d)",
+			len(initialNames), len(reconnectNames)))
+}

--- a/test/e2e/api/watch_test.go
+++ b/test/e2e/api/watch_test.go
@@ -71,13 +71,19 @@ func (t *PorchSuite) TestWatchReturns410OnPlainResume() {
 			// No SendInitialEvents — this is the key: a plain watch resume
 		})
 
-		// Porch should return 410 Gone, which surfaces as an error from Watch()
+		// Porch should return 410 (ResourceExpired), which surfaces as an error from Watch()
 		if err != nil {
-			// Expected: 410 Gone error
-			assert.True(t.T(), apierrors.IsGone(err),
-				"Expected 410 Gone error for plain watch resume, got: %v", err)
+			// Expected: 410 ResourceExpired error (NewResourceExpired uses StatusReasonExpired)
+			assert.True(t.T(), apierrors.IsResourceExpired(err),
+				"Expected 410 ResourceExpired error for plain watch resume, got: %v", err)
 			assert.Contains(t.T(), err.Error(), "sendInitialEvents",
 				"Error message should mention sendInitialEvents")
+
+			// Verify the actual HTTP status code is 410
+			statusErr, ok := err.(*apierrors.StatusError)
+			require.True(t.T(), ok, "Error should be a *StatusError")
+			assert.Equal(t.T(), int32(410), statusErr.ErrStatus.Code,
+				"Expected HTTP status code 410, got: %d", statusErr.ErrStatus.Code)
 			return
 		}
 
@@ -116,30 +122,8 @@ func (t *PorchSuite) TestWatchReturns410OnPlainResume() {
 		defer watcher.Stop()
 
 		// Should receive ADDED events for existing PackageRevisions + a BOOKMARK
-		var addedCount int
-		var gotBookmark bool
+		addedCount, gotBookmark := consumeWatchEventsUntilBookmark(t, watcher, ctx)
 
-		for {
-			select {
-			case ev, ok := <-watcher.ResultChan():
-				if !ok {
-					t.Fatalf("Watch channel closed unexpectedly")
-				}
-				switch ev.Type {
-				case watch.Added:
-					addedCount++
-				case watch.Bookmark:
-					gotBookmark = true
-					goto doneEvents
-				case watch.Error:
-					t.Fatalf("Unexpected error event: %v", ev.Object)
-				}
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for watch events (got %d ADDED, bookmark=%v)", addedCount, gotBookmark)
-			}
-		}
-
-	doneEvents:
 		assert.GreaterOrEqual(t.T(), addedCount, 1,
 			"Should receive at least 1 ADDED event (the package we created)")
 		assert.True(t.T(), gotBookmark,
@@ -212,29 +196,7 @@ func (t *PorchSuite) TestWatchCacheHealsAfterReconnect() {
 	// Collect all initial ADDED events and the bookmark
 	var lastRV string
 	var initialNames []string
-	for {
-		select {
-		case ev, ok := <-watcher1.ResultChan():
-			require.True(t.T(), ok, "Watch channel closed unexpectedly")
-			switch ev.Type {
-			case watch.Added:
-				obj, ok := ev.Object.(metav1.Object)
-				require.True(t.T(), ok)
-				initialNames = append(initialNames, obj.GetName())
-				lastRV = obj.GetResourceVersion()
-			case watch.Bookmark:
-				obj, ok := ev.Object.(metav1.Object)
-				require.True(t.T(), ok)
-				lastRV = obj.GetResourceVersion()
-				goto initialDone
-			case watch.Error:
-				t.Fatalf("Unexpected error during initial watch: %v", ev.Object)
-			}
-		case <-ctx.Done():
-			t.Fatalf("Timeout during initial watch")
-		}
-	}
-initialDone:
+	initialNames, lastRV = collectWatchNames(t, watcher1, ctx)
 	watcher1.Stop()
 
 	require.NotEmpty(t.T(), lastRV, "Should have received a resourceVersion from the initial watch")
@@ -252,8 +214,12 @@ initialDone:
 		// No SendInitialEvents — plain resume
 	})
 	require.Error(t.T(), err, "Plain watch resume should fail with 410")
-	assert.True(t.T(), apierrors.IsGone(err),
-		"Error should be 410 Gone, got: %v", err)
+	assert.True(t.T(), apierrors.IsResourceExpired(err),
+		"Error should be 410 ResourceExpired, got: %v", err)
+	statusErr, ok := err.(*apierrors.StatusError)
+	require.True(t.T(), ok, "Error should be a *StatusError")
+	assert.Equal(t.T(), int32(410), statusErr.ErrStatus.Code,
+		"Expected HTTP status code 410, got: %d", statusErr.ErrStatus.Code)
 
 	// Step 4: Do the correct reconnection (sendInitialEvents=true) — what the reflector
 	// does after receiving 410 (it exits watch() and goes back to ListAndWatch)
@@ -267,26 +233,7 @@ initialDone:
 	defer watcher2.Stop()
 
 	// Step 5: Verify we receive the NEW package (pkg-two) in the re-list
-	var reconnectNames []string
-	for {
-		select {
-		case ev, ok := <-watcher2.ResultChan():
-			require.True(t.T(), ok, "Watch channel closed unexpectedly on reconnect")
-			switch ev.Type {
-			case watch.Added:
-				obj, ok := ev.Object.(metav1.Object)
-				require.True(t.T(), ok)
-				reconnectNames = append(reconnectNames, obj.GetName())
-			case watch.Bookmark:
-				goto reconnectDone
-			case watch.Error:
-				t.Fatalf("Unexpected error during reconnect watch: %v", ev.Object)
-			}
-		case <-ctx.Done():
-			t.Fatalf("Timeout during reconnect watch")
-		}
-	}
-reconnectDone:
+	reconnectNames, _ := collectWatchNames(t, watcher2, ctx)
 
 	// The reconnected watch should contain pkg-two (created while disconnected)
 	foundPkgTwo := false
@@ -306,4 +253,64 @@ reconnectDone:
 	assert.Greater(t.T(), len(reconnectNames), len(initialNames),
 		fmt.Sprintf("Reconnect should have more objects than initial watch (initial=%d, reconnect=%d)",
 			len(initialNames), len(reconnectNames)))
+}
+
+// consumeWatchEventsUntilBookmark reads events from the watcher until a BOOKMARK
+// is received or the context expires. Returns the count of ADDED events and
+// whether a bookmark was received.
+func consumeWatchEventsUntilBookmark(t *PorchSuite, watcher watch.Interface, ctx context.Context) (int, bool) {
+	var addedCount int
+	for {
+		select {
+		case ev, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatalf("Watch channel closed unexpectedly")
+				return addedCount, false
+			}
+			switch ev.Type {
+			case watch.Added:
+				addedCount++
+			case watch.Bookmark:
+				return addedCount, true
+			case watch.Error:
+				t.Fatalf("Unexpected error event: %v", ev.Object)
+				return addedCount, false
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for watch events (got %d ADDED, bookmark=false)", addedCount)
+			return addedCount, false
+		}
+	}
+}
+
+// collectWatchNames reads ADDED events from the watcher until a BOOKMARK is
+// received or the context expires. Returns the collected object names and the
+// last observed resourceVersion.
+func collectWatchNames(t *PorchSuite, watcher watch.Interface, ctx context.Context) ([]string, string) {
+	var names []string
+	var lastRV string
+	for {
+		select {
+		case ev, ok := <-watcher.ResultChan():
+			require.True(t.T(), ok, "Watch channel closed unexpectedly")
+			switch ev.Type {
+			case watch.Added:
+				obj, ok := ev.Object.(metav1.Object)
+				require.True(t.T(), ok)
+				names = append(names, obj.GetName())
+				lastRV = obj.GetResourceVersion()
+			case watch.Bookmark:
+				obj, ok := ev.Object.(metav1.Object)
+				require.True(t.T(), ok)
+				lastRV = obj.GetResourceVersion()
+				return names, lastRV
+			case watch.Error:
+				t.Fatalf("Unexpected error during watch: %v", ev.Object)
+				return names, lastRV
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timeout during watch")
+			return names, lastRV
+		}
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
# Reject watch resume with 410 Gone

---

## Description
<!-- Describe what this PR does and why -->
- What changed: When Porch receives a watch packageRevisions call with a resourceVersion, it will reject the request with 410 Gone if the WatchList feature flag (the same as in k8s) is disabled.
- Why it’s needed: watch calls with resourceVersion set to non-zero expect that all events that have happened since the logical time referred to by the resourceVersion are going to be replayed. Porch can't fulfill this contract, so a s a fallback behavior it sends the current state as ADDED events. But since the client side expects a seamless continuation of events, it won't delete anything from it's client cache that was deleted while the connection was broken, and it didn't receive an event for. The feature flag is needed, becasue controller-runtime clients older than 1.32, or ones that do not have the WatchListClient enabled for them, will always try to run a LIST then a WATCH with a specific resourceVersion. In their case preserving the previous, lossy behavior is the best that can be done.
- How it works: When porch-server gets a request that expects it to continue sending packageRevision events from a previous logical timepoint, it will reject it. This forces a full refresh of the cache. This is not changing the number of events that needs to be sent out by porch-server for a given watcher, but provides correct semantics.  The implemented semantics are still not fully correct, becasue sendIntialEvents=<> & resourceVersion=<> means "send me the state of the database at this timepoint, then send me all the the events since", which porch also can't serve in a semantically correct way, it can only send "state of the database at the current timepoint and events since then", but it's a safe deviation, because the client cannot sort resourceVersions to figure out which was a more recent event. There is a performance gain on implementing it this way on the porch-server side, becasue then inital events can be transmitted over 

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Fixes #1101 

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
- Kiro for generating the test cases for it.