### PR TITLE
Add delete validation to the webhook and ignore marshalling

### DIFF
--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -291,6 +291,7 @@ func createValidatingWebhook(ctx context.Context, cfg *WebhookConfig, caCert []b
 				Operations: []admissionregistrationv1.OperationType{
 					admissionregistrationv1.Create,
 					admissionregistrationv1.Update,
+					admissionregistrationv1.Delete,
 				},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   []string{configapi.GroupVersion.Group},
@@ -517,6 +518,27 @@ func validateRepository(w http.ResponseWriter, r *http.Request, clientReader cli
 
 	if admissionReviewRequest.Request.Resource.Resource != "repositories" {
 		writeErr(fmt.Sprintf("unexpected resource: %s", admissionReviewRequest.Request.Resource.Resource), &w)
+		return
+	}
+
+	// For DELETE operations, Object.Raw is empty — the API server sends the object in OldObject.
+	// No conflict detection needed for deletes, just allow them through.
+	if admissionReviewRequest.Request.Operation == admissionv1.Delete {
+		klog.Infof("repository deletion validated for %s", repoName)
+		resp := &admissionv1.AdmissionResponse{
+			Allowed: true,
+			Result: &metav1.Status{
+				Status:  "Success",
+				Message: "Repository deletion validated successfully",
+			},
+		}
+		responseBytes, err := constructResponse(resp, admissionReviewRequest)
+		if err != nil {
+			writeErr(fmt.Sprintf("error constructing response: %v", err), &w)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(responseBytes)
 		return
 	}
 

--- a/pkg/apiserver/webhooks.go
+++ b/pkg/apiserver/webhooks.go
@@ -538,7 +538,11 @@ func validateRepository(w http.ResponseWriter, r *http.Request, clientReader cli
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(responseBytes)
+		_, err = w.Write(responseBytes) // #nosec G705
+		if err != nil {
+			klog.Errorf("error writing response: %v", err)
+			return
+		}
 		return
 	}
 

--- a/pkg/apiserver/webhooks_test.go
+++ b/pkg/apiserver/webhooks_test.go
@@ -372,6 +372,40 @@ func TestValidateRepository(t *testing.T) {
 			response.Body.String())
 	})
 
+	t.Run("delete operation skips unmarshal and allows", func(t *testing.T) {
+		admissionReview := admissionv1.AdmissionReview{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "AdmissionReview",
+				APIVersion: "admission.k8s.io/v1",
+			},
+			Request: &admissionv1.AdmissionRequest{
+				UID: "delete-123",
+				Resource: v1.GroupVersionResource{
+					Group:    "config.porch.kpt.dev",
+					Version:  "v1alpha1",
+					Resource: "repositories",
+				},
+				Operation: admissionv1.Delete,
+				Name:      "my-repo",
+				Namespace: "test-ns",
+				// Object.Raw is empty on DELETE — this is the scenario that was failing
+				OldObject: runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"my-repo","namespace":"test-ns"}}`)},
+			},
+		}
+		body, err := json.Marshal(admissionReview)
+		require.NoError(t, err)
+
+		request, err := http.NewRequest(http.MethodPost, repositoryValidationEndpoint, bytes.NewReader(body))
+		require.NoError(t, err)
+		request.Header.Set("Content-Type", "application/json")
+
+		response := httptest.NewRecorder()
+		validateRepository(response, request, fakeClient)
+
+		require.Equal(t, http.StatusOK, response.Code)
+		require.Contains(t, response.Body.String(), "Repository deletion validated successfully")
+	})
+
 	createAdmissionReview := func(name, namespace, gitURL, directory, branch string) []byte {
 		repo := configapi.Repository{
 			ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
# Add delete validation to the webhook and ignore marshalling

---

## Description
<!-- Describe what this PR does and why -->
- What changed: Added DELETE to the webhook operations list and added an early return in the validation handler that skips JSON unmarshalling for DELETE requests.

- Why it’s needed: When porch-server is down and a repository is deleted, the API server must fail fast with connection refused instead of hanging indefinitely. Without DELETE in the webhook operations, the deletion bypasses the webhook entirely, goes straight to the controller, and gets stuck trying to remove the finalizer through an unreachable server. Additionally, the webhook handler was unconditionally unmarshalling Object.Raw, which is empty on DELETE requests, causing unexpected end of JSON input errors.

- How it works: The validating webhook now intercepts DELETE operations. If porch-server is down, the API server can't reach the webhook and immediately returns a connection refused error to the client (due to failurePolicy: Fail). If porch-server is up, the handler detects the DELETE operation, skips the unmarshal/conflict-detection logic (which only applies to CREATE/UPDATE), and allows the deletion through.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**

If so, please describe how:
  - E.g. Microsoft Copilot to analyse the code.
  - E.g. Claude code to generate the function someNewFunctionIAdded().
  - E.g. Kiro to generate unit tests.
