### PR TITLE
Cherry-pick #1035 - Fix WatchList bookmark panic

### DIFF
--- a/pkg/registry/porch/watch.go
+++ b/pkg/registry/porch/watch.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2024-2025 The kpt Authors
+// Copyright 2022, 2024-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,11 +35,16 @@ import (
 func createGenericWatch(ctx context.Context, r packageReader, filter repository.ListPackageRevisionFilter, extractor objectExtractor, options *metainternalversion.ListOptions) (watch.Interface, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
+	allowWatchBookmarks := options != nil && options.AllowWatchBookmarks
+	sendInitialEvents := options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents
+	allowWatchBookmarks = effectiveAllowWatchBookmarks(allowWatchBookmarks, sendInitialEvents)
+
 	w := &watcher{
 		cancel:              cancel,
 		resultChan:          make(chan watch.Event, 64),
 		extractor:           extractor,
-		allowWatchBookmarks: options != nil && options.AllowWatchBookmarks,
+		allowWatchBookmarks: allowWatchBookmarks,
+		sendInitialEvents:   sendInitialEvents,
 		bookmarkInterval:    1 * time.Minute, // Default bookmark interval which aligns with Kubernetes standards. Enables code to be tested.
 	}
 	go w.listAndWatch(ctx, r, filter)
@@ -84,6 +89,7 @@ type watcher struct {
 	// objectExtractor function to get the appropriate object from PackageRevision
 	extractor           objectExtractor
 	allowWatchBookmarks bool
+	sendInitialEvents   bool
 	lastResourceVersion string
 	initialEventsSent   bool
 	bookmarkInterval    time.Duration
@@ -307,7 +313,7 @@ func (w *watcher) sendWatchEvent(ev watch.Event) {
 	}
 }
 
-func (w *watcher) sendBookmark(initialEvents bool) {
+func (w *watcher) sendBookmark(markInitialEventsEnd bool) {
 	if w.done {
 		return
 	}
@@ -324,8 +330,8 @@ func (w *watcher) sendBookmark(initialEvents bool) {
 				ResourceVersion: w.lastResourceVersion,
 			},
 		}
-		// Add annotation to mark end of initial events
-		if initialEvents {
+		// Add annotation to mark end of initial events only for WatchList requests
+		if markInitialEventsEnd && w.sendInitialEvents {
 			obj.Annotations = map[string]string{
 				"k8s.io/initial-events-end": "true",
 			}
@@ -335,7 +341,8 @@ func (w *watcher) sendBookmark(initialEvents bool) {
 			Object: obj,
 		}
 		w.resultChan <- ev
-		klog.V(2).Infof("watch %p: sent bookmark with resourceVersion %s (initialEvents=%v)", w, w.lastResourceVersion, initialEvents)
+		didMarkInitialEventsEnd := markInitialEventsEnd && w.sendInitialEvents
+		klog.V(2).Infof("watch %p: sent bookmark with resourceVersion %s (markInitialEventsEnd=%v, sendInitialEvents=%v, annotationApplied=%v)", w, w.lastResourceVersion, markInitialEventsEnd, w.sendInitialEvents, didMarkInitialEventsEnd)
 	}
 }
 
@@ -345,4 +352,10 @@ func (w *watcher) OnPackageRevisionChange(eventType watch.EventType, pr reposito
 	defer w.mutex.Unlock()
 
 	return w.eventCallback(eventType, pr)
+}
+
+// effectiveAllowWatchBookmarks returns true if bookmarks should be sent.
+// WatchList semantics require bookmarks to signal initial-events-end.
+func effectiveAllowWatchBookmarks(allowWatchBookmarks, sendInitialEvents bool) bool {
+	return allowWatchBookmarks || sendInitialEvents
 }

--- a/pkg/registry/porch/watch_test.go
+++ b/pkg/registry/porch/watch_test.go
@@ -186,17 +186,32 @@ func TestWatcherBookmarks(t *testing.T) {
 	tests := []struct {
 		name                string
 		allowWatchBookmarks bool
+		sendInitialEvents   bool
 		expectInitial       bool
 	}{
 		{
-			name:                "bookmarks enabled",
+			name:                "bookmarks enabled with WatchList",
 			allowWatchBookmarks: true,
+			sendInitialEvents:   true,
 			expectInitial:       true,
+		},
+		{
+			name:                "bookmarks enabled without WatchList",
+			allowWatchBookmarks: true,
+			sendInitialEvents:   false,
+			expectInitial:       false,
 		},
 		{
 			name:                "bookmarks disabled",
 			allowWatchBookmarks: false,
+			sendInitialEvents:   false,
 			expectInitial:       false,
+		},
+		{
+			name:                "WatchList forces bookmarks even if allowWatchBookmarks is false",
+			allowWatchBookmarks: false,
+			sendInitialEvents:   true,
+			expectInitial:       true,
 		},
 	}
 
@@ -208,7 +223,8 @@ func TestWatcherBookmarks(t *testing.T) {
 			w := &watcher{
 				cancel:              cancelFunc,
 				resultChan:          make(chan watch.Event, 64),
-				allowWatchBookmarks: tt.allowWatchBookmarks,
+				allowWatchBookmarks: effectiveAllowWatchBookmarks(tt.allowWatchBookmarks, tt.sendInitialEvents),
+				sendInitialEvents:   tt.sendInitialEvents,
 			}
 
 			r := &fakePackageReader{}
@@ -304,6 +320,7 @@ func TestWatcherPeriodicBookmark(t *testing.T) {
 		cancel:              cancelFunc,
 		resultChan:          make(chan watch.Event, 64),
 		allowWatchBookmarks: true,
+		sendInitialEvents:   true,
 		bookmarkInterval:    100 * time.Millisecond,
 	}
 


### PR DESCRIPTION
## Description

- What changed:
  - Cherry-pick of the WatchList bookmark panic fix from PR #1035 (main) to the `1.5` branch
  - Added `sendInitialEvents` field to the watcher, derived from `ListOptions.SendInitialEvents`
  - The `k8s.io/initial-events-end` bookmark annotation is now only sent for WatchList requests (where `SendInitialEvents=true`), not for all bookmark-enabled watches
  - Added `effectiveAllowWatchBookmarks()` helper that forces bookmarks on when WatchList semantics are requested

- How it works:
  - The `sendBookmark()` function now gates the annotation on both `markInitialEventsEnd=true` AND `w.sendInitialEvents=true`
  - WatchList requests (`SendInitialEvents=true`) automatically enable bookmarks via `effectiveAllowWatchBookmarks()`, even if `AllowWatchBookmarks` was not explicitly set

## Related Issue(s)

- Cherry-pick of #1035 to `1.5`

## Type of Change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to port the watch fix from main and update tests.