### PR TITLE
Update Porch API reference in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 replace k8s.io/apiserver v0.36.1 => ./third_party/k8s.io/apiserver-v0.36.1
 
 // TODO: Comment the line below out when the next version of the API is released.
-replace github.com/kptdev/porch/api => ./api
+// replace github.com/kptdev/porch/api => ./api
 
 require (
 	cloud.google.com/go/iam v1.11.0
@@ -27,7 +27,7 @@ require (
 	github.com/kptdev/krm-functions-catalog/functions/go/set-namespace v0.4.5
 	github.com/kptdev/krm-functions-catalog/functions/go/starlark v0.5.5
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
-	github.com/kptdev/porch/api v1.0.0
+	github.com/kptdev/porch/api v1.0.1
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1
@@ -65,11 +65,12 @@ require (
 	k8s.io/kube-aggregator v0.36.1
 	k8s.io/kubectl v0.36.1
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
-	sigs.k8s.io/cli-utils v0.37.2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
+
+require sigs.k8s.io/cli-utils v0.37.2 // indirect
 
 require (
 	cel.dev/expr v0.25.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/kptdev/krm-functions-catalog/functions/go/starlark v0.5.5 h1:2fVPRn0k
 github.com/kptdev/krm-functions-catalog/functions/go/starlark v0.5.5/go.mod h1:PE/l25mFdKm9MibK2sh/vO1YdFvrMIc3MXwyJW/scB0=
 github.com/kptdev/krm-functions-sdk/go/fn v1.0.4 h1:2Cl68JgaNva8eZ/YzqiZNOXkjIhavqLsoGOnxYN13Oc=
 github.com/kptdev/krm-functions-sdk/go/fn v1.0.4/go.mod h1:NqMHvghKasESpZImCDIOp5r10g3vmOeCcHzvjyL+4vk=
+github.com/kptdev/porch/api v1.0.1 h1:juMFLFN7RNeSzGSTyve/aHYODk4t7AGWfCXnvmzVG0o=
+github.com/kptdev/porch/api v1.0.1/go.mod h1:ixE34HC9j3OmA2F5v215l97X//izul0qbg5ci/F5xSo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=


### PR DESCRIPTION
# Update Porch API reference in go.mod

---

## Description
<!-- Describe what this PR does and why -->
- What changed: The Porch API reference in the Porch go.mod is updated to point at v1.0.1 of the Porch API
- Why it’s needed: The Porch API reference in the Porch go.mod was a redirect
- How it works: go.mod updated

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
